### PR TITLE
Set up the pinned endpoints in a conference if a new peer enters

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -657,6 +657,16 @@ public class Endpoint
     }
 
     /**
+     * Adds an endpoint to the selected endpoints' list but does not trigger
+     * any further actions.
+     * @param endpoint The {@code Endpoint} object to be added
+     */
+    public void addSelectedEndpointNoSideEffect(Endpoint endpoint)
+    {
+        weakSelectedEndpoints.add( new WeakReference<Endpoint>(endpoint) );
+    }
+
+    /**
      * Notifies this {@code Endpoint} that a
      * {@code SelectedEndpointChangedEvent} has been received by the associated
      * {@code SctpConnection}.

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -16,6 +16,7 @@
 package org.jitsi.videobridge;
 
 import java.util.*;
+import java.util.List;
 import java.util.regex.*;
 
 import net.java.sip.communicator.impl.protocol.jabber.extensions.*;
@@ -37,6 +38,7 @@ import org.jitsi.eventadmin.*;
 import org.jitsi.videobridge.health.*;
 import org.jitsi.videobridge.pubsub.*;
 import org.jitsi.videobridge.xmpp.*;
+import org.jitsi.videobridge.simulcast.*;
 import org.jivesoftware.smack.packet.*;
 import org.jivesoftware.smack.provider.*;
 import org.jivesoftware.smackx.pubsub.*;
@@ -795,7 +797,13 @@ public class Videobridge
                             String endpoint = channelIQ.getEndpoint();
 
                             if (endpoint != null)
+                            {
                                 channel.setEndpoint(endpoint);
+                                setupInitialSelectedEndpoints(
+                                        conference,
+                                        endpoint,
+                                        channelIQ.getReceivingSimulcastLayer());
+                            }
 
                             /*
                              * The attribute last-n is optional. If a value is
@@ -1530,5 +1538,58 @@ public class Videobridge
             }
         }
         return contentStreamCount;
+    }
+
+    /**
+     * Sets the selected endpoint list of the conference's endpoints based on
+     * the selected receiving simulcast layer of the new endpoint.
+     * This method is intended to be called when a new endpoint enters the
+     * conference.
+     *
+     * @param conference The conference that is the subject of the change
+     * @param endpoint The id of the endpoint that entered the conference
+     * @param receivingSimulcastLayer The default received simulcast layer that
+     *                                is received by the <tt>endpoint<tt/>
+     */
+    private void setupInitialSelectedEndpoints(
+            Conference conference,
+            String endpoint,
+            Integer receivingSimulcastLayer)
+    {
+        List<Endpoint> othersInThisConference =
+                conference.getEndpoints();
+
+        Endpoint me = conference.getOrCreateEndpoint(endpoint);
+
+        // Add everyone to my selected endpoints
+        if (receivingSimulcastLayer != null &&
+                receivingSimulcastLayer !=
+                SimulcastStream.SIMULCAST_LAYER_ORDER_BASE)
+        {
+            for (Endpoint other : othersInThisConference)
+            {
+                if (!other.equals(me)) {
+                    me.addSelectedEndpointNoSideEffect(other);
+                }
+            }
+        }
+
+        // Add me to everyone else
+        for (Endpoint other : othersInThisConference) {
+            List<RtpChannel> othersVideoChannels =
+                    other.getChannels(MediaType.VIDEO);
+            if (othersVideoChannels.size() > 0)
+            {
+                int othersReceiveSimulcastLayer =
+                        ((VideoChannel)othersVideoChannels.get(0))
+                                .getReceiveSimulcastLayer();
+                if (othersReceiveSimulcastLayer !=
+                        SimulcastStream.SIMULCAST_LAYER_ORDER_BASE
+                        && !other.equals(me))
+                {
+                    other.addSelectedEndpointNoSideEffect(me);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/org/jitsi/videobridge/simulcast/SimulcastReceiver.java
+++ b/src/main/java/org/jitsi/videobridge/simulcast/SimulcastReceiver.java
@@ -156,29 +156,6 @@ public class SimulcastReceiver
     }
 
     /**
-     * Reads TIMEOUT_ON_FRAME_COUNT from the <tt>ConfigurationService</tt>
-     *
-     * @param cfg The global <tt>ConfigurationService</tt> object
-     */
-    private static void initializeConfiguration(ConfigurationService cfg) {
-        if (cfg == null)
-        {
-            logger.warn("Can't set TIMEOUT_ON_FRAME_COUNT because "
-                    + "the configuration service was not found. "
-                    + "Using " + DEFAULT_TIMEOUT_ON_FRAME_COUNT
-                    + " as default");
-
-            TIMEOUT_ON_FRAME_COUNT = DEFAULT_TIMEOUT_ON_FRAME_COUNT;
-        }
-        else
-        {
-            TIMEOUT_ON_FRAME_COUNT = cfg.getInt(
-                    TIMEOUT_ON_FRAME_COUNT_CONFIG_KEY,
-                    DEFAULT_TIMEOUT_ON_FRAME_COUNT);
-        }
-    }
-
-    /**
      * Returns true if the endpoint has signaled one or more simulcast streams.
      *
      * @return true if the endpoint has signaled one or more simulcast streams,

--- a/src/main/java/org/jitsi/videobridge/simulcast/SimulcastReceiver.java
+++ b/src/main/java/org/jitsi/videobridge/simulcast/SimulcastReceiver.java
@@ -156,6 +156,29 @@ public class SimulcastReceiver
     }
 
     /**
+     * Reads TIMEOUT_ON_FRAME_COUNT from the <tt>ConfigurationService</tt>
+     *
+     * @param cfg The global <tt>ConfigurationService</tt> object
+     */
+    private static void initializeConfiguration(ConfigurationService cfg) {
+        if (cfg == null)
+        {
+            logger.warn("Can't set TIMEOUT_ON_FRAME_COUNT because "
+                    + "the configuration service was not found. "
+                    + "Using " + DEFAULT_TIMEOUT_ON_FRAME_COUNT
+                    + " as default");
+
+            TIMEOUT_ON_FRAME_COUNT = DEFAULT_TIMEOUT_ON_FRAME_COUNT;
+        }
+        else
+        {
+            TIMEOUT_ON_FRAME_COUNT = cfg.getInt(
+                    TIMEOUT_ON_FRAME_COUNT_CONFIG_KEY,
+                    DEFAULT_TIMEOUT_ON_FRAME_COUNT);
+        }
+    }
+
+    /**
      * Returns true if the endpoint has signaled one or more simulcast streams.
      *
      * @return true if the endpoint has signaled one or more simulcast streams,


### PR DESCRIPTION
Selected endpoints are set correctly if a peer uses the receive-simulcast-layer attribute in the channel IQ