### PR TITLE
fix: Patch Conference 500 error due to missing sctpConnection

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -958,9 +958,12 @@ public class Videobridge
                             if (sctpConn == null && expire == 0)
                                 continue;
                             // endpoint
-                            if (endpointID != null)
+                            if (endpointID != null && sctpConn != null)
                                 sctpConn.setEndpoint(endpointID);
                         }
+
+                        if (sctpConn == null)
+                            continue;
 
                         // expire
                         if (expire


### PR DESCRIPTION
This fixes the stack trace

```
at java.lang.Thread.run(Thread.java:745)
at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540)
at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:257)
at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:310)
at org.eclipse.jetty.server.Server.handle(Server.java:497)
at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:52)
at org.jitsi.videobridge.rest.HandlerImpl.handle(HandlerImpl.java)
at org.jitsi.videobridge.rest.HandlerImpl.handleColibriJSON(HandlerImpl.java)
at org.jitsi.videobridge.rest.HandlerImpl.doPatchConferenceJSON(HandlerImpl.java)
at org.jitsi.videobridge.Videobridge.handleColibriConferenceIQ(Videobridge.java:987)
java.lang.NullPointerException
```

The issue is we checked for expire = 0 AND sctpConn = null to continue, and if sctpConn was null but expire was not 0, we would run into this exception.

Simplified the code based on review.
