### PR TITLE
Fix setting RTP relay type to mixer

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Content.java
+++ b/src/main/java/org/jitsi/videobridge/Content.java
@@ -301,8 +301,6 @@ public class Content
         // Initialize channel
         channel.initialize(rtpLevelRelayType);
 
-        Videobridge videobridge = getConference().getVideobridge();
-
         if (logger.isInfoEnabled())
         {
             /*
@@ -311,6 +309,7 @@ public class Content
              * of causing deadlocks.
              */
 
+            Videobridge videobridge = getConference().getVideobridge();
             logger.info(
                     "Created channel " + channel.getID() + " of content "
                         + getName() + " of conference " + conference.getID()

--- a/src/main/java/org/jitsi/videobridge/Content.java
+++ b/src/main/java/org/jitsi/videobridge/Content.java
@@ -19,6 +19,7 @@ import java.io.*;
 import java.lang.ref.*;
 import java.util.*;
 
+import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
 
 import org.jitsi.eventadmin.*;
@@ -247,12 +248,14 @@ public class Content
      * or {@link RawUdpTransportPacketExtension#NAMESPACE}.
      * @param initiator the value to use for the initiator field, or
      * <tt>null</tt> to use the default value.
+     * @param rtpLevelRelayType
      * @return the created <tt>RtpChannel</tt> instance.
      * @throws Exception
      */
     public RtpChannel createRtpChannel(String channelBundleId,
                                        String transportNamespace,
-                                       Boolean initiator)
+                                       Boolean initiator,
+                                       RTPLevelRelayType rtpLevelRelayType)
         throws Exception
     {
         RtpChannel channel = null;
@@ -296,7 +299,7 @@ public class Content
         while (channel == null);
 
         // Initialize channel
-        channel.initialize();
+        channel.initialize(rtpLevelRelayType);
 
         Videobridge videobridge = getConference().getVideobridge();
 

--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -949,6 +949,12 @@ public class RtpChannel
     public void initialize()
         throws IOException
     {
+        initialize(null);
+    }
+
+    void initialize(RTPLevelRelayType rtpLevelRelayType)
+        throws IOException
+    {
         super.initialize();
 
         MediaService mediaService = getMediaService();
@@ -970,6 +976,21 @@ public class RtpChannel
             stream.setProperty(RtpChannel.class.getName(), this);
             if (transformEngine != null)
                 stream.setExternalTransformer(transformEngine);
+
+            /*
+             * The attribute rtp-level-relay-type specifies the
+             * vale of pretty much the most important Channel
+             * property given that Jitsi Videobridge implements
+             * an RTP-level relay. Consequently, it is
+             * intuitively a sign of common sense to take the
+             * value into account as possible.
+             *
+             * The attribute rtp-level-relay-type is optional.
+             * If a value is not specified, then the Channel
+             * rtpLevelRelayType is to not be changed.
+             */
+            if (rtpLevelRelayType != null)
+                setRTPLevelRelayType(rtpLevelRelayType);
 
             // The transport manager could be already connected, in which case
             // (since we just created the stream), any previous calls to

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -204,7 +204,14 @@ public class VideoChannel
     public void initialize()
         throws IOException
     {
-        super.initialize();
+        initialize(null);
+    }
+
+    @Override
+    void initialize(RTPLevelRelayType rtpLevelRelayType)
+        throws IOException
+    {
+        super.initialize(rtpLevelRelayType);
 
         ConfigurationService cfg
             = getContent().getConference().getVideobridge()

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -740,7 +740,8 @@ public class Videobridge
                                     = content.createRtpChannel(
                                         channelBundleId,
                                         transportNamespace,
-                                        channelIQ.isInitiator());
+                                        channelIQ.isInitiator(),
+                                        channelIQ.getRTPLevelRelayType());
                                 channelCreated = true;
                             }
                         }
@@ -771,24 +772,6 @@ public class Videobridge
                                         && channel.isExpired())
                                     continue;
                             }
-
-                            /*
-                             * The attribute rtp-level-relay-type specifies the
-                             * vale of pretty much the most important Channel
-                             * property given that Jitsi Videobridge implements
-                             * an RTP-level relay. Consequently, it is
-                             * intuitively a sign of common sense to take the
-                             * value into account as possible.
-                             *
-                             * The attribute rtp-level-relay-type is optional.
-                             * If a value is not specified, then the Channel
-                             * rtpLevelRelayType is to not be changed.
-                             */
-                            RTPLevelRelayType rtpLevelRelayType
-                                = channelIQ.getRTPLevelRelayType();
-
-                            if (rtpLevelRelayType != null)
-                                channel.setRTPLevelRelayType(rtpLevelRelayType);
 
                             // endpoint
                             // The attribute endpoint is optional. If a value is

--- a/src/main/java/org/jitsi/videobridge/health/Health.java
+++ b/src/main/java/org/jitsi/videobridge/health/Health.java
@@ -95,7 +95,8 @@ public class Health
                     = content.createRtpChannel(
                             channelBundleId,
                             /* transportNamespace */ null,
-                            initiator);
+                            initiator,
+                            null);
 
                 // Fail as quickly as possible.
                 if (rtpChannel == null)

--- a/src/test/java/org/jitsi/videobridge/RawUdpConferenceTest.java
+++ b/src/test/java/org/jitsi/videobridge/RawUdpConferenceTest.java
@@ -91,4 +91,30 @@ public class RawUdpConferenceTest
             assertNotEquals("127.0.0.1", candidate.getAttribute("ip"));
         }
     }
+
+    /**
+     * Tests requesting a raw UDP channel with RTP level relay type MIXER
+     */
+    @Test
+    public void testMixerChannel()
+            throws Exception
+    {
+        String focusJid = "focusJid";
+
+        ColibriConferenceIQ confIq
+                = ColibriUtilities.createConferenceIq(focusJid);
+        ColibriConferenceIQ.Channel channel
+                = confIq.getContents().get(0).getChannel(0);
+        channel.setTransport(new RawUdpTransportPacketExtension());
+        channel.setRTPLevelRelayType(RTPLevelRelayType.MIXER);
+
+        IQ respIq = bridge.handleColibriConferenceIQ(confIq);
+
+        assertTrue(respIq instanceof ColibriConferenceIQ);
+        ColibriConferenceIQ respConfIq = (ColibriConferenceIQ) respIq;
+
+        assertEquals(RTPLevelRelayType.MIXER,
+                        respConfIq.getContents().get(0).getChannel(0).
+                            getRTPLevelRelayType());
+    }
 }


### PR DESCRIPTION
(This PR includes https://github.com/jitsi/jitsi-videobridge/pull/128 in terms of test infrastructure, please accept that one before).

This fixes the first part of https://github.com/jitsi/jitsi-videobridge/issues/102 and presumably also https://github.com/jitsi/jitsi-videobridge/issues/9

The problem was:
RtpChannel.initialize calls transportConnected because for RawUdpTransportManager, isConnected is immediately true. Then transportConnected -> maybeStartStream -> getRTPLevelRelayType
As the RTP level type is not yet set at this point in time, it will be set to the default TRANSLATOR in getRTPLevelRelayType.

There is explicitly a comment stating

            /*
             * We've postponed the invocation of the method
             * getRTPLevelRelayType() in order to make sure that the conference
             * focus has had a chance to set the RTP-level relay type. We have
             * to invoke the method MediaStream#setSSRCFactory(SSRCFactory)
             * before starting the stream.
             */

but it's just not true before the patch proposed here.

