### PR TITLE
basic setup for adding more detailed channel statistics

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Content.java
+++ b/src/main/java/org/jitsi/videobridge/Content.java
@@ -29,6 +29,7 @@ import org.jitsi.service.neomedia.device.*;
 import org.jitsi.service.neomedia.recording.*;
 import org.jitsi.util.*;
 import org.jitsi.util.event.*;
+import org.jitsi.videobridge.stats.RtpChannelStatistics;
 import org.osgi.framework.*;
 
 /**
@@ -58,6 +59,7 @@ public class Content
      * The <tt>Channel</tt>s of this <tt>Content</tt> mapped by their IDs.
      */
     private final Map<String,Channel> channels = new HashMap<>();
+    private final Map<String, RtpChannelStatistics> channelStats = new HashMap<>();
 
     /**
      * The <tt>Conference</tt> which has initialized this <tt>Content</tt>.
@@ -292,7 +294,9 @@ public class Content
                             transportNamespace, initiator);
                         break;
                     }
+                    RtpChannelStatistics rtpChannelStats = new RtpChannelStatistics(id, channel);
                     channels.put(id, channel);
+                    channelStats.put(id, rtpChannelStats);
                 }
             }
         }
@@ -457,6 +461,7 @@ public class Content
             if (channel.equals(channels.get(id)))
             {
                 channels.remove(id);
+                channelStats.remove(id);
                 expireChannel = true;
             }
             else

--- a/src/main/java/org/jitsi/videobridge/rest/HandlerImpl.java
+++ b/src/main/java/org/jitsi/videobridge/rest/HandlerImpl.java
@@ -488,19 +488,19 @@ class HandlerImpl
                     = statsManager.getStatistics().iterator();
                 Statistics statistics = null;
 
-                if (i.hasNext())
+                Map<String, Object> stats = new HashMap<>();
+                JSONObject statisticsJSONObject = new JSONObject();
+                while (i.hasNext()) {
                     statistics = i.next();
-
-                JSONObject statisticsJSONObject
-                    = JSONSerializer.serializeStatistics(statistics);
+                    statisticsJSONObject.putAll(statistics.getStats());
+                }
                 Writer writer = response.getWriter();
-
-                response.setStatus(HttpServletResponse.SC_OK);
                 if (statisticsJSONObject == null)
                     writer.write("null");
                 else
                     statisticsJSONObject.writeJSONString(writer);
 
+                response.setStatus(HttpServletResponse.SC_OK);
                 return;
             }
         }

--- a/src/main/java/org/jitsi/videobridge/stats/RtpChannelStatistics.java
+++ b/src/main/java/org/jitsi/videobridge/stats/RtpChannelStatistics.java
@@ -1,0 +1,136 @@
+package org.jitsi.videobridge.stats;
+
+import org.jitsi.osgi.ServiceUtils2;
+import org.jitsi.service.neomedia.MediaStreamStats;
+import org.jitsi.videobridge.RtpChannel;
+
+import java.lang.ref.WeakReference;
+import java.text.DateFormat;
+import java.text.DecimalFormat;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+import java.util.concurrent.locks.Lock;
+
+/**
+ * Created by brian on 3/15/2016.
+ */
+public class RtpChannelStatistics
+    extends Statistics
+{
+    /**
+     * The <tt>DateFormat</tt> to be utilized by <tt>VideobridgeStatistics</tt>
+     * in order to represent time and date as <tt>String</tt>.
+     */
+    private static final DateFormat dateFormat;
+
+    private static final DecimalFormat decimalFormat
+            = new DecimalFormat("#.#####");
+
+    /**
+     * The indicator which determines whether {@link #generate()} is executing
+     * on this <tt>VideobridgeStatistics</tt>. If <tt>true</tt>, invocations of
+     * <tt>generate()</tt> will do nothing. Introduced in order to mitigate an
+     * issue in which a blocking in <tt>generate()</tt> will cause a multiple of
+     * threads to be initialized and blocked.
+     */
+    private boolean inGenerate = false;
+
+    private String channelId;
+    private WeakReference<RtpChannel> weakChannel;
+    private WeakReference<StatsManager> weakStatsManager;
+
+    static
+    {
+        dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    public RtpChannelStatistics(String channelId, RtpChannel channel)
+    {
+        this.channelId = channelId;
+        this.weakChannel = new WeakReference<>(channel);
+        this.weakStatsManager = new WeakReference<>(ServiceUtils2.getService(StatsManagerBundleActivator.getBundleContext(), StatsManager.class));
+
+        weakStatsManager.get().addStatistics(this, 1000);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void generate()
+    {
+        // If a thread is already executing generate and has potentially
+        // blocked, do not allow other threads to fall into the same trap.
+        Lock lock = this.lock.writeLock();
+        boolean inGenerate;
+
+        lock.lock();
+        try
+        {
+            if (this.inGenerate)
+            {
+                inGenerate = true;
+            }
+            else
+            {
+                // Enter the generate method.
+                inGenerate = false;
+                this.inGenerate = true;
+            }
+        }
+        finally
+        {
+            lock.unlock();
+        }
+        if (!inGenerate)
+        {
+            try
+            {
+                generate0();
+            }
+            finally
+            {
+                // Exit the generate method.
+                lock.lock();
+                try
+                {
+                    this.inGenerate = false;
+                }
+                finally
+                {
+                    lock.unlock();
+                }
+            }
+        }
+    }
+
+    /**
+     * Generates/updates the statistics represented by this instance outside a
+     * synchronized block.
+     */
+    static int dummyValue = 0;
+    protected void generate0()
+    {
+        MediaStreamStats streamStats = this.weakChannel.get().getStream().getMediaStreamStats();
+        streamStats.updateStats();
+        long numIncomingPacketsLost = streamStats.getNbPacketsLost();
+        long numIncomingPackets = streamStats.getNbPackets();
+
+
+        // Now that (the new values of) the statistics have been calculated and
+        // the risks of the current thread hanging have been reduced as much as
+        // possible, commit (the new values of) the statistics.
+        Lock lock = this.lock.writeLock();
+        lock.lock();
+        try
+        {
+            unlockedSetStat(this.channelId + ".incomingPackets", numIncomingPackets);
+            unlockedSetStat(this.channelId + ".incomingPacketsLost", numIncomingPacketsLost);
+        }
+        finally
+        {
+            lock.unlock();
+        }
+    }
+}


### PR DESCRIPTION
I'd like to get the team's feedback on this general method of adding more detailed statistics to the videobridge (assuming this is something that you'd be interested in having upstream).  The idea here is to be able to get detailed statistics for every channel (individual numbers for packet loss, bitrate, etc.) for the purpose of debugging.  I don't know if there's already a design in mind for how to achieve this, nor do I know if this is the best (or even a good) design for doing this, but wanted to at least start a conversation on how this could be done.  Thanks.

NOTE: consider this a 'design review', I'm not interested in integrating this as-is at this point.