### PR TITLE
Don't use Map<>.containsKey before Map<>.get

### DIFF
--- a/src/main/java/org/jitsi/videobridge/pubsub/PubSubPublisher.java
+++ b/src/main/java/org/jitsi/videobridge/pubsub/PubSubPublisher.java
@@ -65,17 +65,14 @@ public class PubSubPublisher
      */
     public static PubSubPublisher getPubsubManager(String serviceName)
     {
-        PubSubPublisher publisher;
+        PubSubPublisher publisher = instances.get(serviceName);
 
-        if (instances.containsKey(serviceName))
-        {
-            publisher = instances.get(serviceName);
-        }
-        else
+        if (publisher == null)
         {
             publisher = new PubSubPublisher(serviceName);
             instances.put(serviceName, publisher);
         }
+
         return publisher;
     }
 

--- a/src/main/java/org/jitsi/videobridge/simulcast/sendmodes/RewritingSendMode.java
+++ b/src/main/java/org/jitsi/videobridge/simulcast/sendmodes/RewritingSendMode.java
@@ -82,9 +82,9 @@ public class RewritingSendMode
         Integer pktSequenceNumber = pkt.getSequenceNumber();
         int diff = 1;
 
-        if (lastPktSequenceNumbers.containsKey(pktSSRC))
+        Integer lastReceivedSeq = lastPktSequenceNumbers.get(pktSSRC);
+        if (lastReceivedSeq != null)
         {
-            int lastReceivedSeq = lastPktSequenceNumbers.get(pktSSRC);
             diff = RTPUtils.sequenceNumberDiff(
                 pkt.getSequenceNumber(), lastReceivedSeq);
         }


### PR DESCRIPTION
if the key doesn't exist Map<>.get return null,
and we are not putting null as value, so use that.