### PR TITLE
fix(Close Stream Race): Race condition closing a stream resulting in NullPointer

### DIFF
--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -174,7 +174,7 @@ public class RtpChannel
     /**
      * Whether {@link #stream} has been closed.
      */
-    private boolean streamClosed = false;
+    private final AtomicBoolean streamClosed = new AtomicBoolean(false);
 
     /**
      * The <tt>PropertyChangeListener</tt> which listens to changes of the
@@ -589,13 +589,11 @@ public class RtpChannel
     @Override
     protected void closeStream()
     {
-        if (!streamClosed)
+        if (!streamClosed.compareAndSet(false, true))
         {
             stream.setProperty(Channel.class.getName(), null);
             removeStreamListeners();
             stream.close();
-
-            streamClosed = true;
         }
     }
 


### PR DESCRIPTION
This fixes the NPE when two threads attempt to close the channel at the same time:

```
java.lang.NullPointerException
    at org.jitsi.videobridge.RtpChannel.closeStream(RtpChannel.java:599)
    at org.jitsi.videobridge.Channel.expire(Channel.java:339)
    at org.jitsi.videobridge.VideobridgeExpireThread.expire(VideobridgeExpireThread.java:141)
    at org.jitsi.videobridge.VideobridgeExpireThread.run(VideobridgeExpireThread.java:216)
```
