### PR TITLE
Skips registering an osgi service on every callstats initializing

### DIFF
--- a/src/main/java/org/jitsi/videobridge/stats/CallStatsIOTransport.java
+++ b/src/main/java/org/jitsi/videobridge/stats/CallStatsIOTransport.java
@@ -113,6 +113,12 @@ public class CallStatsIOTransport
      */
     private void callStatsOnInitialized(CallStats callStats, String msg)
     {
+        // callstats get re-initialized every few hours, which
+        // can leads to registering callstats in osgi many times, while
+        // the service instance is the same
+        if(serviceRegistration != null)
+            return;
+
         bridgeStatusInfoBuilder = new BridgeStatusInfoBuilder();
 
         if (logger.isDebugEnabled())


### PR DESCRIPTION
Skips registering an osgi service on every callstats initializing, as it is re-authenticating every few hours and firing onInitialized.