### PR TITLE
Fixed bug in ant script to create dist directory if it is not there

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -275,6 +275,7 @@
     </target>
 
     <target name="dist.macosx" depends="make">
+        <mkdir dir="${dist}/macosx" />
         <zip destfile="${dist}/macosx/${packname.macosx}.zip">
             <zipfileset file="jitsi-videobridge.jar"
                         prefix="${packname.macosx}" />


### PR DESCRIPTION
$ ant dist.macosx
...
dist.macosx:
      [zip] Building zip: /Users/manuel/git/jitsi-videobridge/dist/macosx/jitsi-videobridge-macosx-build.SVN.zip

BUILD FAILED
/Users/manuel/git/jitsi-videobridge/build.xml:278: Problem creating zip: /Users/manuel/git/jitsi-videobridge/dist/macosx/jitsi-videobridge-macosx-build.SVN.zip (No such file or directory) (and the archive is probably corrupt but I could not delete it)
