### PR TITLE
Use exec in wrapper scripts for launching java

### DIFF
--- a/resources/collect-dump-logs.sh
+++ b/resources/collect-dump-logs.sh
@@ -5,14 +5,13 @@
 
 PID=$(cat /var/run/jitsi-videobridge.pid)
 if [ $PID ]; then
-    PROC_PID=$(pgrep -P $PID)
-    echo "Jvb at pid $PROC_PID"
+    echo "Jvb at pid $PID"
     STAMP=`date +%Y-%m-%d-%H%M`
-    THREADS_FILE="/tmp/stack-${STAMP}-${PROC_PID}.threads"
-    HEAP_FILE="/tmp/heap-${STAMP}-${PROC_PID}.bin"
-    sudo -u jvb jstack ${PROC_PID} > ${THREADS_FILE}
-    sudo -u jvb jmap -dump:live,format=b,file=${HEAP_FILE} ${PROC_PID}
-    tar zcvf jvb-dumps-${STAMP}-${PROC_PID}.tgz ${THREADS_FILE} ${HEAP_FILE} /var/log/jitsi/jvb.log
+    THREADS_FILE="/tmp/stack-${STAMP}-${PID}.threads"
+    HEAP_FILE="/tmp/heap-${STAMP}-${PID}.bin"
+    sudo -u jvb jstack ${PID} > ${THREADS_FILE}
+    sudo -u jvb jmap -dump:live,format=b,file=${HEAP_FILE} ${PID}
+    tar zcvf jvb-dumps-${STAMP}-${PID}.tgz ${THREADS_FILE} ${HEAP_FILE} /var/log/jitsi/jvb.log
     rm ${HEAP_FILE} ${THREADS_FILE}
 else
     echo "JVB not running."

--- a/resources/install/debian/init.d
+++ b/resources/install/debian/init.d
@@ -36,24 +36,13 @@ test -x $DAEMON || exit 0
 
 set -e
 
-killParentPid() {
-    PARENT_PID=$(ps -o pid --no-headers --ppid $1 || true)
-    if [ $PARENT_PID ]; then
-        kill $PARENT_PID
-    fi
-}
-
 stop() {
     if [ -f $PIDFILE ]; then
         PID=$(cat $PIDFILE)
     fi
     echo -n "Stopping $DESC: "
     if [ $PID ]; then
-        killParentPid $PID
-        rm $PIDFILE || true
-        echo "$NAME stopped."
-    elif [ $(ps -C jvb.sh --no-headers -o pid) ]; then
-        kill $(ps -o pid --no-headers --ppid $(ps -C jvb.sh --no-headers -o pid))
+        kill $PID
         rm $PIDFILE || true
         echo "$NAME stopped."
     else
@@ -83,7 +72,7 @@ reload() {
 }
 
 status() {
-    status_of_proc -p $PIDFILE "$DAEMON" "$NAME" && exit 0 || exit $?
+    status_of_proc -p $PIDFILE java "$NAME" && exit 0 || exit $?
 }
 
 case "$1" in

--- a/resources/install/linux-64/jvb.sh
+++ b/resources/install/linux-64/jvb.sh
@@ -34,4 +34,4 @@ fi
 
 if [ -z "$VIDEOBRIDGE_MAX_MEMORY" ]; then VIDEOBRIDGE_MAX_MEMORY=3072m; fi
 
-LD_LIBRARY_PATH=$libs java -Xmx$VIDEOBRIDGE_MAX_MEMORY $VIDEOBRIDGE_DEBUG_OPTIONS -XX:-HeapDumpOnOutOfMemoryError -Djava.library.path=$libs $LOGGING_CONFIG_PARAM $JAVA_SYS_PROPS -cp $cp $mainClass $@
+LD_LIBRARY_PATH=$libs exec java -Xmx$VIDEOBRIDGE_MAX_MEMORY $VIDEOBRIDGE_DEBUG_OPTIONS -XX:-HeapDumpOnOutOfMemoryError -Djava.library.path=$libs $LOGGING_CONFIG_PARAM $JAVA_SYS_PROPS -cp $cp $mainClass $@

--- a/resources/install/linux/jvb.sh
+++ b/resources/install/linux/jvb.sh
@@ -32,4 +32,4 @@ if [ -f $videobridge_rc  ]; then
         source $videobridge_rc
 fi
 
-java $VIDEOBRIDGE_DEBUG_OPTIONS -Djava.library.path=$libs $LOGGING_CONFIG_PARAM $JAVA_SYS_PROPS -cp $cp $mainClass $@
+exec java $VIDEOBRIDGE_DEBUG_OPTIONS -Djava.library.path=$libs $LOGGING_CONFIG_PARAM $JAVA_SYS_PROPS -cp $cp $mainClass $@

--- a/resources/install/macosx/jvb.sh
+++ b/resources/install/macosx/jvb.sh
@@ -28,4 +28,4 @@ if [ -f $videobridge_rc  ]; then
 fi
 
 
-java $VIDEOBRIDGE_DEBUG_OPTIONS -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config -cp $cp $mainClass $@
+exec java $VIDEOBRIDGE_DEBUG_OPTIONS -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config -cp $cp $mainClass $@


### PR DESCRIPTION
When launching Java from a wrapper script, it's usually better to use
exec, so that the extra bash process isn't hanging around. It also helps
shutdown and process monitoring (like with upstart, systemd, docker,
etc.) since they would be monitoring (and killing) the Java process
itself, instead of the wrapper script.