### PR TITLE
Allow the stream direction to be changed before connected if using ICE.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -1458,9 +1458,12 @@ public class RtpChannel
      */
     public void setDirection(MediaDirection direction)
     {
-        // XXX We modify the stream direction only after latching has finished.
-        if (streamTarget.getDataAddress() != null)
-            stream.setDirection(direction);
+        // If using latching, only modify the direction if the stream target destination is connected
+        if ((getTransportManager() instanceof RawUdpTransportManager && streamTarget.getDataAddress() != null) ||
+            getTransportManager() instanceof IceUdpTransportManager)
+        {
+          stream.setDirection(direction);
+        }
 
         touch(); // It seems this Channel is still active.
     }


### PR DESCRIPTION
if we're using ice, don't block setting the direction if the connection isn't made yet.

@emcho here's a sample of what some checks for this around the code may look like (and this is a place where we've commented out the check altogether since we're not using latching).  if it looks good, we can start taking a look at other places where checks like this would be useful.
