### PR TITLE
Added SuppressWarnings annotation

### DIFF
--- a/src/org/jitsi/videobridge/simulcast/SimulcastReceiver.java
+++ b/src/org/jitsi/videobridge/simulcast/SimulcastReceiver.java
@@ -737,6 +737,7 @@ class SimulcastReceiver
      *
      * @param id
      */
+    @SuppressWarnings("unused")
     private void maybeSendStartHighQualityStreamCommand(String id)
     {
         Endpoint newEndpoint = null;


### PR DESCRIPTION
Added @SuppressWarnings("unused") annotation to prevent dead code confusion regarding the StringUtils.isNullOrEmpty(eSelectedEndpointID) check done in the "if" block and within a "debug" block of code inside the previously mentioned "if" block. Lines 800 and 814.
