### PR TITLE
Fix #227: Fix SSRC Mapping when people join a recorded conversation

### DIFF
--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -1726,6 +1726,17 @@ public class RtpChannel
         addedSSRCs.removeAll(oldSignaledSSRCs);
         if (!addedSSRCs.isEmpty())
         {
+
+            Recorder recorder = null;
+            Synchronizer synchronizer = null;
+            Endpoint endpoint = null;
+            if (getContent().isRecording())
+            {
+                recorder = getContent().getRecorder();
+                synchronizer = recorder.getSynchronizer();
+                endpoint = getEndpoint();
+            }
+
             for (Integer addedSSRC : addedSSRCs)
             {
                 try
@@ -1733,6 +1744,15 @@ public class RtpChannel
                     // Do allow the number of explicitly signalled SSRCs to
                     // exceed the limit.
                     addReceiveSSRC(addedSSRC, false);
+
+                    // If recording is enabled, we need to add the mapping from
+                    // SSRC to EndpointID into the Synchronizer
+                    // instance used by RecorderRtpImpl.
+                    if (recorder != null && endpoint != null && synchronizer != null)
+                    {
+                        synchronizer.setEndpoint(addedSSRC & 0xffffffffl,
+                            endpoint.getID());
+                    }
                 }
                 catch (SizeExceededException see)
                 {


### PR DESCRIPTION
Add the mapping from SSRC to EndpointID to the Synchronizer instance used by
RecorderRtpImpl when new SSRCs are signalled over colibri.