### PR TITLE
Update bcprov-jdk15on to 1.54

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.jitsi</groupId>
     <artifactId>jitsi-universe</artifactId>
-    <version>1.0-20160204.002115-13</version>
+    <version>1.0-20160405.154511-15</version>
   </parent>
 
   <artifactId>jitsi-videobridge</artifactId>
@@ -24,23 +24,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- callstats requires httpclient 4.3+. -->
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>4.4</version>
-      </dependency>
-      <!-- callstats requires httpcore 4.2+. -->
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpcore</artifactId>
-        <version>4.4</version>
-      </dependency>
-      <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
-        <version>1.54</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.jitsi</groupId>
     <artifactId>jitsi-universe</artifactId>
-    <version>1.0-20160405.154511-15</version>
+    <version>1.0-20160405.235512-16</version>
   </parent>
 
   <artifactId>jitsi-videobridge</artifactId>


### PR DESCRIPTION
Imports https://github.com/jitsi/jitsi-videobridge/pull/123 from @champtar's fork into a jitsi/jitsi-videobridge branch in order to enable automatic testing of further changes.