### PR TITLE
Always generate a positive SSRC.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Content.java
+++ b/src/main/java/org/jitsi/videobridge/Content.java
@@ -821,7 +821,7 @@ public class Content
                          * The places that are involved in this have been tagged
                          * with TAG(cat4-local-ssrc-hurricane).
                          */
-                        initialLocalSSRC = Videobridge.RANDOM.nextInt();
+                        initialLocalSSRC = Videobridge.RANDOM.nextLong() & 0xffffffffl;
 
                         rtpTranslatorImpl.setLocalSSRC(initialLocalSSRC);
 

--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -279,7 +279,7 @@ public class RtpChannel
          * synchronization source identifier (SSRC), which Jitsi Videobridge
          * pre-announces.
          */
-        initialLocalSSRC = Videobridge.RANDOM.nextInt();
+        initialLocalSSRC = Videobridge.RANDOM.nextLong() & 0xffffffffl;
 
         conferenceSpeechActivity
             = getContent().getConference().getSpeechActivity();


### PR DESCRIPTION
Does not really fix anything, as the SSRC is converted to unsigned before being sent out (in SourcePacketExtension.setSSRC). However, this eases debugging and makes the code cleaner IMHO.

The same problem seems to exist in libjitsi:SSRCFactoryImpl.doGenerateSSRC, though.