### PR TITLE
Use getLocalHostLanAddress to avoid using 127.0.0.1 as the local IP

### DIFF
--- a/src/main/java/org/jitsi/videobridge/RawUdpTransportManager.java
+++ b/src/main/java/org/jitsi/videobridge/RawUdpTransportManager.java
@@ -17,6 +17,7 @@ package org.jitsi.videobridge;
 
 import java.io.*;
 import java.net.*;
+import java.util.*;
 
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
@@ -144,6 +145,109 @@ public class RawUdpTransportManager
     }
 
     /**
+     * Returns an <code>InetAddress</code> object encapsulating what is most
+     * likely the machine's LAN IP address.
+     * <p>
+     * This method is intended for use as a replacement of JDK method
+     * <code>InetAddress.getLocalHost</code>, because that method is ambiguous
+     * on Linux systems. Linux systems enumerate the loopback network
+     * interface the same way as regular LAN network interfaces, but the JDK
+     * <code>InetAddress.getLocalHost</code> method does not specify the
+     * algorithm used to select the address returned under such circumstances,
+     * and will often return the loopback address, which is not valid for
+     * network communication. Details
+     * <a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4665037">
+     * here</a>.
+     * <p>
+     * This method will scan all IP addresses on all network interfaces on
+     * the host machine to determine the IP address most likely to be the
+     * machine's LAN address. If the machine has multiple IP addresses, this
+     * method will prefer a site-local IP address (e.g. 192.168.x.x or
+     * 10.10.x.x, usually IPv4) if the machine has one (and will return the
+     * first site-local address if the machine has more than one), but if the
+     * machine does not hold a site-local address, this method will return
+     * simply the first non-loopback address found (IPv4 or IPv6).
+     * <p>
+     * If this method cannot find a non-loopback address using this selection
+     * algorithm, it will fall back to calling and returning the result of JDK
+     * method <code>InetAddress.getLocalHost</code>.
+     * <p>
+     *
+     * @throws UnknownHostException If the LAN address of the machine cannot
+     * be found.
+     */
+    private static InetAddress getLocalHostLanAddress()
+            throws UnknownHostException
+    {
+        try
+        {
+            InetAddress candidateAddress = null;
+            // Iterate all NICs (network interface cards)...
+            for (Enumeration<NetworkInterface> networkInterfaces =
+                    NetworkInterface.getNetworkInterfaces();
+                 networkInterfaces.hasMoreElements(); )
+            {
+                NetworkInterface networkInterface =
+                        networkInterfaces.nextElement();
+                // Iterate all IP addresses assigned to each card...
+                for (Enumeration<InetAddress> inetAddresses =
+                        networkInterface.getInetAddresses();
+                     inetAddresses.hasMoreElements(); )
+                {
+                    InetAddress inetAddress = inetAddresses.nextElement();
+                    if (!inetAddress.isLoopbackAddress())
+                    {
+                        if (inetAddress.isSiteLocalAddress())
+                        {
+                            // Found non-loopback site-local address.
+                            // Return it immediately...
+                            return inetAddress;
+                        }
+                        else if (candidateAddress == null)
+                        {
+                            // Found non-loopback address, but not necessarily
+                            // site-local. Store it as a candidate to be
+                            // returned if site-local address is not
+                            // subsequently found...
+                            candidateAddress = inetAddress;
+                            // Note that we don't repeatedly assign
+                            // non-loopback non-site-local addresses as
+                            // candidates, only the first. For subsequent
+                            // iterations, candidate will be non-null.
+                        }
+                    }
+                }
+            }
+            if (candidateAddress != null)
+            {
+                // We did not find a site-local address, but we found some
+                // other non-loopback address. Server might have a
+                // non-site-local address assigned to its NIC (or it might be
+                // running IPv6 which deprecates the "site-local" concept).
+                // Return this non-loopback candidate address...
+                return candidateAddress;
+            }
+            // At this point, we did not find a non-loopback address. Fall back
+            // to returning whatever InetAddress.getLocalHost() returns...
+            InetAddress jdkSuppliedAddress = InetAddress.getLocalHost();
+            if (jdkSuppliedAddress == null)
+            {
+                throw new UnknownHostException("The JDK InetAddress" +
+                        ".getLocalHost() method unexpectedly returned null.");
+            }
+            return jdkSuppliedAddress;
+        }
+        catch (Exception e)
+        {
+            UnknownHostException unknownHostException =
+                    new UnknownHostException(
+                            "Failed to determine LAN address: " + e);
+            unknownHostException.initCause(e);
+            throw unknownHostException;
+        }
+    }
+
+    /**
      * Allocates the datagram sockets expected of this <tt>TransportManager</tt>
      * for the purposes of RTCP and RTP transmission and represents them in the
      * form of a <tt>StreamConnector</tt> instance.
@@ -218,7 +322,7 @@ public class RawUdpTransportManager
             }
         }
         if (bindAddr == null)
-            bindAddr = InetAddress.getLocalHost();
+            bindAddr = getLocalHostLanAddress();
 
         StreamConnector streamConnector = new DefaultStreamConnector(bindAddr);
 

--- a/src/test/java/org/jitsi/videobridge/RawUdpConferenceTest.java
+++ b/src/test/java/org/jitsi/videobridge/RawUdpConferenceTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge;
+
+import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
+import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
+import org.jivesoftware.smack.packet.*;
+import org.junit.*;
+import org.junit.runner.*;
+import org.junit.runners.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests videobridge on conferences with raw UDP channels.
+ *
+ * @author Johannes Singler
+ */
+@RunWith(JUnit4.class)
+public class RawUdpConferenceTest
+{
+    /**
+     * Tested <tt>Videobridge</tt> instance.
+     */
+    private static Videobridge bridge;
+
+    private static OSGiHandler osgiHandler = new OSGiHandler();
+
+    /**
+     * Initializes OSGi and the videobridge.
+     */
+    @BeforeClass
+    public static void setUp()
+        throws InterruptedException
+    {
+        osgiHandler.start();
+
+        bridge = osgiHandler.getService(Videobridge.class);
+    }
+
+    /**
+     * Shutdown OSGi and the videobridge.
+     */
+    @AfterClass
+    public static void tearDown()
+        throws InterruptedException
+    {
+        osgiHandler.stop();
+    }
+
+    /**
+     * Tests when requesting a raw UDP channel, we do not get candidates with
+     * 127.0.0.1 IPs.
+     *
+     * Test fails only if the machine has only a loopback interface, which is
+     * very unlikely.
+     */
+    @Test
+    public void testNo_127_0_0_0_CandidateIps()
+        throws Exception
+    {
+        String focusJid = "focusJid";
+
+        ColibriConferenceIQ confIq
+            = ColibriUtilities.createConferenceIq(focusJid);
+        confIq.getContents().get(0).getChannel(0).
+                setTransport(new RawUdpTransportPacketExtension());
+
+        IQ respIq = bridge.handleColibriConferenceIQ(confIq);
+
+        assertTrue(respIq instanceof ColibriConferenceIQ);
+        ColibriConferenceIQ respConfIq = (ColibriConferenceIQ) respIq;
+
+        for (CandidatePacketExtension candidate :
+                respConfIq.getContents().get(0).getChannel(0).
+                        getTransport().getCandidateList())
+        {
+            assertNotEquals("127.0.0.1", candidate.getAttribute("ip"));
+        }
+    }
+}

--- a/src/test/java/org/jitsi/videobridge/VideoBridgeTestSuite.java
+++ b/src/test/java/org/jitsi/videobridge/VideoBridgeTestSuite.java
@@ -27,6 +27,7 @@ import org.junit.runners.*;
 @Suite.SuiteClasses(
     {
         FocusControlTest.class,
+        RawUdpConferenceTest.class,
         BridgeShutdownTest.class // This one must be the last one
     })
 public class VideoBridgeTestSuite


### PR DESCRIPTION
The code is mostly taken from here, which should also be Apache-licensed
https://issues.apache.org/jira/browse/JCS-40

It fixes the second problem in https://github.com/jitsi/jitsi-videobridge/issues/102

It might be desirable anyway to allow to configure "the" IP address. Suggestions for a property name?