### PR TITLE
Implement packet delay in RtpChannel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-protocol-jabber</artifactId>
-      <version>2.9-20160302.230919-9</version>
+      <version>2.9-20160505.143533-15</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-20160420.145638-153</version>
+      <version>1.0-20160505.164723-157</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -1081,6 +1081,22 @@ public class RtpChannel
     }
 
     /**
+     * Initializes the <tt>RtpChannelTransformEngine</tt> that will be used by
+     * this <tt>RtpChannel</tt>.
+     *
+     * @return the just created <tt>RtpChannelTransformEngine</tt> instance.
+     */
+    RtpChannelTransformEngine initializeTransformerEngine()
+    {
+        transformEngine = new RtpChannelTransformEngine(this);
+        if (stream != null)
+        {
+            stream.setExternalTransformer(transformEngine);
+        }
+        return transformEngine;
+    }
+
+    /**
      * Starts {@link #stream} if it has not been started yet and if the state of
      * this <tt>Channel</tt> meets the prerequisites to invoke
      * {@link MediaStream#start()}. For example, <tt>MediaStream</tt> may be
@@ -1942,21 +1958,6 @@ public class RtpChannel
     }
 
     /**
-     * Sets the <tt>RtpChannelTransformEngine</tt> to be used by this
-     * <tt>RtpChannel</tt>.
-     * @param transformEngine the <tt>RtpChannelTransformEngine</tt> to set.
-     */
-    void setTransformEngine(RtpChannelTransformEngine transformEngine)
-    {
-        if (this.transformEngine != transformEngine)
-        {
-            this.transformEngine = transformEngine;
-            if (stream != null)
-                stream.setExternalTransformer(transformEngine);
-        }
-    }
-
-    /**
      * Closes {@link #transformEngine}. Normally this would be done by
      * {@link #stream} when it is being closed, but we have observed cases (e.g.
      * when running health checks) where it doesn't happen, and since
@@ -2047,6 +2048,30 @@ public class RtpChannel
     public ConferenceSpeechActivity getConferenceSpeechActivity()
     {
         return conferenceSpeechActivity;
+    }
+
+    /**
+     * Sets a delay of the RTP stream expressed in a number of packets.
+     * The property is immutable which means than once set can not be changed
+     * later.
+     *
+     * *NOTE* that this delay is meant to be used only for audio and video
+     * synchronization tests and should never be used in production.
+     *
+     * @param packetDelay tells by how many packets RTP stream should be
+     * delayed. Will have effect only if greater than 0.
+     *
+     * @return <tt>true</tt> if the delay has been set or <tt>false</tt>
+     * otherwise.
+     */
+    public boolean setPacketDelay(int packetDelay)
+    {
+        RtpChannelTransformEngine engine = this.transformEngine;
+        if (engine == null)
+        {
+            engine = initializeTransformerEngine();
+        }
+        return engine.setPacketDelay(packetDelay);
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -201,7 +201,7 @@ public class VideoChannel
     {
         super(content, id, channelBundleId, transportNamespace, initiator);
 
-        setTransformEngine(new RtpChannelTransformEngine(this));
+        initializeTransformerEngine();
 
         ConfigurationService cfg
             = content.getConference().getVideobridge()

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -846,6 +846,13 @@ public class Videobridge
                             if (adaptiveSimulcast != null)
                                 channel.setAdaptiveSimulcast(adaptiveSimulcast);
 
+                            // Packet delay - for automated testing purpose only
+                            Integer packetDelay = channelIQ.getPacketDelay();
+                            if (packetDelay != null)
+                            {
+                                channel.setPacketDelay(packetDelay);
+                            }
+
                             /*
                              * XXX The attribute initiator is optional. If a
                              * value is not specified, then the Channel


### PR DESCRIPTION
Adds packet delay property to the RTP channels which is
meant to be used during automated testing of the lip-sync
feature.