### PR TITLE
Support RFC 4145 setup attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ice4j</artifactId>
-      <version>1.0-20160323.233049-19</version>
+      <version>1.0-20160328.200106-21</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-20160325.182640-122</version>
+      <version>1.0-20160328.202717-123</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
+++ b/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
@@ -727,19 +727,16 @@ public class IceUdpTransportManager
         // configured min port. When maxPort is reached, allocation will begin
         // from minPort again, so we don't have to worry about wraps.
         int maxAllocatedPort
-                = getMaxAllocatedPort(
+            = getMaxAllocatedPort(
                     iceStream,
                     portTracker.getMinPort(),
                     portTracker.getMaxPort());
         if (maxAllocatedPort > 0)
         {
-            portTracker.setNextPort(1 + maxAllocatedPort);
+            int nextPort = 1 + maxAllocatedPort;
+            portTracker.setNextPort(nextPort);
             if (logger.isDebugEnabled())
-            {
-                logger.debug(
-                    "Updating the port tracker min port: "
-                            + (1 + maxAllocatedPort));
-            }
+                logger.debug("Updating the port tracker min port: " + nextPort);
         }
 
         return iceAgent;
@@ -751,13 +748,14 @@ public class IceUdpTransportManager
      */
     private int getMaxAllocatedPort(IceMediaStream iceStream, int min, int max)
     {
-        return Math.max(
-                getMaxAllocatedPort(
-                        iceStream.getComponent(Component.RTP),
-                        min, max),
-                getMaxAllocatedPort(
-                        iceStream.getComponent(Component.RTCP),
-                        min, max));
+        return
+            Math.max(
+                    getMaxAllocatedPort(
+                            iceStream.getComponent(Component.RTP),
+                            min, max),
+                    getMaxAllocatedPort(
+                            iceStream.getComponent(Component.RTCP),
+                            min, max));
     }
 
     /**
@@ -774,9 +772,12 @@ public class IceUdpTransportManager
             {
                 int candidatePort = candidate.getTransportAddress().getPort();
 
-                if (min <= candidatePort && candidatePort <= max
-                        && candidatePort > maxAllocatedPort)
+                if (min <= candidatePort
+                        && candidatePort <= max
+                        && maxAllocatedPort < candidatePort)
+                {
                     maxAllocatedPort = candidatePort;
+                }
             }
         }
 
@@ -910,10 +911,10 @@ public class IceUdpTransportManager
     }
 
     /**
-     * Sets up {@link #dtlsControl} according to <tt>transport</tt>,
-     * adds all (supported) remote candidates from <tt>transport</tt>
-     * to {@link #iceAgent} and starts {@link #iceAgent} if it isn't already
-     * started.
+     * Sets up {@link #dtlsControl} according to <tt>transport</tt>, adds all
+     * (supported) remote candidates from <tt>transport</tt> to
+     * {@link #iceAgent} and starts {@link #iceAgent} if it isn't started
+     * already.
      */
     private synchronized void doStartConnectivityEstablishment(
             IceUdpTransportPacketExtension transport)
@@ -927,7 +928,8 @@ public class IceUdpTransportManager
             if (channelForDtls != null && channelForDtls instanceof RtpChannel)
             {
                 ((RtpChannel) channelForDtls)
-                        .getDatagramFilter(true).setAcceptNonRtp(false);
+                    .getDatagramFilter(true)
+                        .setAcceptNonRtp(false);
             }
         }
 
@@ -1011,7 +1013,7 @@ public class IceUdpTransportManager
             }
 
             Component component
-                    = iceStream.getComponent(candidate.getComponent());
+                = iceStream.getComponent(candidate.getComponent());
             String relAddr;
             int relPort;
             TransportAddress relatedAddress = null;
@@ -1064,9 +1066,8 @@ public class IceUdpTransportManager
             if (remoteCandidateCount == 0)
             {
                 // XXX Effectively, the check above but realizing that all
-                // candidates were ignored: iceAgentStateIsRunning
-                // && (candidates.size() == 0).
-                return;
+                // candidates were ignored:
+                // iceAgentStateIsRunning && candidates.isEmpty().
             }
             else
             {

--- a/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
+++ b/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
@@ -237,7 +237,7 @@ public class IceUdpTransportManager
      * Whether this <tt>IceUdpTransportManager</tt> will serve as the the
      * controlling or controlled ICE agent.
      */
-    private final boolean isControlling;
+    private final boolean controlling;
 
     /**
      * The number of {@link org.ice4j.ice.Component}-s to create in
@@ -265,23 +265,23 @@ public class IceUdpTransportManager
      *
      * @param conference the <tt>Conference</tt> which created this
      * <tt>TransportManager</tt>.
-     * @param isControlling whether the new instance is to server as a
-     * controlling or controlled ICE agent.
+     * @param controlling {@code true} if the new instance is to serve as a
+     * controlling ICE agent and passive DTLS endpoint; otherwise, {@code false}
      * @throws IOException
      */
     public IceUdpTransportManager(Conference conference,
-                                  boolean isControlling)
+                                  boolean controlling)
         throws IOException
     {
-        this(conference, isControlling, 2, DEFAULT_ICE_STREAM_NAME);
+        this(conference, controlling, 2, DEFAULT_ICE_STREAM_NAME);
     }
 
     public IceUdpTransportManager(Conference conference,
-                                  boolean isControlling,
+                                  boolean controlling,
                                   int numComponents)
         throws IOException
     {
-        this(conference, isControlling, numComponents, DEFAULT_ICE_STREAM_NAME);
+        this(conference, controlling, numComponents, DEFAULT_ICE_STREAM_NAME);
     }
 
     /**
@@ -289,8 +289,8 @@ public class IceUdpTransportManager
      *
      * @param conference the <tt>Conference</tt> which created this
      * <tt>TransportManager</tt>.
-     * @param isControlling whether the new instance is to server as a
-     * controlling or controlled ICE agent.
+     * @param controlling {@code true} if the new instance is to serve as a
+     * controlling ICE agent and passive DTLS endpoint; otherwise, {@code false}
      * @param numComponents the number of ICE components that this instance is
      * to start with.
      * @param iceStreamName the name of the ICE stream to be created by this
@@ -298,20 +298,20 @@ public class IceUdpTransportManager
      * @throws IOException
      */
     public IceUdpTransportManager(Conference conference,
-                                  boolean isControlling,
+                                  boolean controlling,
                                   int numComponents,
                                   String iceStreamName)
         throws IOException
     {
         this.conference = conference;
+        this.controlling = controlling;
         this.numComponents = numComponents;
         this.rtcpmux = numComponents == 1;
-        this.isControlling = isControlling;
 
         dtlsControl = new DtlsControlImpl(false);
         dtlsControl.registerUser(this);
 
-        iceAgent = createIceAgent(isControlling, iceStreamName, rtcpmux);
+        iceAgent = createIceAgent(controlling, iceStreamName, rtcpmux);
         iceAgent.addStateChangeListener(iceAgentStateChangeListener);
         iceStream = iceAgent.getStream(iceStreamName);
         iceStream.addPairChangeListener(iceStreamPairChangeListener);
@@ -326,18 +326,18 @@ public class IceUdpTransportManager
      *
      * @param conference the <tt>Conference</tt> which created this
      * <tt>TransportManager</tt>.
-     * @param isControlling whether the new instance is to server as a
-     * controlling or controlled ICE agent.
+     * @param controlling {@code true} if the new instance is to serve as a
+     * controlling ICE agent and passive DTLS endpoint; otherwise, {@code false}
      * @param iceStreamName the name of the ICE stream to be created by this
      * instance.
      * @throws IOException
      */
     public IceUdpTransportManager(Conference conference,
-                                  boolean isControlling,
+                                  boolean controlling,
                                   String iceStreamName)
         throws IOException
     {
-        this(conference, isControlling, 2, iceStreamName);
+        this(conference, controlling, 2, iceStreamName);
     }
 
     /**
@@ -684,13 +684,16 @@ public class IceUdpTransportManager
      * protocol and which is to be used by this instance to implement the Jingle
      * ICE-UDP transport.
      *
+     * @param controlling
+     * @param iceStreamName
+     * @param rtcpmux
      * @return a new <tt>Agent</tt> instance which implements the ICE protocol
      * and which is to be used by this instance to implement the Jingle ICE-UDP
      * transport
      * @throws IOException if initializing a new <tt>Agent</tt> instance for the
      * purposes of this <tt>TransportManager</tt> fails
      */
-    private Agent createIceAgent(boolean isControlling,
+    private Agent createIceAgent(boolean controlling,
                                  String iceStreamName,
                                  boolean rtcpmux)
             throws IOException
@@ -704,7 +707,7 @@ public class IceUdpTransportManager
         //add videobridge specific harvesters such as a mapping and an Amazon
         //AWS EC2 harvester
         appendVideobridgeHarvesters(iceAgent, rtcpmux);
-        iceAgent.setControlling(isControlling);
+        iceAgent.setControlling(controlling);
         iceAgent.setPerformConsentFreshness(true);
 
         PortTracker portTracker = JitsiTransportManager.getPortTracker(null);
@@ -1177,7 +1180,7 @@ public class IceUdpTransportManager
      */
     public boolean isControlling()
     {
-        return isControlling;
+        return controlling;
     }
 
     /**
@@ -1855,7 +1858,7 @@ public class IceUdpTransportManager
     private void startDtls()
     {
         dtlsControl.setSetup(
-                isControlling
+                controlling
                     ? DtlsControl.Setup.PASSIVE
                     : DtlsControl.Setup.ACTIVE);
         dtlsControl.setRtcpmux(rtcpmux);

--- a/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
+++ b/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
@@ -1230,7 +1230,7 @@ public class IceUdpTransportManager
      * {@inheritDoc}
      */
     @Override
-    public DtlsControl getDtlsControl(Channel channel)
+    public DtlsControlImpl getDtlsControl(Channel channel)
     {
         return dtlsControl;
     }

--- a/src/main/java/org/jitsi/videobridge/RawUdpTransportManager.java
+++ b/src/main/java/org/jitsi/videobridge/RawUdpTransportManager.java
@@ -24,6 +24,7 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
 import net.java.sip.communicator.service.netaddr.*;
 import net.java.sip.communicator.util.*;
 
+import org.jitsi.impl.neomedia.transform.dtls.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.util.Logger;
 import org.jitsi.videobridge.xmpp.*;
@@ -433,7 +434,7 @@ public class RawUdpTransportManager
      * RawUdpTransportManager does not implement DTLS.
      */
     @Override
-    public DtlsControl getDtlsControl(Channel channel)
+    public DtlsControlImpl getDtlsControl(Channel channel)
     {
         return null;
     }

--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -1138,6 +1138,7 @@ public class RtpChannel
         stream.setConnector(connector);
 
         Content content = getContent();
+        Conference conference = content.getConference();
 
         if (!stream.isStarted())
         {
@@ -1151,19 +1152,15 @@ public class RtpChannel
             if (RTPLevelRelayType.MIXER.equals(getRTPLevelRelayType()))
                 stream.setSSRCFactory(new SSRCFactoryImpl(initialLocalSSRC));
 
-            synchronized (streamSyncRoot)
-            {   // otherwise races with stream.setDirection()
+            synchronized (streamSyncRoot) // Otherwise, races with stream.setDirection().
+            {
                 stream.start();
             }
 
-            Videobridge videobridge
-                = getContent().getConference().getVideobridge();
-            EventAdmin eventAdmin = videobridge.getEventAdmin();
+            EventAdmin eventAdmin
+                = conference.getVideobridge().getEventAdmin();
             if (eventAdmin != null)
-            {
-                eventAdmin
-                    .sendEvent(EventFactory.streamStarted(this));
-            }
+                eventAdmin.sendEvent(EventFactory.streamStarted(this));
         }
 
         if (logger.isTraceEnabled())
@@ -1171,7 +1168,7 @@ public class RtpChannel
             logger.trace(
                     "Direction of channel " + getID() + " of content "
                         + content.getName() + " of conference "
-                        + content.getConference().getID() + " is "
+                        + conference.getID() + " is "
                         + stream.getDirection() + ".");
         }
 

--- a/src/main/java/org/jitsi/videobridge/SctpConnection.java
+++ b/src/main/java/org/jitsi/videobridge/SctpConnection.java
@@ -947,7 +947,7 @@ public class SctpConnection
         throws IOException
     {
         DtlsControlImpl dtlsControl
-            = (DtlsControlImpl) getTransportManager().getDtlsControl(this);
+            = getTransportManager().getDtlsControl(this);
         DtlsTransformEngine engine = dtlsControl.getTransformEngine();
         DtlsPacketTransformer transformer
             = (DtlsPacketTransformer) engine.getRTPTransformer();

--- a/src/main/java/org/jitsi/videobridge/TransportManager.java
+++ b/src/main/java/org/jitsi/videobridge/TransportManager.java
@@ -21,6 +21,7 @@ import java.util.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
 
+import org.jitsi.impl.neomedia.transform.dtls.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.util.*;
 
@@ -274,7 +275,7 @@ public abstract class TransportManager
      * @return the <tt>DtlsControl</tt> allocated by this instance for use by a
      * specific <tt>Channel</tt>.
      */
-    public abstract DtlsControl getDtlsControl(Channel channel);
+    public abstract DtlsControlImpl getDtlsControl(Channel channel);
 
     /**
      * Gets the <tt>StreamConnector</tt> which represents the datagram sockets

--- a/src/main/java/org/jitsi/videobridge/influxdb/LoggingHandler.java
+++ b/src/main/java/org/jitsi/videobridge/influxdb/LoggingHandler.java
@@ -487,28 +487,35 @@ public class LoggingHandler
         Conference conference = transportManager.getConference();
         if (conference == null)
         {
-            logger.debug("Could not log the transport created event " +
-                "because the conference is null.");
+            logger.debug(
+                    "Could not log the transport_created event"
+                        + " because the conference is null.");
             return;
         }
 
         Agent agent = transportManager.getAgent();
         if (agent == null)
         {
-            logger.debug("Could not log the transport created event " +
-                "because the agent is null.");
+            logger.debug(
+                    "Could not log the transport_created event"
+                        + " because the agent is null.");
             return;
         }
 
-        logEvent(new InfluxDBEvent("transport_created",
-            TRANSPORT_CREATED_COLUMNS,
-            new Object[]{
-                String.valueOf(transportManager.hashCode()),
-                conference.getID(),
-                transportManager.getNumComponents(),
-                agent.getLocalUfrag(),
-                Boolean.valueOf(transportManager.isControlling()).toString()
-            }));
+        logEvent(
+                new InfluxDBEvent(
+                        "transport_created",
+                        TRANSPORT_CREATED_COLUMNS,
+                        new Object[]
+                        {
+                            String.valueOf(transportManager.hashCode()),
+                            conference.getID(),
+                            transportManager.getNumComponents(),
+                            agent.getLocalUfrag(),
+                            Boolean
+                                .valueOf(transportManager.isControlling())
+                                    .toString()
+                        }));
     }
 
     /**


### PR DESCRIPTION
Reports the value of setup attribute defined by https://tools.ietf.org/html/rfc4145#section-4 (that libjitsi's DTLS supports already) from Videobridge to the API client allocating the channel. Takes into account the value sent by the API client to Videobridge. Requires https://github.com/jitsi/libjitsi/pull/119 and https://github.com/jitsi/ice4j/pull/56.

The following modifications were applied while trying to remove a 1 second hard minimum on connectivity establishment between Videobridge and Chrome/WebRTC. Related modifications in lib-jitsi-meet (i.e. which will be introduced in a branch there with the same name) (will) depend on these.