### PR TITLE
Added use of Atomics for expired and lastActivityTime

### DIFF
--- a/src/org/jitsi/videobridge/Channel.java
+++ b/src/org/jitsi/videobridge/Channel.java
@@ -105,7 +105,7 @@ public abstract class Channel
      * <tt>Channel</tt>. In the time interval between the last activity and now,
      * this <tt>Channel</tt> is considered inactive.
      */
-    private AtomicLong lastActivityTime = new AtomicLong();
+    private long lastActivityTime;
 
     /**
      * The <tt>StreamConnector</tt> currently used by this <tt>Channel</tt>.
@@ -485,7 +485,10 @@ public abstract class Channel
      */
     public long getLastActivityTime()
     {
-        return lastActivityTime.get();
+        synchronized (this)
+        {
+            return lastActivityTime;
+        }
     }
 
     /**
@@ -735,8 +738,11 @@ public abstract class Channel
     {
         long now = System.currentTimeMillis();
 
-        if (getLastActivityTime() < now)
-            lastActivityTime.set(now);
+        synchronized (this)
+        {
+            if (getLastActivityTime() < now)
+                lastActivityTime = now;
+        }
     }
 
     /**


### PR DESCRIPTION
The use of Atomics to replace synchronized blocks prevents thread contention and possible deadlocking. Atomics use CAS and are guaranteed to be atomic. In addition this style is also known to speed things up in a lot of instances.
http://www.ibm.com/developerworks/library/j-jtp11234/
