### PR TITLE
Fixes an incorrect check for an invalid SSRC. When an SSRC is express…

### DIFF
--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -1794,9 +1794,9 @@ public class RtpChannel
         Set<Integer> newSignaledSSRCs = new HashSet<>();
         for (SourcePacketExtension source : sources)
         {
-            int ssrc = (int) source.getSSRC();
+            long ssrc = source.getSSRC();
             if (ssrc != -1)
-                newSignaledSSRCs.add((int) source.getSSRC());
+                newSignaledSSRCs.add((int) ssrc);
         }
 
         // Add the added SSRCs.


### PR DESCRIPTION
…ed as an int value, it cannot signal an invalid SSRC. Since the SSRC is available as a long value as well, do the check on the long value which is able to express an invalid SSRC.