### PR TITLE
Removes an unnecessary lock acquisition in order to prevent a deadlock

### DIFF
--- a/src/main/java/org/jitsi/videobridge/TransportManager.java
+++ b/src/main/java/org/jitsi/videobridge/TransportManager.java
@@ -244,10 +244,7 @@ public abstract class TransportManager
      */
     protected List<Channel> getChannels()
     {
-        synchronized (channels)
-        {
-            return channels;
-        }
+        return channels;
     }
 
     /**


### PR DESCRIPTION
reported by Swapnil Bagadia (and reduce the risk of deadlocks in
general).