### PR TITLE
send a last-n notification when a client pins or n pins an endpoint

### DIFF
--- a/src/main/java/org/jitsi/videobridge/LastNController.java
+++ b/src/main/java/org/jitsi/videobridge/LastNController.java
@@ -220,6 +220,7 @@ public class LastNController
                         = Collections.unmodifiableList(newPinnedEndpointIds);
 
                 endpointsToAskForKeyframe = update();
+                update(new ArrayList<String>());
             }
         }
 


### PR DESCRIPTION
the "last-n" notification is the source of truth for clients as to which streams they're receiving from the bridge.  Therefore, it's best to rely on that as the trigger for local layout changes.  If a client pins another client, it doesn't automatically get a new last-n notification which it would normally rely on to actually perform a switch.  This change automatically sends an updated last-n notification when a pin/unpin occurs that changes the pinned list.