### PR TITLE
Fixes and improvements for RTX.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-20160406.060156-132</version>
+      <version>1.0-20160406.222401-133</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -1101,6 +1101,11 @@ public class RtpChannel
                 return;
         }
 
+        RetransmissionRequester retransmissionRequester
+            = stream.getRetransmissionRequester();
+        if (retransmissionRequester != null)
+            retransmissionRequester.setSenderSsrc(getContent().getInitialLocalSSRC());
+
         MediaStreamTarget streamTarget = createStreamTarget();
         StreamConnector connector = getStreamConnector();
         if (streamTarget == null)

--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -1517,7 +1517,7 @@ public class RtpChannel
                 redPayloadType = -1;
                 for (PayloadTypePacketExtension ext : payloadTypes)
                 {
-                    if ("rtx".equalsIgnoreCase(ext.getName()))
+                    if (Constants.RTX.equalsIgnoreCase(ext.getName()))
                     {
                         rtxPayloadType = (byte) ext.getID();
                         for (ParameterPacketExtension ppe : ext.getParameters())

--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -1534,6 +1534,14 @@ public class RtpChannel
                         redPayloadType = (byte) ext.getID();
                     }
                 }
+
+                RetransmissionRequester retransmissionRequester
+                    = stream.getRetransmissionRequester();
+                if (retransmissionRequester != null)
+                {
+                    retransmissionRequester.configureRtx(rtxPayloadType,
+                                                         fidSourceGroups);
+                }
             }
         }
 
@@ -1909,6 +1917,15 @@ public class RtpChannel
                 // one for the RTX stream.
                 fidSourceGroups.put(first, second);
             }
+        }
+
+        // The RTX configuration (PT and SSRC maps) may have changed.
+        RetransmissionRequester retransmissionRequester
+            = stream.getRetransmissionRequester();
+        if (retransmissionRequester != null)
+        {
+            retransmissionRequester.configureRtx(rtxPayloadType,
+                                                 fidSourceGroups);
         }
     }
 

--- a/src/main/java/org/jitsi/videobridge/transform/RtxTransformer.java
+++ b/src/main/java/org/jitsi/videobridge/transform/RtxTransformer.java
@@ -61,6 +61,8 @@ public class RtxTransformer
      */
     RtxTransformer(RtpChannel channel)
     {
+        super(RTPPacketPredicate.INSTANCE);
+
         this.channel = channel;
     }
 
@@ -71,9 +73,8 @@ public class RtxTransformer
     @Override
     public RawPacket transform(RawPacket pkt)
     {
-        byte rtxPt;
-        if (pkt != null && (rtxPt = channel.getRtxPayloadType()) != -1
-            && pkt.getPayloadType() == rtxPt)
+        byte rtxPt = channel.getRtxPayloadType();
+        if (rtxPt != -1 && pkt.getPayloadType() == rtxPt)
         {
             pkt = handleRtxPacket(pkt);
         }

--- a/src/main/java/org/jitsi/videobridge/transform/RtxTransformer.java
+++ b/src/main/java/org/jitsi/videobridge/transform/RtxTransformer.java
@@ -399,6 +399,7 @@ public class RtxTransformer
         if (mediaStream != null)
         {
             rtxPkt.setSSRC((int) rtxSsrc);
+            rtxPkt.setPayloadType(rtxPt);
             // Only call getNextRtxSequenceNumber() when we're sure we're going
             // to transmit a packet, because it consumes a sequence number.
             rtxPkt.setSequenceNumber(getNextRtxSequenceNumber(rtxSsrc));


### PR DESCRIPTION
Fixes numerous small issues with the RTX format. Strips RTX from incoming RTX packets, in order to work with simulcast and its SSRC rewriting. Passes RTX configuration to libjitsi's RetransmissionRequester.

Note: this depends on libjitsi#129.