### PR TITLE
Fix a regression after #190 when RawUdpTransport is used.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -1108,37 +1108,34 @@ public class RtpChannel
 
         MediaStreamTarget streamTarget = createStreamTarget();
         StreamConnector connector = getStreamConnector();
-        if (streamTarget == null)
-        {
-            logger.info("Not starting stream, target is null");
-            return;
-        }
-
         if (connector == null)
         {
             logger.info("Not starting stream, connector is null");
             return;
         }
 
-        InetSocketAddress dataAddr = streamTarget.getDataAddress();
-        if (dataAddr == null)
+        if (streamTarget != null)
         {
-            logger.info(
-                "Not starting stream, the target's data address is null");
-            return;
+            InetSocketAddress dataAddr = streamTarget.getDataAddress();
+            if (dataAddr == null)
+            {
+                logger.info(
+                        "Not starting stream, the target's data address is null");
+                return;
+            }
+
+            this.streamTarget.setDataHostAddress(dataAddr.getAddress());
+            this.streamTarget.setDataPort(dataAddr.getPort());
+
+            InetSocketAddress ctrlAddr = streamTarget.getControlAddress();
+            if (ctrlAddr != null)
+            {
+                this.streamTarget.setControlHostAddress(ctrlAddr.getAddress());
+                this.streamTarget.setControlPort(ctrlAddr.getPort());
+            }
+
+            stream.setTarget(streamTarget);
         }
-
-        this.streamTarget.setDataHostAddress(dataAddr.getAddress());
-        this.streamTarget.setDataPort(dataAddr.getPort());
-
-        InetSocketAddress ctrlAddr = streamTarget.getControlAddress();
-        if (ctrlAddr != null)
-        {
-            this.streamTarget.setControlHostAddress(ctrlAddr.getAddress());
-            this.streamTarget.setControlPort(ctrlAddr.getPort());
-        }
-
-        stream.setTarget(streamTarget);
         stream.setConnector(connector);
 
         Content content = getContent();


### PR DESCRIPTION
After #190 when RawUdpTransport is used the media stream never starts, because with RawUdpTransport the streamTarget is always null by definition, and so maybeStartStream() returns too early without reaching stream.start().
I mantained the setTarget / setConnector order as in #190.


