### PR TITLE
Prevent NullPointerException when there are no simulcast source groups.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -915,16 +915,18 @@ public class VideoChannel
 
         }
 
-        // FID groups have been saved in RtpChannel. Make sure any changes are
-        // propagated to the appropriate SimulcastStream-s.
-        for (Map.Entry<Long, Long> entry : this.fidSourceGroups.entrySet())
-        {
-            SimulcastStream simulcastStream = ssrc2stream.get(entry.getKey());
-            simulcastStream.setRTXSSRC(entry.getValue());
+        if (simulcastStreams != null) {
+            // FID groups have been saved in RtpChannel. Make sure any changes are
+            // propagated to the appropriate SimulcastStream-s.
+            for (Map.Entry<Long, Long> entry : this.fidSourceGroups.entrySet())
+            {
+                SimulcastStream simulcastStream = ssrc2stream.get(entry.getKey());
+                simulcastStream.setRTXSSRC(entry.getValue());
+            }
+        
+            simulcastEngine
+                .getSimulcastReceiver().setSimulcastStreams(simulcastStreams);
         }
-
-        simulcastEngine
-            .getSimulcastReceiver().setSimulcastStreams(simulcastStreams);
     }
 
     /**


### PR DESCRIPTION
The main for loop at line 894 short circuits if a source group does not
have a simulcast semantic. If there are no simulcast source groups at
all, the ssrc2stream hash map is never populated, triggering a NPE
after the main for loop.

This change detects that there were no simulcast groups and skips
running those final steps.