### PR TITLE
Add a generic 'endpoint' colibri message that allows clients to commu…

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -227,8 +227,6 @@ public class Conference
      *  see broadcastMessageOnDataChannels below
      */
     public void sendMessageOnDataChannels(String msg, List<Endpoint> endpoints) {
-        System.out.println("broadcasting message to " + endpoints.size() + " endpoints");
-        System.out.println(msg);
         for (Endpoint endpoint : endpoints) {
             try
             {

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -221,6 +221,28 @@ public class Conference
     }
 
     /**
+     * Used to send a message to a subset of endpoints in the call, primary use case
+     *  being a message that has originated from an endpoint (as opposed to a message
+     *  originating from the bridge and being sent to all endpoints in the call, for that
+     *  see broadcastMessageOnDataChannels below
+     */
+    public void sendMessageOnDataChannels(String msg, List<Endpoint> endpoints) {
+        System.out.println("broadcasting message to " + endpoints.size() + " endpoints");
+        System.out.println(msg);
+        for (Endpoint endpoint : endpoints) {
+            try
+            {
+                endpoint.sendMessageOnDataChannel(msg);
+            }
+            catch (IOException e)
+            {
+                logger.error("Failed to send message on data channel.", e);
+            }
+        }
+    }
+
+
+    /**
      * Broadcasts string message to al participants over default data channel.
      *
      * @param msg the message to be advertised across conference peers.

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -247,17 +247,7 @@ public class Conference
      */
     private void broadcastMessageOnDataChannels(String msg)
     {
-        for (Endpoint endpoint : getEndpoints())
-        {
-            try
-            {
-                endpoint.sendMessageOnDataChannel(msg);
-            }
-            catch (IOException e)
-            {
-                logger.error("Failed to send message on data channel.", e);
-            }
-        }
+        sendMessageOnDataChannels(msg, getEndpoints());
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -437,27 +437,34 @@ public class Endpoint
     }
 
     /**
-     * Handles an opaque essage from this {@code Endpoint} that should be forwarded
-     * to either: a) another client in this conference (1:1 message) or b) all other
-     * clients in this conference (broadcast message)
+     * Handles an opaque essage from this {@code Endpoint} that should be 
+     * forwarded to either: a) another client in this conference (1:1 
+     * message) or b) all other clients in this conference (broadcast message)
      *
-     * @param src the {@WebRtcDataStream) by which {@code jsonObject} has been received
-     * @param jsonObject the JSON object with {@link Videobridge#COLIBRI_CLASS} EndpointMessage
-     * which has been received by the associated {@code SctpConnection}
+     * @param src the {@WebRtcDataStream) by which {@code jsonObject} has 
+     * been received
+     * @param jsonObject the JSON object with 
+     * {@link Videobridge#COLIBRI_CLASS} EndpointMessage which has been 
+     * received by the associated {@code SctpConnection}
      *
      * EndpointMessage definition:
-     * 'to': If the 'to' field contains the endpoint id of another endpoint in this conference, the
-     * message will be treated as a 1:1 message and forwarded just to that endpoint.  If the 'to'
-     * field is an empty string, the message will be treated as a broadcast and sent to all other
+     * 'to': If the 'to' field contains the endpoint id of another endpoint 
+     * in this conference, the message will be treated as a 1:1 message and 
+     * forwarded just to that endpoint.  If the 'to' field is an empty 
+     * string, the message will be treated as a broadcast and sent to all other
      * endpoints in this conference.
-     * 'msgPayload': An opaque payload.  The bridge does not need to know or care what is contained
-     * in the 'msgPayload' field, it will just forward it blindly.
+     * 'msgPayload': An opaque payload.  The bridge does not need to know or 
+     * care what is contained in the 'msgPayload' field, it will just forward 
+     * it blindly.
      *
-     * NOTE: This message is designed to allow endpoints to pass their own application-specific messaging
-     * to one another without requiring the bridge to know of or understand every message type.  These
-     * messages will be forwarded by the bridge using the same DataChannel as other jitsi messages
-     * (e.g. active speaker and last-n notifications).  It is not recommended to send high-volume
-     * message traffic on this channel (e.g. file transfer), such that it may interfere with other jitsi-messages.
+     * NOTE: This message is designed to allow endpoints to pass their own 
+     * application-specific messaging to one another without requiring the 
+     * bridge to know of or understand every message type.  These messages 
+     * will be forwarded by the bridge using the same DataChannel as other 
+     * jitsi messages (e.g. active speaker and last-n notifications).  
+     * It is not recommended to send high-volume message traffic on this 
+     * channel (e.g. file transfer), such that it may interfere with other 
+     * jitsi-messages.
      */
     private void onClientEndpointMessage(
             WebRtcDataStream src,

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -436,6 +436,29 @@ public class Endpoint
             onClientEndpointMessage(src, jsonObject);
     }
 
+    /**
+     * Handles an opaque essage from this {@code Endpoint} that should be forwarded
+     * to either: a) another client in this conference (1:1 message) or b) all other
+     * clients in this conference (broadcast message)
+     *
+     * @param src the {@WebRtcDataStream) by which {@code jsonObject} has been received
+     * @param jsonObject the JSON object with {@link Videobridge#COLIBRI_CLASS} EndpointMessage
+     * which has been received by the associated {@code SctpConnection}
+     *
+     * EndpointMessage definition:
+     * 'to': If the 'to' field contains the endpoint id of another endpoint in this conference, the
+     * message will be treated as a 1:1 message and forwarded just to that endpoint.  If the 'to'
+     * field is an empty string, the message will be treated as a broadcast and sent to all other
+     * endpoints in this conference.
+     * 'msgPayload': An opaque payload.  The bridge does not need to know or care what is contained
+     * in the 'msgPayload' field, it will just forward it blindly.
+     *
+     * NOTE: This message is designed to allow endpoints to pass their own application-specific messaging
+     * to one another without requiring the bridge to know of or understand every message type.  These
+     * messages will be forwarded by the bridge using the same DataChannel as other jitsi messages
+     * (e.g. active speaker and last-n notifications).  It is not recommended to send high-volume
+     * message traffic on this channel (e.g. file transfer), such that it may interfere with other jitsi-messages.
+     */
     private void onClientEndpointMessage(
             WebRtcDataStream src,
             JSONObject jsonObject)
@@ -443,10 +466,9 @@ public class Endpoint
         String to = (String)jsonObject.get("to");
         String msgPayload = ((JSONObject)jsonObject.get("msgPayload")).toString();
         Conference conf = getConference();
-        if ("broadcast".equals(to))
+        if ("".equals(to))
         {
-            // "broadcast" from an endpoint's perspective means
-            // 'send to everyone else in the conference except for me'
+            // Broadcast message
             List<Endpoint> endpointSubset = new ArrayList<Endpoint>();
             for (Endpoint endpoint : conf.getEndpoints()) {
                 if (!endpoint.getID().equalsIgnoreCase(getID()))
@@ -458,6 +480,7 @@ public class Endpoint
         }
         else
         {
+            // 1:1 message
             Endpoint ep = conf.getEndpoint(to);
             if (ep != null)
             {


### PR DESCRIPTION
…nicate an arbitrary payload to one another/an entire conference.


I thought I'd run this idea by the jitsi team.  I wanted to add a generic colibri message that applications can use to communicate application-specific information over the data channel.  Our use cases centered around endpoints being able to send information in either '1:1' (endpoint sends a message specifically to another endpoint) or 'broadcast' (endpoint sends a message to everyone else in the conference) modes.  This way applications can send their own messages over the existing datachannel when connecting via the bridge.

The way I've got it formatted now is this:
message {
  colibriClass: "EndpointMessage",
  to: "broadcast" | <user_id [the id used by the bridge]>,
  msgPayload: <arbitrary message payload, jitsi doesn't care, up to application developer>
}
but I'm open to suggestions, this was just what I threw together to match our use case.  Let me know if this is a feature that you think would make sense to be included upstream.