### PR TITLE
Remove some compiler warnings

### DIFF
--- a/src/main/java/org/jitsi/videobridge/EventFactory.java
+++ b/src/main/java/org/jitsi/videobridge/EventFactory.java
@@ -294,7 +294,7 @@ public class EventFactory
             IceProcessingState oldState,
             IceProcessingState newState)
     {
-        Dictionary properties = new Hashtable(3);
+        Dictionary<String, Object> properties = new Hashtable<>(3);
 
         properties.put(EVENT_SOURCE, transportManager);
         properties.put("oldState", oldState);


### PR DESCRIPTION
(use ```Dictionary<String, Object>``` for Event properties)

Signed-off-by: Etienne CHAMPETIER <champetier.etienne@gmail.com>