### PR TITLE
Pass java flags in from init script

### DIFF
--- a/resources/install/debian/init.d
+++ b/resources/install/debian/init.d
@@ -67,7 +67,7 @@ start() {
         exit 1
     fi
     echo -n "Starting $DESC: "
-    DAEMON_START_CMD="exec $DAEMON $DAEMON_OPTS < /dev/null >> $LOGFILE 2>&1"
+    DAEMON_START_CMD="JAVA_FLAGS=$JAVA_FLAGS exec $DAEMON $DAEMON_OPTS < /dev/null >> $LOGFILE 2>&1"
     AUTHBIND_CMD=""
     if [ "$AUTHBIND" = "yes" ]; then
         AUTHBIND_CMD="/usr/bin/authbind --deep /bin/bash -c "

--- a/resources/install/linux-64/jvb.sh
+++ b/resources/install/linux-64/jvb.sh
@@ -29,4 +29,4 @@ fi
 
 if [ -z "$VIDEOBRIDGE_MAX_MEMORY" ]; then VIDEOBRIDGE_MAX_MEMORY=3072m; fi
 
-LD_LIBRARY_PATH=$libs java -Xmx$VIDEOBRIDGE_MAX_MEMORY $VIDEOBRIDGE_DEBUG_OPTIONS -XX:-HeapDumpOnOutOfMemoryError -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config -cp $cp $mainClass $@
+LD_LIBRARY_PATH=$libs java -Xmx$VIDEOBRIDGE_MAX_MEMORY $VIDEOBRIDGE_DEBUG_OPTIONS -XX:-HeapDumpOnOutOfMemoryError -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config $JAVA_FLAGS -cp $cp $mainClass $@

--- a/resources/install/linux/jvb.sh
+++ b/resources/install/linux/jvb.sh
@@ -28,4 +28,4 @@ if [ -f $videobridge_rc  ]; then
 fi
 
 
-java $VIDEOBRIDGE_DEBUG_OPTIONS -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config -cp $cp $mainClass $@
+java $VIDEOBRIDGE_DEBUG_OPTIONS -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config $JAVA_FLAGS -cp $cp $mainClass $@

--- a/resources/install/macosx/jvb.sh
+++ b/resources/install/macosx/jvb.sh
@@ -28,4 +28,4 @@ if [ -f $videobridge_rc  ]; then
 fi
 
 
-java $VIDEOBRIDGE_DEBUG_OPTIONS -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config -cp $cp $mainClass $@
+java $VIDEOBRIDGE_DEBUG_OPTIONS -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config $JAVA_FLAGS -cp $cp $mainClass $@


### PR DESCRIPTION
Allows setting java runtime values such as sip-communicator flags by setting
JAVA_FLAGS in /etc/jitsi/videobridge/config, rather supplying them in
/usr/share/jitsi-videobridge/.sip-communicator/sip-commnicator.properties

For example, enabling statistics in /etc/jitsi/videobridge/config becomes:

   JAVA_FLAGS="-Dorg.jitsi.videobridge.ENABLE_STATISTICS=true"