### PR TITLE
Failing stream switching warnings.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/simulcast/SimulcastReceiver.java
+++ b/src/main/java/org/jitsi/videobridge/simulcast/SimulcastReceiver.java
@@ -466,7 +466,9 @@ public class SimulcastReceiver
                             "(or delayed). Last pkt sequence number=" +
                             acceptedStream.lastPktSequenceNumber +
                             ", expected sequence number="
-                            + expectedPktSequenceNumber);
+                            + expectedPktSequenceNumber +
+                            ", received sequence number="
+                            + pktSequenceNumber);
                     }
                 }
                 else


### PR DESCRIPTION
Adds a warning message in an effort to identify the cause of failing stream switching in the context of simulcast.