### PR TITLE
Revert 5c577d2

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -1432,11 +1432,6 @@ public class Videobridge
                         + " initialization.",
                     e);
         }
-
-        // CandidateHarvesters may take (non-trivial) time to initialize so
-        // initialize them as soon as possible, don't wait to initialize them
-        // after a Channel is requested.
-        IceUdpTransportManager.initializeStaticHarvesters(cfg);
     }
 
     /**


### PR DESCRIPTION
TcpHarvester binds to specific local addresses, Jetty binds to all/any
local addresses. Consequently, Jetty will fail to bind if TcpHarvester
binds first and Jetty is supposed to share a port with TcpHarvester. To
resolve this failure, initialize TcpHarvester as late as possible and
leave Jetty to bind at startup.