### PR TITLE
Fix a NullPointerException in IceUdpTransportManager

### DIFF
--- a/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
+++ b/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
@@ -1818,7 +1818,17 @@ public class IceUdpTransportManager
                             }
                         }
 
+                        // XXX The value of the field iceAgent is null at times.
+                        Agent iceAgent = getAgent();
+
+                        if (iceAgent == null)
+                        {
+                            // This TransportManager has (probably) been closed.
+                            return;
+                        }
+
                         IceProcessingState state = iceAgent.getState();
+
                         if (IceProcessingState.COMPLETED.equals(state)
                                 || IceProcessingState.TERMINATED.equals(state))
                         {


### PR DESCRIPTION
Fixes a NullPointerException in IceUdpTransportManager which occurs repeatedly and regularly. That's likely happening during health checks (from Jicofo, for example). No functionality appears to be broken.