### PR TITLE
Uses a PacketQueue for packets coming out of the SCTP stack in order to

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-20160321.041150-118</version>
+      <version>1.0-20160324.161250-119</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -26,10 +26,10 @@ import javax.media.rtp.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
 
+import org.ice4j.util.*;
 import org.jitsi.impl.neomedia.*;
 import org.jitsi.impl.neomedia.rtcp.*;
 import org.jitsi.impl.neomedia.rtcp.termination.strategies.*;
-import org.jitsi.impl.neomedia.rtp.remotebitrateestimator.*;
 import org.jitsi.impl.neomedia.transform.*;
 import org.jitsi.service.configuration.*;
 import org.jitsi.service.neomedia.*;


### PR DESCRIPTION
ensure that the calling thread does not block. We have
observed that blocking this thread (e.g. by having it eventually try
to write to a Socket) results in calls to usrsctp_socket to block (i.e.
to our inability to initialize any new SCTP sockets).