### PR TITLE
Fixes a problem where you may get stuck with low quality video

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -366,7 +366,7 @@ public class Endpoint
      * @return the currently selected <tt>Endpoint</tt>s at this
      * <tt>Endpoint</tt>.
      */
-    private Set<Endpoint> getSelectedEndpoints()
+    public Set<Endpoint> getSelectedEndpoints()
     {
         Set<Endpoint> result = new HashSet<>();
         for (WeakReference<Endpoint> wr : weakSelectedEndpoints)

--- a/src/main/java/org/jitsi/videobridge/simulcast/SimulcastSender.java
+++ b/src/main/java/org/jitsi/videobridge/simulcast/SimulcastSender.java
@@ -327,10 +327,10 @@ public class SimulcastSender
 
         boolean thisWasInTheSelectedEndpoints
                 = oldEndpoints.contains(sendEndpoint);
-        boolean thisWillbeInTheSelectedEndpoints
+        boolean thisWillBeInTheSelectedEndpoints
                 = newEndpoints.contains(sendEndpoint);
 
-        if (thisWillbeInTheSelectedEndpoints)
+        if (thisWillBeInTheSelectedEndpoints)
         {
             int overrideOrder = getSimulcastSenderManager().getOverrideOrder();
             if (overrideOrder
@@ -344,8 +344,9 @@ public class SimulcastSender
             }
         }
         else if(thisWasInTheSelectedEndpoints)
-        { // It was in the old selected endpoints but it is not present in the
-          // new ones
+        {
+            // It was in the old selected endpoints but it is not present in the
+            // new ones
             newTargetOrder = lqOrder;
         }
         else

--- a/src/main/java/org/jitsi/videobridge/simulcast/SimulcastSenderManager.java
+++ b/src/main/java/org/jitsi/videobridge/simulcast/SimulcastSenderManager.java
@@ -155,18 +155,15 @@ public class SimulcastSenderManager
 
         if (simulcastSender == null) // Create a new sender.
         {
-            int targetOrder = simulcastEngine
-                .getVideoChannel() // never null.
-                .getReceiveSimulcastLayer();
+            VideoChannel videoChannel = simulcastEngine.getVideoChannel();
+            int targetOrder = videoChannel.getReceiveSimulcastLayer();
 
-            Endpoint sendingEndpoint = simulcastReceiver // never null.
-                .getSimulcastEngine() // never null.
-                .getVideoChannel() // never null.
-                .getEndpoint(); // might be null.
+            Endpoint sendingEndpoint = simulcastReceiver
+                .getSimulcastEngine()
+                .getVideoChannel()
+                .getEndpoint();
 
-            Endpoint receivingEndpoint = simulcastEngine // never null.
-                .getVideoChannel() // never null.
-                .getEndpoint(); // might be null.
+            Endpoint receivingEndpoint = videoChannel.getEndpoint();
 
             if (receivingEndpoint != null && sendingEndpoint != null)
             {

--- a/src/main/java/org/jitsi/videobridge/simulcast/SimulcastSenderManager.java
+++ b/src/main/java/org/jitsi/videobridge/simulcast/SimulcastSenderManager.java
@@ -134,8 +134,15 @@ public class SimulcastSenderManager
     private synchronized SimulcastSender getOrCreateSimulcastSender(
         SimulcastReceiver simulcastReceiver)
     {
-        if (simulcastReceiver == null
-                || !simulcastReceiver.isSimulcastSignaled())
+        if (simulcastReceiver == null)
+        {
+            return null;
+        }
+
+        SimulcastStream[] simulcastStreams
+            = simulcastReceiver.getSimulcastStreams();
+
+        if (simulcastStreams == null || simulcastStreams.length == 0)
         {
             return null;
         }
@@ -144,10 +151,25 @@ public class SimulcastSenderManager
 
         if (simulcastSender == null) // Create a new sender.
         {
+            Endpoint sendingEndpoint = simulcastReceiver // never null.
+                .getSimulcastEngine() // never null.
+                .getVideoChannel() // never null.
+                .getEndpoint(); // might be null.
+
+            Endpoint receivingEndpoint = simulcastEngine // never null.
+                .getVideoChannel() // never null.
+                .getEndpoint(); // might be null.
+
+            Set<Endpoint> selectedEndpoints
+                = receivingEndpoint.getSelectedEndpoints(); // never null.
+
             // Create a new sender.
-            int targetOrder = simulcastEngine.
-                    getVideoChannel().
-                    getReceiveSimulcastLayer();
+            int targetOrder = sendingEndpoint != null
+                && receivingEndpoint != null
+                && selectedEndpoints.contains(sendingEndpoint)
+
+                ? simulcastStreams.length - 1
+                : simulcastEngine.getVideoChannel().getReceiveSimulcastLayer();
 
             simulcastSender = new SimulcastSender(
                     this,

--- a/src/main/java/org/jitsi/videobridge/simulcast/SimulcastSenderManager.java
+++ b/src/main/java/org/jitsi/videobridge/simulcast/SimulcastSenderManager.java
@@ -151,6 +151,10 @@ public class SimulcastSenderManager
 
         if (simulcastSender == null) // Create a new sender.
         {
+            int targetOrder = simulcastEngine
+                .getVideoChannel() // never null.
+                .getReceiveSimulcastLayer();
+
             Endpoint sendingEndpoint = simulcastReceiver // never null.
                 .getSimulcastEngine() // never null.
                 .getVideoChannel() // never null.
@@ -160,17 +164,18 @@ public class SimulcastSenderManager
                 .getVideoChannel() // never null.
                 .getEndpoint(); // might be null.
 
-            Set<Endpoint> selectedEndpoints
-                = receivingEndpoint.getSelectedEndpoints(); // never null.
+            if (receivingEndpoint != null && sendingEndpoint != null)
+            {
+                Set<Endpoint> selectedEndpoints
+                    = receivingEndpoint.getSelectedEndpoints(); // never null.
+
+                if (selectedEndpoints.contains(sendingEndpoint))
+                {
+                    targetOrder = simulcastStreams.length - 1;
+                }
+            }
 
             // Create a new sender.
-            int targetOrder = sendingEndpoint != null
-                && receivingEndpoint != null
-                && selectedEndpoints.contains(sendingEndpoint)
-
-                ? simulcastStreams.length - 1
-                : simulcastEngine.getVideoChannel().getReceiveSimulcastLayer();
-
             simulcastSender = new SimulcastSender(
                     this,
                     simulcastReceiver,

--- a/src/main/java/org/jitsi/videobridge/simulcast/SimulcastSenderManager.java
+++ b/src/main/java/org/jitsi/videobridge/simulcast/SimulcastSenderManager.java
@@ -144,6 +144,10 @@ public class SimulcastSenderManager
 
         if (simulcastStreams == null || simulcastStreams.length == 0)
         {
+            // This is equivalent to !simulcastReceiver.isSimulcastSignaled() in
+            // which case we don't want to create a SimulcastSender. The reason
+            // why we don't call the isSimulcastSignaled method is because we
+            // might need a reference to the simulcastStreams later on.
             return null;
         }
 


### PR DESCRIPTION
When data channel connection establishment is fast and if the selected
endpoint data channel message is sent early enough then when one user
(re)joins a call, it's getting a good quality stream from the participant
that was already in the room. But the user that was already in the room,
gets a low quality stream from the newly joined client. So effectively,
in a 1:1 session, one user always ends up with a low quality stream of
the remote... The user that joined first.