### PR TITLE
add json escape; test with endpoint=foo\ bar@host

### DIFF
--- a/src/org/jitsi/videobridge/Conference.java
+++ b/src/org/jitsi/videobridge/Conference.java
@@ -23,6 +23,7 @@ import org.jitsi.service.neomedia.recording.*;
 import org.jitsi.util.Logger;
 import org.jitsi.util.event.*;
 import org.osgi.framework.*;
+import org.json.simple.*;
 
 /**
  * Represents a conference in the terms of Jitsi Videobridge.
@@ -295,7 +296,8 @@ public class Conference
     {
         return
             "{\"colibriClass\":\"DominantSpeakerEndpointChangeEvent\","
-                + "\"dominantSpeakerEndpoint\":\"" + dominantSpeaker.getID()
+                + "\"dominantSpeakerEndpoint\":\"" 
+                + JSONObject.escape(dominantSpeaker.getID())
                 + "\"}";
     }
 


### PR DESCRIPTION
whoops, pushed to the wrong remote master. Anyway... haven't deployed that yet, need to do so before merging.

It seems that endpoints like "foo\ bar@host/resource" make the current code generate invalid JSON for dominant speaker events. 
