### PR TITLE
Exclude slf4j-simple

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,12 @@
     <dependency>
       <groupId>callstats</groupId>
       <artifactId>callstats</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>


### PR DESCRIPTION
slf4j-jdk14 is already a dependency, and SLF4J emits a warning when
multiple SLF4J bindings are on the classpath.
