### PR TITLE
make prosody happy, too

### DIFF
--- a/src/org/jitsi/videobridge/pubsub/PubSubPublisher.java
+++ b/src/org/jitsi/videobridge/pubsub/PubSubPublisher.java
@@ -334,6 +334,22 @@ public class PubSubPublisher
                 return;
             }
         }
+        else if(error != null
+            && XMPPError.Type.AUTH.equals(error.getType())
+            && XMPPError.Condition.forbidden.toString()
+                .equals(error.getCondition()))
+        {
+            String nodeName = pendingCreateRequests.get(packetID);
+            if(nodeName != null)
+            {
+                //the node already exists but isowned by 
+                // someone else
+                nodes.add(nodeName);
+                pendingCreateRequests.remove(packetID);
+                fireResponseCreateEvent(Response.SUCCESS);
+                return;
+            }
+        }
 
         String errorMessage = "Error received when ";
         if(pendingCreateRequests.remove(packetID) != null)


### PR DESCRIPTION
prosody returns forbidden errors for already existing nodes with a different owner (per xep-0060)
