### PR TITLE
Delete superfluous Tracked class

### DIFF
--- a/src/main/java/org/jitsi/videobridge/simulcast/SimulcastEngine.java
+++ b/src/main/java/org/jitsi/videobridge/simulcast/SimulcastEngine.java
@@ -256,7 +256,7 @@ public class SimulcastEngine
 
             return p;
         }
-    };
+    }
 
     /**
      * The RTCP <tt>PacketTransformer</tt> of this <tt>SimulcastEngine</tt>.
@@ -320,5 +320,5 @@ public class SimulcastEngine
             // Don't touch incoming RTCP traffic.
             return pkt;
         }
-    };
+    }
 }

--- a/src/main/java/org/jitsi/videobridge/simulcast/sendmodes/RewritingSendMode.java
+++ b/src/main/java/org/jitsi/videobridge/simulcast/sendmodes/RewritingSendMode.java
@@ -84,12 +84,7 @@ public class RewritingSendMode
         }
 
         SimulcastStream current = getCurrent();
-        if (current != null && current.match(pkt))
-        {
-            return true;
-        }
-
-        return false;
+        return current != null && current.match(pkt);
     }
 
     @Override


### PR DESCRIPTION
SimulcastEngine defines an internal Tracked class which is being used superfluously. I've deleted the class and replaced its use with a (boolean) method return value.

Additionally, I've fixed a few simple IntelliJ IDEA warnings (in a separate commit), one of which is a source code simplification.