### PR TITLE
Added SuppressWarnings annotation

### DIFF
--- a/src/org/jitsi/videobridge/Videobridge.java
+++ b/src/org/jitsi/videobridge/Videobridge.java
@@ -544,6 +544,7 @@ public class Videobridge
      * @throws Exception to reply with <tt>internal-server-error</tt> to the
      * specified request
      */
+    @SuppressWarnings("deprecation")
     public IQ handleColibriConferenceIQ(
             ColibriConferenceIQ conferenceIQ)
         throws Exception


### PR DESCRIPTION
Added the @SuppressWarnings("deprecation") to handleColibriConferenceIQ method to mute warnings for the already annotated "FIXME" section regarding Content.getSctpConnection(Endpoint) deprecation.
