### PR TITLE
Enable adaptive simulcast by default

### DIFF
--- a/src/main/java/org/jitsi/videobridge/ratecontrol/AdaptiveSimulcastBitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/ratecontrol/AdaptiveSimulcastBitrateController.java
@@ -296,18 +296,35 @@ public class AdaptiveSimulcastBitrateController
     {
         SimulcastEngine simulcastEngine
                 = channel.getTransformEngine().getSimulcastEngine();
-        SimulcastSenderManager ssm
-                = simulcastEngine.getSimulcastSenderManager();
-        if (enable)
+        if (simulcastEngine != null)
         {
-            ssm.setOverrideOrder(
-                    SimulcastSenderManager.SIMULCAST_LAYER_ORDER_NO_OVERRIDE);
-            logger.info("Enabling HQ layer for endpoint " + getEndpointID());
+            SimulcastSenderManager ssm
+                = simulcastEngine.getSimulcastSenderManager();
+            if (ssm != null)
+            {
+                if (enable)
+                {
+                    ssm.setOverrideOrder(
+                        SimulcastSenderManager.SIMULCAST_LAYER_ORDER_NO_OVERRIDE);
+
+                    logger
+                        .info(
+                            "Enabling HQ layer for endpoint " + getEndpointID());
+                }
+                else
+                {
+                    ssm.setOverrideOrder(TARGET_ORDER_HD - 1);
+                    logger
+                        .info(
+                            "Disabling HQ layer for endpoint " + getEndpointID());
+                }
+            }
         }
         else
         {
-            ssm.setOverrideOrder(TARGET_ORDER_HD - 1);
-            logger.info("Disabling HQ layer for endpoint " + getEndpointID());
+            logger.error("Failed to enable or disable theHQ layer, "
+                         + "simulcastEngine is null. Maybe simulcast is not "
+                         + "enabled for this channel?");
         }
     }
 


### PR DESCRIPTION
Adds null checks which could occur if adaptive simulcast is enabled, but
simulcast is disabled.