### PR TITLE
Fixes issues with lastN when the N+1th person joins

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -540,12 +540,7 @@ public class Endpoint
                             + " {pinnedId}."));
         }
 
-        List<String> newPinnedIDList = Collections.EMPTY_LIST;
-        if (newPinnedEndpointID == null || "".equals(newPinnedEndpointID))
-        {
-            newPinnedIDList = Collections.singletonList(newPinnedEndpointID);
-        }
-
+        List<String> newPinnedIDList = (newPinnedEndpointID == null) ? Collections.EMPTY_LIST : Collections.singletonList(newPinnedEndpointID);
         pinnedEndpointsChanged(newPinnedIDList);
     }
 

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -494,8 +494,6 @@ public class VideoChannel
                 sendLastNEndpointsChangeEventOnDataChannel(
                         lastNController.getForwardedEndpoints(), null);
             }
-
-            updateInLastN(this);
         }
     }
 


### PR DESCRIPTION
Removed call to updateInLastN() when SCTP connection is ready.
This appeared to make all clients disregard the N+1th person's video feed.

Also, Fixes logic for when pinned endpoints change. It was previously passing only null or empty lists of endpoints. 