### PR TITLE
General build improvements

### DIFF
--- a/.sip-communicator/sip-communicator.properties
+++ b/.sip-communicator/sip-communicator.properties
@@ -1,0 +1,3 @@
+#Properties file for Jitsi Videobridge and libjitsi parameters.
+
+#org.jitsi.videobridge.ENABLE_STATISTICS=true

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,61 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>1.4</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>create</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <git-SHA-1>${buildNumber}</git-SHA-1>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.jitsi.videobridge.Main</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.4.3</version>
@@ -255,7 +310,7 @@
             <configuration>
               <appendAssemblyId>false</appendAssemblyId>
               <descriptor>src/assembly/linux-x64-bin-archive.xml</descriptor>
-              <finalName>${project.artifactId}-linux-x64-${project.version}</finalName>
+              <finalName>${project.artifactId}-linux-x64-${project.version}_${buildNumber}</finalName>
               <skipAssembly>${assembly.skipAssembly}</skipAssembly>
             </configuration>
           </execution>
@@ -268,7 +323,7 @@
             <configuration>
               <appendAssemblyId>false</appendAssemblyId>
               <descriptor>src/assembly/linux-x86-bin-archive.xml</descriptor>
-              <finalName>${project.artifactId}-linux-x86-${project.version}</finalName>
+              <finalName>${project.artifactId}-linux-x86-${project.version}_${buildNumber}</finalName>
               <skipAssembly>${assembly.skipAssembly}</skipAssembly>
             </configuration>
           </execution>
@@ -281,7 +336,7 @@
             <configuration>
               <appendAssemblyId>false</appendAssemblyId>
               <descriptor>src/assembly/macosx-bin-archive.xml</descriptor>
-              <finalName>${project.artifactId}-macosx-${project.version}</finalName>
+              <finalName>${project.artifactId}-macosx-${project.version}_${buildNumber}</finalName>
               <skipAssembly>${assembly.skipAssembly}</skipAssembly>
             </configuration>
           </execution>
@@ -294,7 +349,7 @@
             <configuration>
               <appendAssemblyId>false</appendAssemblyId>
               <descriptor>src/assembly/windows-x64-bin-archive.xml</descriptor>
-              <finalName>${project.artifactId}-windows-x64-${project.version}</finalName>
+              <finalName>${project.artifactId}-windows-x64-${project.version}_${buildNumber}</finalName>
               <skipAssembly>${assembly.skipAssembly}</skipAssembly>
             </configuration>
           </execution>
@@ -307,9 +362,22 @@
             <configuration>
               <appendAssemblyId>false</appendAssemblyId>
               <descriptor>src/assembly/windows-x86-bin-archive.xml</descriptor>
-              <finalName>${project.artifactId}-windows-x86-${project.version}</finalName>
+              <finalName>${project.artifactId}-windows-x86-${project.version}_${buildNumber}</finalName>
               <skipAssembly>${assembly.skipAssembly}</skipAssembly>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>auto-clean</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,36 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.jitsi.videobridge.Main</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>

--- a/resources/install/linux-64/jvb.sh
+++ b/resources/install/linux-64/jvb.sh
@@ -34,4 +34,4 @@ fi
 
 if [ -z "$VIDEOBRIDGE_MAX_MEMORY" ]; then VIDEOBRIDGE_MAX_MEMORY=3072m; fi
 
-LD_LIBRARY_PATH=$libs exec java -Xmx$VIDEOBRIDGE_MAX_MEMORY $VIDEOBRIDGE_DEBUG_OPTIONS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -Djava.library.path=$libs $LOGGING_CONFIG_PARAM $JAVA_SYS_PROPS -cp $cp $mainClass $@
+LD_LIBRARY_PATH=$libs exec java -Xmx$VIDEOBRIDGE_MAX_MEMORY $VIDEOBRIDGE_DEBUG_OPTIONS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=$SCRIPT_DIR -Djava.library.path=$libs $LOGGING_CONFIG_PARAM $JAVA_SYS_PROPS -cp $cp $mainClass $@

--- a/resources/install/linux/jvb.sh
+++ b/resources/install/linux/jvb.sh
@@ -32,4 +32,4 @@ if [ -f $videobridge_rc  ]; then
         source $videobridge_rc
 fi
 
-exec java $VIDEOBRIDGE_DEBUG_OPTIONS -Djava.library.path=$libs $LOGGING_CONFIG_PARAM $JAVA_SYS_PROPS -cp $cp $mainClass $@
+exec java $VIDEOBRIDGE_DEBUG_OPTIONS -Djava.library.path=$libs $LOGGING_CONFIG_PARAM $JAVA_SYS_PROPS -Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=$SCRIPT_DIR -cp $cp $mainClass $@

--- a/resources/install/macosx/jvb.sh
+++ b/resources/install/macosx/jvb.sh
@@ -28,4 +28,4 @@ if [ -f $videobridge_rc  ]; then
 fi
 
 
-exec java $VIDEOBRIDGE_DEBUG_OPTIONS -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config -cp $cp $mainClass $@
+exec java $VIDEOBRIDGE_DEBUG_OPTIONS -Djava.library.path=$libs -Djava.util.logging.config.file=$logging_config -Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=$SCRIPT_DIR -cp $cp $mainClass $@

--- a/src/assembly/linux-x64-bin-archive.xml
+++ b/src/assembly/linux-x64-bin-archive.xml
@@ -40,5 +40,9 @@
         <include>jvb.sh</include>
       </includes>
     </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/.sip-communicator</directory>
+      <outputDirectory>.sip-communicator</outputDirectory>
+    </fileSet>
   </fileSets>
 </assembly>

--- a/src/assembly/linux-x64-bin-archive.xml
+++ b/src/assembly/linux-x64-bin-archive.xml
@@ -15,6 +15,9 @@
       <includes>
         <include>*.jar</include>
       </includes>
+      <excludes>
+        <exclude>original-*.jar</exclude>
+      </excludes>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/lib</directory>

--- a/src/assembly/linux-x64-bin-archive.xml
+++ b/src/assembly/linux-x64-bin-archive.xml
@@ -8,14 +8,6 @@
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
   <baseDirectory>${project.artifactId}-linux-x64-${project.version}</baseDirectory>
-  <dependencySets>
-    <dependencySet>
-      <outputDirectory>lib</outputDirectory>
-      <scope>runtime</scope>
-      <useProjectArtifact>false</useProjectArtifact>
-      <unpack>false</unpack>
-    </dependencySet>
-  </dependencySets>
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}</directory>

--- a/src/assembly/linux-x86-bin-archive.xml
+++ b/src/assembly/linux-x86-bin-archive.xml
@@ -8,14 +8,6 @@
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
   <baseDirectory>${project.artifactId}-linux-x86-${project.version}</baseDirectory>
-  <dependencySets>
-    <dependencySet>
-      <outputDirectory>lib</outputDirectory>
-      <scope>runtime</scope>
-      <useProjectArtifact>false</useProjectArtifact>
-      <unpack>false</unpack>
-    </dependencySet>
-  </dependencySets>
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}</directory>

--- a/src/assembly/linux-x86-bin-archive.xml
+++ b/src/assembly/linux-x86-bin-archive.xml
@@ -40,5 +40,9 @@
         <include>jvb.sh</include>
       </includes>
     </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/.sip-communicator</directory>
+      <outputDirectory>.sip-communicator</outputDirectory>
+    </fileSet>
   </fileSets>
 </assembly>

--- a/src/assembly/linux-x86-bin-archive.xml
+++ b/src/assembly/linux-x86-bin-archive.xml
@@ -15,6 +15,9 @@
       <includes>
         <include>*.jar</include>
       </includes>
+      <excludes>
+        <exclude>original-*.jar</exclude>
+      </excludes>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/lib</directory>

--- a/src/assembly/macosx-bin-archive.xml
+++ b/src/assembly/macosx-bin-archive.xml
@@ -40,5 +40,9 @@
         <include>jvb.sh</include>
       </includes>
     </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/.sip-communicator</directory>
+      <outputDirectory>.sip-communicator</outputDirectory>
+    </fileSet>
   </fileSets>
 </assembly>

--- a/src/assembly/macosx-bin-archive.xml
+++ b/src/assembly/macosx-bin-archive.xml
@@ -8,14 +8,6 @@
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
   <baseDirectory>${project.artifactId}-macosx-${project.version}</baseDirectory>
-  <dependencySets>
-    <dependencySet>
-      <outputDirectory>lib</outputDirectory>
-      <scope>runtime</scope>
-      <useProjectArtifact>false</useProjectArtifact>
-      <unpack>false</unpack>
-    </dependencySet>
-  </dependencySets>
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}</directory>

--- a/src/assembly/macosx-bin-archive.xml
+++ b/src/assembly/macosx-bin-archive.xml
@@ -15,6 +15,9 @@
       <includes>
         <include>*.jar</include>
       </includes>
+      <excludes>
+        <exclude>original-*.jar</exclude>
+      </excludes>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/lib</directory>

--- a/src/assembly/windows-x64-bin-archive.xml
+++ b/src/assembly/windows-x64-bin-archive.xml
@@ -15,6 +15,9 @@
       <includes>
         <include>*.jar</include>
       </includes>
+      <excludes>
+        <exclude>original-*.jar</exclude>
+      </excludes>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/lib</directory>

--- a/src/assembly/windows-x64-bin-archive.xml
+++ b/src/assembly/windows-x64-bin-archive.xml
@@ -8,14 +8,6 @@
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
   <baseDirectory>${project.artifactId}-windows-x64-${project.version}</baseDirectory>
-  <dependencySets>
-    <dependencySet>
-      <outputDirectory>lib</outputDirectory>
-      <scope>runtime</scope>
-      <useProjectArtifact>false</useProjectArtifact>
-      <unpack>false</unpack>
-    </dependencySet>
-  </dependencySets>
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}</directory>

--- a/src/assembly/windows-x64-bin-archive.xml
+++ b/src/assembly/windows-x64-bin-archive.xml
@@ -39,5 +39,9 @@
         <include>jvb.bat</include>
       </includes>
     </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/.sip-communicator</directory>
+      <outputDirectory>.sip-communicator</outputDirectory>
+    </fileSet>
   </fileSets>
 </assembly>

--- a/src/assembly/windows-x86-bin-archive.xml
+++ b/src/assembly/windows-x86-bin-archive.xml
@@ -8,14 +8,6 @@
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
   <baseDirectory>${project.artifactId}-windows-x86-${project.version}</baseDirectory>
-  <dependencySets>
-    <dependencySet>
-      <outputDirectory>lib</outputDirectory>
-      <scope>runtime</scope>
-      <useProjectArtifact>false</useProjectArtifact>
-      <unpack>false</unpack>
-    </dependencySet>
-  </dependencySets>
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}</directory>


### PR DESCRIPTION
With this PR we have these improvements:

- creation of a single jar containing all the dependencies required by JVB;

- the jar will contain in the manifest the SHA-1 taken from the last commit;

- the distributable package will contain a reference to the SHA-1 in the filename, and also an empty _sip-communicator.properties_ file useful to eventually configure some parameters for libjitsi or JVB;

NOTES:

- I tested only the linux-x64 package since I don't have Windows or Mac OSX machines available;

- During the package process, the Maven shade plugins signals some overlapping classes in the dependencies:
[WARNING] xmlpull-1.1.3.4a.jar, xpp3-1.1.4c.jar define 4 overlapping classes: 
[WARNING]   - org.xmlpull.v1.XmlPullParserException
[WARNING]   - org.xmlpull.v1.XmlSerializer
[WARNING]   - org.xmlpull.v1.XmlPullParser
[WARNING]   - org.xmlpull.v1.XmlPullParserFactory
[WARNING] slf4j-simple-1.6.1.jar, slf4j-jdk14-1.7.7.jar define 3 overlapping classes: 
[WARNING]   - org.slf4j.impl.StaticMarkerBinder
[WARNING]   - org.slf4j.impl.StaticLoggerBinder
[WARNING]   - org.slf4j.impl.StaticMDCBinder
[WARNING] org.apache.felix.framework-4.4.0.jar, org.apache.felix.main-4.4.0.jar define 163 overlapping classes: 
[WARNING]   - org.osgi.framework.namespace.PackageNamespace
[WARNING]   - org.osgi.framework.hooks.bundle.CollisionHook
[WARNING]   - org.apache.felix.framework.BundleRevisionDependencies
[WARNING]   - org.apache.felix.framework.util.WeakZipFileFactory$WeakZipFile
[WARNING]   - org.apache.felix.framework.cache.Content
[WARNING]   - org.apache.felix.framework.util.VersionRange
[WARNING]   - org.apache.felix.framework.PackageAdminImpl$2
[WARNING]   - org.apache.felix.framework.ServiceRegistrationImpl$ServiceFactoryPrivileged
[WARNING]   - org.apache.felix.framework.FrameworkStartLevelImpl$1
[WARNING]   - org.apache.felix.framework.util.EventDispatcher$3
[WARNING]   - 153 more...
[WARNING] jitsi-lgpl-dependencies-1.0-SNAPSHOT.jar, libjitsi-1.0-SNAPSHOT.jar define 4 overlapping classes: 
[WARNING]   - org.jitsi.impl.neomedia.codec.FFmpeg
[WARNING]   - org.jitsi.util.JNIUtils
[WARNING]   - org.jitsi.impl.neomedia.codec.audio.g722.JNIEncoder
[WARNING]   - org.jitsi.impl.neomedia.codec.audio.g722.JNIDecoder
[WARNING] org.apache.felix.framework-4.4.0.jar, org.osgi.core-4.3.1.jar, org.apache.felix.main-4.4.0.jar define 82 overlapping classes: 
[WARNING]   - org.osgi.framework.AdminPermission$1
[WARNING]   - org.osgi.framework.FrameworkUtil$FilterImpl$Parser
[WARNING]   - org.osgi.framework.Bundle
[WARNING]   - org.osgi.framework.FrameworkUtil$DNChainMatching
[WARNING]   - org.osgi.framework.launch.FrameworkFactory
[WARNING]   - org.osgi.framework.PackagePermission
[WARNING]   - org.osgi.framework.hooks.service.EventHook
[WARNING]   - org.osgi.framework.AdaptPermissionCollection
[WARNING]   - org.osgi.framework.ServicePermission$1
[WARNING]   - org.osgi.framework.FrameworkUtil
[WARNING]   - 72 more...
[WARNING] core-2.0.0.jar, tinder-1.2.3.jar define 17 overlapping classes: 
[WARNING]   - org.jivesoftware.util.FastDateFormat$UnpaddedNumberField
[WARNING]   - org.jivesoftware.util.FastDateFormat$TimeZoneDisplayKey
[WARNING]   - org.jivesoftware.util.FastDateFormat$Rule
[WARNING]   - org.jivesoftware.util.FastDateFormat$TwoDigitMonthField
[WARNING]   - org.jivesoftware.util.FastDateFormat$NumberRule
[WARNING]   - org.jivesoftware.util.FastDateFormat$Pair
[WARNING]   - org.jivesoftware.util.FastDateFormat$TwoDigitYearField
[WARNING]   - org.jivesoftware.util.FastDateFormat$UnpaddedMonthField
[WARNING]   - org.jivesoftware.util.FastDateFormat$TwoDigitNumberField
[WARNING]   - org.jivesoftware.util.FastDateFormat$TwelveHourField
[WARNING]   - 7 more...

I checked these dependencies and it seems that the version in the final jar is the right one, and JVB is working without issues.

