### PR TITLE
Removed dead code block and rolled-up logic

### DIFF
--- a/src/org/jitsi/videobridge/SctpConnection.java
+++ b/src/org/jitsi/videobridge/SctpConnection.java
@@ -836,20 +836,12 @@ public class SctpConnection
 
         // Protocol Length & Protocol
         String protocol = WEBRTC_DATA_CHANNEL_PROTOCOL;
-        byte[] protocolBytes;
-        int protocolByteLength;
+        byte[] protocolBytes = protocol.getBytes("UTF-8");
+        int protocolByteLength = protocolBytes.length;
 
-        if (protocol == null)
+        if (protocolByteLength > 0xFFFF)
         {
-            protocolBytes = null;
-            protocolByteLength = 0;
-        }
-        else
-        {
-            protocolBytes = protocol.getBytes("UTF-8");
-            protocolByteLength = protocolBytes.length;
-            if (protocolByteLength > 0xFFFF)
-                protocolByteLength = 0xFFFF;
+            protocolByteLength = 0xFFFF;
         }
 
         ByteBuffer packet


### PR DESCRIPTION
The protocol cannot be null in the removed code as it is final static in the class and has a forced value. There is no need for the removed "if" block.
