### PR TITLE
set the media format of a mixed audio channel when we get the answer,

### DIFF
--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -548,35 +548,6 @@ public class RtpChannel
                         }
                     }
 
-                    /*
-                     * When performing content mixing (rather than RTP
-                     * translation/relay), the MediaStream needs a MediaFormat
-                     * to be set in order to make it capable of sending media
-                     * data.
-                     */
-                    if (RTPLevelRelayType.MIXER.equals(getRTPLevelRelayType()))
-                    {
-                        Map<Byte, MediaFormat> payloadTypes
-                            = stream.getDynamicRTPPayloadTypes();
-
-                        if (payloadTypes != null)
-                        {
-                            int pt = data[off + 1] & 0x7f;
-                            MediaFormat format = payloadTypes.get((byte) pt);
-
-                            if ((format != null)
-                                    && !format.equals(stream.getFormat()))
-                            {
-                                stream.setFormat(format);
-                                synchronized (streamSyncRoot)
-                                {   // otherwise races with stream.start()
-                                    stream.setDirection(MediaDirection.SENDRECV);
-                                }
-                                notify = true;
-                            }
-                        }
-                    }
-
                     if (notify)
                         notifyFocus();
                 }
@@ -1676,14 +1647,6 @@ public class RtpChannel
                 MediaDevice device = getContent().getMixer();
 
                 stream.setDevice(device);
-
-                /*
-                 * It is necessary to start receiving media in order to
-                 * determine the MediaFormat in which the stream will send the
-                 * media it generates.
-                 */
-                if (stream.getFormat() == null)
-                    stream.setDirection(MediaDirection.RECVONLY);
                 break;
 
             case TRANSLATOR:

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -22,16 +22,19 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.health.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
+import net.java.sip.communicator.impl.protocol.jabber.jinglesdp.JingleUtils;
 import net.java.sip.communicator.service.shutdown.*;
 import net.java.sip.communicator.util.*;
 
 import org.ice4j.ice.harvest.*;
 import org.ice4j.stack.*;
 import org.jitsi.eventadmin.*;
+import org.jitsi.impl.neomedia.rtp.translator.Payload;
 import org.jitsi.osgi.*;
 import org.jitsi.service.configuration.*;
 import org.jitsi.service.libjitsi.*;
 import org.jitsi.service.neomedia.*;
+import org.jitsi.service.neomedia.format.MediaFormat;
 import org.jitsi.util.*;
 import org.jitsi.util.Logger;
 import org.jitsi.videobridge.health.*;
@@ -783,6 +786,29 @@ public class Videobridge
 
                                     videoChannel.setReceiveSimulcastLayer(
                                             receiveSimulcastLayer);
+                                }
+
+                                if (channel instanceof AudioChannel &&
+                                        channel.getRTPLevelRelayType() == RTPLevelRelayType.MIXER)
+                                {
+                                    /*
+                                     * If the channel is set to use the mixer, set the mixer
+                                     * media format to the first format signaled
+                                     */
+                                    if (!channelIQ.getPayloadTypes().isEmpty())
+                                    {
+                                        /*
+                                         * XXX: instead pick pt with highest clockrate? choose via some other means?
+                                         */
+                                        PayloadTypePacketExtension pt = channelIQ.getPayloadTypes().get(0);
+                                        MediaFormat mf =
+                                                JingleUtils.payloadTypeToMediaFormat(
+                                                        pt,
+                                                        content.getMediaService(),
+                                                        null);
+                                        channel.getStream().setFormat(mf);
+                                    }
+
                                 }
 
                                 channelCreated = true;


### PR DESCRIPTION
and don't force the channel to go to recvonly until it receives a packet
