### PR TITLE
Uses a separate "data" content in the conference created for health

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -964,6 +964,14 @@ public class Endpoint
                 ? (oldValue != null)
                 : !sctpConnection.equals(oldValue))
         {
+            if (oldValue != null && sctpConnection != null)
+            {
+                // This is not necessarily invalid, but with the current
+                // codebase it likely indicates a problem. If we start to
+                // actually use it, this warning should be removed.
+                logger.warn("Replacing an Endpoint's SctpConnection.");
+            }
+
             this.sctpConnection = new WeakReference<>(sctpConnection);
 
             firePropertyChange(

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -960,9 +960,7 @@ public class Endpoint
     {
         Object oldValue = getSctpConnection();
 
-        if ((sctpConnection == null)
-                ? (oldValue != null)
-                : !sctpConnection.equals(oldValue))
+        if (!Objects.equals(oldValue, sctpConnection))
         {
             if (oldValue != null && sctpConnection != null)
             {

--- a/src/main/java/org/jitsi/videobridge/health/Health.java
+++ b/src/main/java/org/jitsi/videobridge/health/Health.java
@@ -101,18 +101,21 @@ public class Health
                 // Fail as quickly as possible.
                 if (rtpChannel == null)
                     throw new NullPointerException();
+            }
 
-                // SctpConnection
-                SctpConnection sctpConnection
-                    = content.createSctpConnection(
-                            endpoint,
-                            /* sctpPort */ RANDOM.nextInt(),
-                            channelBundleId,
-                            initiator);
+            // SctpConnection
+            Content dataContent = conference.getOrCreateContent("data");
+            SctpConnection sctpConnection
+                = dataContent.createSctpConnection(
+                        endpoint,
+                        /* sctpPort */ RANDOM.nextInt(),
+                        channelBundleId,
+                        initiator);
 
-                // Fail as quickly as possible.
-                if (sctpConnection == null)
-                    throw new NullPointerException();
+            // Fail as quickly as possible.
+            if (sctpConnection == null)
+            {
+                throw new NullPointerException();
             }
         }
 


### PR DESCRIPTION
checks. Does not add SctpConnection-s to the audio and video contents.