### PR TITLE
Fix: race condition between addChannel() and close() when assigning sctpConnection AND channelForDtls

### DIFF
--- a/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
+++ b/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
@@ -415,13 +415,8 @@ public class IceUdpTransportManager
                 // channelForDtls, because it needs DTLS packets for the application
                 // data inside them.
                 sctpConnection = (SctpConnection) channel;
-                if (channelForDtls != null)
+                if (channelForDtls != null && channelForDtls instanceof RtpChannel)
                 {
-                    /*
-                     * channelForDtls is necessarily an RtpChannel, because we don't
-                     * add more than one SctpConnection. The SctpConnection socket
-                     * will automatically accept DTLS.
-                     */
                     RtpChannel rtpChannelForDtls = (RtpChannel) channelForDtls;
 
                     rtpChannelForDtls.getDatagramFilter(false).setAcceptNonRtp(


### PR DESCRIPTION
This request fixes a race condition caused by close and addChannel mutating the reference to SctpConnection and channelForDtls. This can result in a stack trace causing a cast exception. The result is the participant in the conference receives no media.

The fix is a simple synchronize block, since there is a tight connection between the value of the sctpConnection and channelForDtls and two areas where these values can be mutated - addChannel and close. I looked for any chances of dead-locks by carefully analyzing any locks obtained within the new synchronize block and didn't find any;  I also ensured all areas that read and write these variables are done while the lock is held, which turned out to be the same areas, allowing for this simpler approach.

Load testing this fix reveals no race conditions are occurring now.  The previous pull request made the situation much better, but didn't cover all cases.
