### PR TITLE
flesh out long-polling support in the rest api and add a endpoint exp…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
       <artifactId>jetty-rewrite</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-continuation</artifactId>
+      <version>9.3.5.v20151012</version>
+    </dependency>
+    <dependency>
       <groupId>org.fusesource</groupId>
       <artifactId>sigar</artifactId>
     </dependency>

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -21,6 +21,7 @@ import java.lang.ref.*;
 import java.lang.reflect.*;
 import java.text.*;
 import java.util.*;
+import java.util.concurrent.*;
 
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.ColibriConferenceIQ.Recording.*;
@@ -158,6 +159,14 @@ public class Conference
      */
     private final Map<String, IceUdpTransportManager> transportManagers
         = new HashMap<>();
+
+    /**
+     * Queue to which any push events are added.  These events will be pulled by another
+     *  object who will send them out.
+     * NOTE: this sucks.  this should use whatever mechanism is used to push events out
+     *  the xmpp channel.
+     */
+    private final BlockingQueue<JSONObject> pushEventQueue = new LinkedBlockingQueue();
 
     /**
      * The <tt>Videobridge</tt> which has initialized this <tt>Conference</tt>.
@@ -1677,5 +1686,23 @@ public class Conference
     public String getName()
     {
         return name;
+    }
+
+    public void addPushEvent(JSONObject event)
+    {
+      System.out.println("CONF ADDING PUSH EVENT");
+      try {
+        pushEventQueue.put(event);
+      } 
+      catch (InterruptedException e)
+      {
+        logger.error("Conference " + getID() + " failed to add push event to queue: " + event.toString());
+      }
+    }
+
+    public JSONObject getPushEvent() throws InterruptedException
+    {
+      System.out.println("CONF GETTING PUSH EVENT");
+      return pushEventQueue.take();
     }
 }

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -867,6 +867,12 @@ public class Endpoint
      */
     public void expire()
     {
+        System.out.println("ENDPOINT " + getID() + " EXPIRING");
         this.expired = true;
+        Conference conference = getConference();
+        JSONObject endpointExpirationEvent = new JSONObject();
+        endpointExpirationEvent.put("type", "expiration");
+        endpointExpirationEvent.put("endpoint_id", getID());
+        conference.addPushEvent(endpointExpirationEvent);
     }
 }

--- a/src/main/java/org/jitsi/videobridge/rest/ConfPushAsyncService.java
+++ b/src/main/java/org/jitsi/videobridge/rest/ConfPushAsyncService.java
@@ -1,0 +1,33 @@
+package org.jitsi.videobridge.rest;
+
+import org.jitsi.videobridge.Conference;
+import org.json.simple.JSONObject;
+
+import javax.servlet.AsyncContext;
+import java.io.IOException;
+
+/**
+ * Created by brian on 1/19/16.
+ */
+public class ConfPushAsyncService implements Runnable {
+  private final AsyncContext context;
+  private final Conference conference;
+
+  public ConfPushAsyncService(AsyncContext context, Conference conference) {
+    this.context = context;
+    this.conference = conference;
+  }
+
+  public void run() {
+    try {
+      JSONObject pushEvent = conference.getPushEvent();
+      pushEvent.writeJSONString(context.getResponse().getWriter());
+      context.complete();
+    } catch (InterruptedException e) {
+      //TODO
+    } catch (IOException e) {
+      //TODO
+    }
+  }
+
+}

--- a/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
+++ b/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
@@ -209,11 +209,12 @@ public class RESTBundleActivator
      * to {@code servletContextHandler}
      */
     private ServletHolder initializeLongPollingServlet(
+            BundleContext bundleContext,
             ServletContextHandler servletContextHandler)
     {
         ServletHolder holder = new ServletHolder();
 
-        holder.setServlet(new LongPollingServlet());
+        holder.setServlet(new LongPollingServlet(bundleContext));
 
         // The rules for mappings of the Servlet specification do not allow path
         // matching in the middle of the path.
@@ -417,7 +418,7 @@ public class RESTBundleActivator
             b = true;
 
         // LongPollingServlet
-        servletHolder = initializeLongPollingServlet(servletContextHandler);
+        servletHolder = initializeLongPollingServlet(bundleContext, servletContextHandler);
         if (servletHolder != null)
             b = true;
 


### PR DESCRIPTION
…iration message.  NEEDS CLEANUP.

There's some ugly, temporary hacks here; I'd consider this basically a straw man implementation for the purpose of review. Hopefully the basic ideas are sound, but I figured I'd just get this review going in the background so the team can take a look and we can get it cleaned up and committed upstream. Mainly, need input on the mechanism by which the core code will push events to the long-polling channel--ideally this would be the same as how it's done with xmpp.

@lyubomir

NOTE: re-opened this as I accidentally did the previous one from the wrong branch.
