### PR TITLE
callstats uses conference name to report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>callstats</groupId>
-      <artifactId>callstats</artifactId>
-      <version>0.0.1-20160426.085453-7</version>
+      <groupId>io.callstats</groupId>
+      <artifactId>callstats-java-sdk</artifactId>
+      <version>3.1.1</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -203,6 +203,7 @@ public class Conference
      * initialization of the new instance and from whom further/future requests
      * to manage the new instance must come or they will be ignored.
      * Pass <tt>null</tt> to override this safety check.
+     * @param name world readable name of this instance if any.
      * @param eventAdmin the {@code EventAdmin} instance to be used by the new
      * instance and all instances (of {@code Content}, {@code Channel}, etc.)
      * created by it.
@@ -210,6 +211,7 @@ public class Conference
     public Conference(Videobridge videobridge,
                       String id,
                       String focus,
+                      String name,
                       EventAdmin eventAdmin)
     {
         if (videobridge == null)
@@ -221,6 +223,7 @@ public class Conference
         this.id = id;
         this.focus = focus;
         this.eventAdmin = eventAdmin;
+        this.name = name;
 
         lastKnownFocus = focus;
 
@@ -1671,16 +1674,6 @@ public class Conference
                 }
             }
         }
-    }
-
-    /**
-     * Sets the conference name.
-     *
-     * @param name the new name.
-     */
-    public void setName(String name)
-    {
-        this.name = name;
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -221,12 +221,13 @@ public class Videobridge
      * the conference focus which will own the new instance i.e. from whom
      * further/future requests to manage the new instance must come or they will
      * be ignored. Pass <tt>null</tt> to override this safety check.
+     * @param name world readable name of the conference to create.
      * @return a new <tt>Conference</tt> instance with an ID unique to the
      * <tt>Conference</tt> instances listed by this <tt>Videobridge</tt>
      */
-    public Conference createConference(String focus)
+    public Conference createConference(String focus, String name)
     {
-        return this.createConference(focus, /* eventadmin */ true);
+        return this.createConference(focus, name, /* eventadmin */ true);
     }
 
     /**
@@ -242,13 +243,15 @@ public class Videobridge
      * the conference focus which will own the new instance i.e. from whom
      * further/future requests to manage the new instance must come or they will
      * be ignored. Pass <tt>null</tt> to override this safety check.
+     * @param name world readable name of the conference to create.
      * @param eventadmin {@code true} to enable support for the
      * {@code eventadmin} package i.e. fire {@code Event}s through
      * {@code EventAdmin}; otherwise, {@code false}
      * @return a new <tt>Conference</tt> instance with an ID unique to the
      * <tt>Conference</tt> instances listed by this <tt>Videobridge</tt>
      */
-    public Conference createConference(String focus, boolean eventadmin)
+    public Conference createConference(
+        String focus, String name, boolean eventadmin)
     {
         Conference conference = null;
 
@@ -265,6 +268,7 @@ public class Videobridge
                                 this,
                                 id,
                                 focus,
+                                name,
                                 eventadmin ? getEventAdmin() : null);
                     conferences.put(id, conference);
                 }
@@ -640,7 +644,8 @@ public class Videobridge
             {
                 if (!isShutdownInProgress())
                 {
-                    conference = createConference(focus);
+                    conference
+                        = createConference(focus, conferenceIQ.getName());
                 }
                 else
                 {
@@ -671,10 +676,6 @@ public class Videobridge
         }
         else
         {
-            String name = conferenceIQ.getName();
-            if (name != null)
-                conference.setName(name);
-
             responseConferenceIQ = new ColibriConferenceIQ();
             conference.describeShallow(responseConferenceIQ);
 

--- a/src/main/java/org/jitsi/videobridge/eventadmin/callstats/Activator.java
+++ b/src/main/java/org/jitsi/videobridge/eventadmin/callstats/Activator.java
@@ -133,11 +133,16 @@ public class Activator
                     + "."
                     + StatsManagerBundleActivator.STAT_TRANSPORT_CALLSTATS_IO,
                 interval);
+            String conferenceIDPrefix = ConfigUtils.getString(
+                cfg,
+                "io.callstats.sdk.CallStats.conferenceIDPrefix",
+                null);
 
             conferenceStatsHandler = new CallStatsConferenceStatsHandler();
             conferenceStatsHandler.start(
                 (CallStats) service,
                 bridgeId,
+                conferenceIDPrefix,
                 interval);
 
             String[] topics = { "org/jitsi/*" };

--- a/src/main/java/org/jitsi/videobridge/eventadmin/callstats/CallStatsConferenceStatsHandler.java
+++ b/src/main/java/org/jitsi/videobridge/eventadmin/callstats/CallStatsConferenceStatsHandler.java
@@ -71,7 +71,9 @@ class CallStatsConferenceStatsHandler
      * generating and pushing statistics per conference for every Channel.
      */
     private final RecurringProcessibleExecutor statisticsExecutor
-        = new RecurringProcessibleExecutor();
+        = new RecurringProcessibleExecutor(
+            CallStatsConferenceStatsHandler.class.getSimpleName()
+                + "-statisticsExecutor");
 
     /**
      * List of the processor per conference. Kept in order to stop and

--- a/src/main/java/org/jitsi/videobridge/health/Health.java
+++ b/src/main/java/org/jitsi/videobridge/health/Health.java
@@ -141,6 +141,7 @@ public class Health
         Conference conference
             = videobridge.createConference(
                     /* focus */ null,
+                    /* name */ null,
                     /* eventadmin */ false);
 
         // Fail as quickly as possible.


### PR DESCRIPTION
Callstats uses conference name to report. Pulls callstats from maven central.