### PR TITLE
Configure the raw udp transport bind address.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/RawUdpTransportManager.java
+++ b/src/main/java/org/jitsi/videobridge/RawUdpTransportManager.java
@@ -25,6 +25,7 @@ import net.java.sip.communicator.service.netaddr.*;
 import net.java.sip.communicator.util.*;
 
 import org.jitsi.impl.neomedia.transform.dtls.*;
+import org.jitsi.service.configuration.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.util.Logger;
 import org.jitsi.videobridge.xmpp.*;
@@ -322,8 +323,33 @@ public class RawUdpTransportManager
                     break;
             }
         }
+
         if (bindAddr == null)
-            bindAddr = getLocalHostLanAddress();
+        {
+            ConfigurationService cfg
+                    = ServiceUtils.getService(
+                    bundleContext,
+                    ConfigurationService.class);
+
+            HarvesterConfiguration addressesConfig
+                    = HarvesterConfiguration.getInstance(cfg);
+
+            InetAddress publicAddress = null;
+
+            /*if the harverster public address is configured,
+             *use this as the bind address.
+             *NOTE: both public and local addresses need to be configured
+             */
+            if (addressesConfig != null && addressesConfig.getPublicAddress() != null)
+            {
+                publicAddress = addressesConfig.getPublicAddress().getAddress();
+            }
+
+            if (publicAddress != null)
+                bindAddr = publicAddress;
+            else
+                bindAddr = getLocalHostLanAddress();
+        }
 
         StreamConnector streamConnector = new DefaultStreamConnector(bindAddr);
 


### PR DESCRIPTION
Use NAT_HARVESTER_PUBLIC_ADDRESS to configure raw udp transport bind address.
This is useful if there are multiple IP addresses in the machine, and getLocalHostLanAddress() could get the wrong IP, or JVB is running behind a NAT.

NOTE: both public and local addresses need to be configured.