### PR TITLE
Breaks out of the loop if the SCTP socket early

### DIFF
--- a/src/main/java/org/jitsi/videobridge/SctpConnection.java
+++ b/src/main/java/org/jitsi/videobridge/SctpConnection.java
@@ -1080,6 +1080,9 @@ public class SctpConnection
         {
             do
             {
+                if (sctpSocket == null)
+                    break;
+
                 iceSocket.receive(recv);
 
                 RawPacket[] send
@@ -1117,9 +1120,6 @@ public class SctpConnection
                                 s.getBuffer(), s.getOffset(), s.getLength());
                     }
                 }
-
-                if (sctpSocket == null)
-                    break;
 
                 // Pass network packet to SCTP stack
                 for (RawPacket s : send)


### PR DESCRIPTION
Breaks out of the loop if the SCTP socket is closed before trying to receive from the ICE socket.

This potentially avoids an infinite loop, if the ICE socket
implementation is faulty and returns something (e.g. a packet with
length 0) when the socket is closed. More importantly, it makes it
obvious to anyone reading the code that such a scenario is not possible.