### PR TITLE
Adding capability to read JVM options from an external rc file

### DIFF
--- a/lib/videobridge.rc
+++ b/lib/videobridge.rc
@@ -1,0 +1,8 @@
+# The amount of memory that the java process can consume.
+# Use the format that is in use for java's -Xmx switch
+# The default is 3072m
+# Only effective on linux, 64 bit
+# VIDEOBRIDGE_MAX_MEMORY=3072m
+
+# Uncomment the next line to enable the remote debugging of the video bridge
+# VIDEOBRIDGE_DEBUG_OPTIONS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000"

--- a/resources/install/linux-64/jvb.sh
+++ b/resources/install/linux-64/jvb.sh
@@ -21,5 +21,12 @@ mainClass="org.jitsi.videobridge.Main"
 cp=$(JARS=($SCRIPT_DIR/jitsi-videobridge.jar $SCRIPT_DIR/lib/*.jar); IFS=:; echo "${JARS[*]}")
 libs="$SCRIPT_DIR/lib/native/linux-64"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
+videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"
 
-LD_LIBRARY_PATH=$libs java -Xmx3072m -XX:-HeapDumpOnOutOfMemoryError -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config -cp $cp $mainClass $@
+if [ -f $videobridge_rc  ]; then
+        source $videobridge_rc
+fi
+
+if [ -z "$VIDEOBRIDGE_MAX_MEMORY" ]; then VIDEOBRIDGE_MAX_MEMORY=3072m; fi
+
+LD_LIBRARY_PATH=$libs java -Xmx$VIDEOBRIDGE_MAX_MEMORY $VIDEOBRIDGE_DEBUG_OPTIONS -XX:-HeapDumpOnOutOfMemoryError -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config -cp $cp $mainClass $@

--- a/resources/install/linux/jvb.sh
+++ b/resources/install/linux/jvb.sh
@@ -21,5 +21,11 @@ mainClass="org.jitsi.videobridge.Main"
 cp=$(JARS=($SCRIPT_DIR/jitsi-videobridge.jar $SCRIPT_DIR/lib/*.jar); IFS=:; echo "${JARS[*]}")
 libs="$SCRIPT_DIR/lib/native/linux"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
+videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"
 
-java -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config -cp $cp $mainClass $@
+if [ -f $videobridge_rc  ]; then
+        source $videobridge_rc
+fi
+
+
+java $VIDEOBRIDGE_DEBUG_OPTIONS -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config -cp $cp $mainClass $@

--- a/resources/install/macosx/jvb.sh
+++ b/resources/install/macosx/jvb.sh
@@ -21,5 +21,11 @@ mainClass="org.jitsi.videobridge.Main"
 cp=$(JARS=($SCRIPT_DIR/jitsi-videobridge.jar $SCRIPT_DIR/lib/*.jar); IFS=:; echo "${JARS[*]}")
 libs="$SCRIPT_DIR/lib/native/macosx"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
+videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"
 
-java -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config -cp $cp $mainClass $@
+if [ -f $videobridge_rc  ]; then
+        source $videobridge_rc
+fi
+
+
+java $VIDEOBRIDGE_DEBUG_OPTIONS -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config -cp $cp $mainClass $@


### PR DESCRIPTION
I would like to set some options of the java process from an external config file.
The rc file seemed to be a more elegant solution for these options than the command line parameters.
The memory limit could be calculated based on the total memory of the server in the rc file.

There was no memory limit in the 32 bit linux and the osx jvb.sh files so I didn't apply the limit on those architectures.
