### PR TITLE
Synchronize access to RtpChannel.stream.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -544,7 +544,10 @@ public class RtpChannel
                                     && !format.equals(stream.getFormat()))
                             {
                                 stream.setFormat(format);
-                                stream.setDirection(MediaDirection.SENDRECV);
+                                synchronized (streamSyncRoot)
+                                {   // otherwise races with stream.start()
+                                    stream.setDirection(MediaDirection.SENDRECV);
+                                }
                                 notify = true;
                             }
                         }
@@ -1048,7 +1051,10 @@ public class RtpChannel
             if (RTPLevelRelayType.MIXER.equals(getRTPLevelRelayType()))
                 stream.setSSRCFactory(new SSRCFactoryImpl(initialLocalSSRC));
 
-            stream.start();
+            synchronized (streamSyncRoot)
+            {   // otherwise races with stream.setDirection()
+                stream.start();
+            }
 
             Videobridge videobridge
                 = getContent().getConference().getVideobridge();


### PR DESCRIPTION
This fixes a nasty race condition during media channel establishment. We noticed it in mixer mode using an automated test with all components on a single machine, so it might be due to very tight timing.

In RtpChannel, during the execution of 

    stream.start()

a media packet from the peer comes in already, indirectly triggering 

    stream.setDirection(MediaDirection.SENDRECV);

in another thread.
However, as MediaStreamImpl.started is not yet set to true, this call effectively does not start the outgoing stream, resulting in a one-way media stream.

This could alternatively be fixed by declaring MediaStreamImpl.start/stop/setDirection as "synchronized" in libjitsi.