### PR TITLE
Removes an inadvertently added "synchronized" which was observed to c…

### DIFF
--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -601,7 +601,7 @@ public class RtpChannel
      * #receiveSSRCs} would have exceeded {@link #MAX_RECEIVE_SSRCS} with the
      * addition of the new SSRC.
      */
-    private synchronized boolean addReceiveSSRC(int receiveSSRC,
+    private boolean addReceiveSSRC(int receiveSSRC,
                                                 boolean checkLimit)
         throws SizeExceededException
     {


### PR DESCRIPTION
…ause a deadlock.