### PR TITLE
Endpoint connection monitoring

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Channel.java
+++ b/src/main/java/org/jitsi/videobridge/Channel.java
@@ -65,6 +65,11 @@ public abstract class Channel
     private final String channelBundleId;
 
     /**
+     * Remembers when this <tt>Channel</tt> instance was created.
+     */
+    private final long creationTimestamp = System.currentTimeMillis();
+
+    /**
      * The name of the <tt>Channel</tt> property <tt>endpoint</tt> which
      * points to the <tt>Endpoint</tt> of the conference participant associated
      * with this <tt>Channel</tt>..
@@ -460,6 +465,18 @@ public abstract class Channel
     public Content getContent()
     {
         return content;
+    }
+
+    /**
+     * Gets the time in milliseconds which tells when this <tt>Channel</tt> was
+     * created.
+     *
+     * @return the time in milliseconds which indicates when this
+     * <tt>Channel</tt> instance was created.
+     */
+    public long getCreationTimestamp()
+    {
+        return creationTimestamp;
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -1512,6 +1512,12 @@ public class Conference
                  * implement it as well.
                  */
                 endpoint.sctpConnectionReady(sctpConnection);
+                // Trigger SCTP connection ready event
+                if (eventAdmin != null)
+                {
+                    eventAdmin.postEvent(
+                            EventFactory.endpointSctpConnReady(endpoint));
+                }
             }
         }
     }

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -317,7 +317,7 @@ public class Conference
      *
      * @param msg the message to be advertised across conference peers.
      */
-    private void broadcastMessageOnDataChannels(String msg)
+    public void broadcastMessageOnDataChannels(String msg)
     {
         sendMessageOnDataChannels(msg, getEndpoints());
     }

--- a/src/main/java/org/jitsi/videobridge/EndpointConnectionStatus.java
+++ b/src/main/java/org/jitsi/videobridge/EndpointConnectionStatus.java
@@ -279,8 +279,10 @@ public class EndpointConnectionStatus
             if (System.currentTimeMillis() - mostRecentChannelCreated
                     > firstTransferTimeout)
             {
-                logger.debug(endpointId + " is having trouble establishing"
-                        + " the connection and will be marked as inactive");
+                if (logger.isDebugEnabled())
+                    logger.debug(
+                            endpointId + " is having trouble establishing"
+                            + " the connection and will be marked as inactive");
                 // Let the logic below mark endpoint as inactive.
                 // Beware that FIRST_TRANSFER_TIMEOUT constant MUST be greater
                 // than MAX_INACTIVITY_LIMIT for this logic to work.
@@ -289,7 +291,9 @@ public class EndpointConnectionStatus
             else
             {
                 // Wait for the endpoint to connect...
-                logger.debug(endpointId + " not ready for activity checks yet");
+                if (logger.isDebugEnabled())
+                    logger.debug(
+                            endpointId + " not ready for activity checks yet");
                 return;
             }
         }

--- a/src/main/java/org/jitsi/videobridge/EndpointConnectionStatus.java
+++ b/src/main/java/org/jitsi/videobridge/EndpointConnectionStatus.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge;
+
+import net.java.sip.communicator.util.Logger;
+
+import org.json.simple.*;
+
+import org.osgi.framework.*;
+
+import java.util.*;
+
+/**
+ * This module monitors all endpoints across all conferences currently hosted
+ * on the bridge for their connectivity status and sends notifications through
+ * the data channel.
+ *
+ * An endpoint's connectivity status is considered connected as long as there
+ * is any traffic activity seen on any of it's channels as defined in
+ * {@link Channel#lastTransportActivityTime}. When there is no activity for
+ * longer than {@link #MAX_INACTIVITY_LIMIT} it will be assumed that
+ * the endpoint is having some connectivity issues. Those may be temporary or
+ * permanent. When that happens there will be a Colibri message broadcasted
+ * to all conference endpoints. The Colibri class name of the message is defined
+ * in {@link #COLIBRI_CLASS_ENDPOINT_CONNECTIVITY_STATUS} and it will contain
+ * "active" attribute set to "false". If those problems turn out to be temporary
+ * and the traffic is restored another message is sent with "active" set to
+ * "true".
+ *
+ * The modules is started by OSGi as configured in
+ * {@link org.jitsi.videobridge.osgi.JvbBundleConfig}
+ *
+ * @author Pawel Domas
+ */
+public class EndpointConnectionStatus
+    implements BundleActivator
+{
+    /**
+     * The logger instance used by this class.
+     */
+    private final static Logger logger
+        = Logger.getLogger(EndpointConnectionStatus.class);
+
+    /**
+     * Constant value defines the name of "colibriClass" for connectivity status
+     * notifications sent over the data channels.
+     */
+    private static final String COLIBRI_CLASS_ENDPOINT_CONNECTIVITY_STATUS
+        = "EndpointConnectivityStatusChangeEvent";
+
+    /**
+     * How long an endpoint can be inactive before it wil be considered
+     * disconnected.
+     */
+    private final static long MAX_INACTIVITY_LIMIT = 3000L;
+
+    /**
+     * How often connectivity status is being probed. Value in milliseconds.
+     */
+    private final static long PROBE_INTERVAL = 500L;
+
+    /**
+     * OSGi BC for this module.
+     */
+    private BundleContext bundleContext;
+
+    /**
+     * The list of <tt>Endpoint</tt>s which have current their connection status
+     * classified as inactive.
+     */
+    private List<Endpoint> inactiveEndpoints = new LinkedList<>();
+
+    /**
+     * The timer which runs the periodical connection status probing operation.
+     */
+    private Timer timer;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void start(BundleContext bundleContext)
+        throws Exception
+    {
+        this.bundleContext = bundleContext;
+
+        if (timer == null)
+        {
+            timer = new Timer("EndpointConnectionStatusMonitoring", true);
+            timer.schedule(new TimerTask()
+            {
+                @Override
+                public void run()
+                {
+                    doMonitor();
+                }
+            }, PROBE_INTERVAL, PROBE_INTERVAL);
+        }
+        else
+        {
+            logger.error("Endpoint connection monitoring is already running");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void stop(BundleContext bundleContext)
+        throws Exception
+    {
+        if (timer != null)
+        {
+            timer.cancel();
+            timer = null;
+        }
+
+        inactiveEndpoints.clear();
+
+        this.bundleContext = null;
+    }
+
+    /**
+     * Periodic task which is executed in {@link #PROBE_INTERVAL} intervals.
+     * Monitors endpoints connectivity status.
+     */
+    private void doMonitor()
+    {
+        BundleContext bundleContext = this.bundleContext;
+        if (bundleContext != null)
+        {
+            Collection<Videobridge> jvbs
+                = Videobridge.getVideobridges(bundleContext);
+            for (Videobridge videobridge : jvbs)
+            {
+                Conference[] conferences = videobridge.getConferences();
+                for (Conference conference : conferences)
+                {
+                    List<Endpoint> endpoints = conference.getEndpoints();
+                    for (Endpoint endpoint : endpoints)
+                    {
+                        monitorEndpointActivity(endpoint);
+                    }
+                }
+
+                cleanupExpiredEndpointsStatus();
+            }
+        }
+    }
+
+    private void monitorEndpointActivity(Endpoint endpoint)
+    {
+        long lastActivity = 0;
+
+        // Go over all RTP channels to get the latest timestamp
+        List<RtpChannel> rtpChannels = endpoint.getChannels(null);
+        for (RtpChannel channel : rtpChannels)
+        {
+            long channelLastActivity = channel.getLastTransportActivityTime();
+            if (channelLastActivity > lastActivity)
+            {
+                lastActivity = channelLastActivity;
+            }
+        }
+        // Also check SctpConnection
+        SctpConnection sctpConnection = endpoint.getSctpConnection();
+        if (sctpConnection != null)
+        {
+            long lastSctpActivity
+                = sctpConnection.getLastTransportActivityTime();
+            if (lastSctpActivity > lastActivity)
+            {
+                lastActivity = lastSctpActivity;
+            }
+        }
+
+        // Transport not initialized yet
+        if (lastActivity == 0)
+        {
+            logger.debug(endpoint + " not ready for activity checks yet");
+            return;
+        }
+
+        String endpointId = endpoint.getID();
+        long noActivityForMs = System.currentTimeMillis() - lastActivity;
+        boolean inactive = noActivityForMs > MAX_INACTIVITY_LIMIT;
+        if (inactive && !inactiveEndpoints.contains(endpoint))
+        {
+            logger.debug(endpointId + " is considered disconnected");
+
+            inactiveEndpoints.add(endpoint);
+            // Broadcast connection "inactive" message over data channels
+            sendEndpointConnectionStatus(endpoint, false);
+        }
+        else if (!inactive && inactiveEndpoints.contains(endpoint))
+        {
+            logger.debug(endpointId + " has reconnected");
+
+            inactiveEndpoints.remove(endpoint);
+            // Broadcast connection "active" message over data channels
+            sendEndpointConnectionStatus(endpoint, true);
+        }
+
+        if (inactive && logger.isDebugEnabled())
+        {
+            logger.debug(String.format(
+                    "No activity on %s for %s",
+                    endpointId, (( (double) noActivityForMs) / 1000d )));
+        }
+    }
+
+    private void sendEndpointConnectionStatus(Endpoint    endpoint,
+                                              boolean     isConnected)
+    {
+        Conference conference = endpoint.getConference();
+        if (conference != null)
+        {
+            // We broadcast the message also to the endpoint itself for
+            // debugging purposes
+            conference.broadcastMessageOnDataChannels(
+                    createEndpointConnectivityStatusChangeEvent(
+                            endpoint, isConnected));
+        }
+        else
+        {
+            logger.warn("Attempt to send connectivity status update for " +
+                    "endpoint without parent conference instance(expired?)");
+        }
+    }
+
+    private String createEndpointConnectivityStatusChangeEvent(
+            Endpoint endpoint, boolean connected)
+    {
+        return
+            "{\"colibriClass\":\""
+                + COLIBRI_CLASS_ENDPOINT_CONNECTIVITY_STATUS
+                + "\",\"endpoint\":\"" + JSONValue.escape(endpoint.getID())
+                +"\", \"active\":\"" + String.valueOf(connected)
+                + "\"}";
+    }
+
+    private void cleanupExpiredEndpointsStatus()
+    {
+        Iterator<Endpoint> endpoints = inactiveEndpoints.iterator();
+        while (endpoints.hasNext())
+        {
+            Endpoint endpoint = endpoints.next();
+            if (endpoint.getConference().isExpired())
+            {
+                logger.debug("Removing endpoint from expired conference: "
+                        + endpoint.getID());
+
+                endpoints.remove();
+            }
+        }
+    }
+}

--- a/src/main/java/org/jitsi/videobridge/EventFactory.java
+++ b/src/main/java/org/jitsi/videobridge/EventFactory.java
@@ -80,6 +80,14 @@ public class EventFactory
         = "org/jitsi/videobridge/Endpoint/STREAM_STARTED";
 
     /**
+     * The name of the topic of a "SCTP connection ready" event triggered on
+     * an endpoint instance when it's SCTP connection is ready for
+     * sending/receiving data.
+     */
+    public static final String SCTP_CONN_READY_TOPIC
+        = "org/jitsi/videobridge/Endpoint/SCTP_CONN_READY";
+
+    /**
      * The name of the topic of a "transport channel created" event.
      */
     public static final String TRANSPORT_CHANNEL_ADDED_TOPIC
@@ -209,6 +217,23 @@ public class EventFactory
             new Event(
                     ENDPOINT_DISPLAY_NAME_CHANGED_TOPIC,
                     makeProperties(endpoint));
+    }
+
+    /**
+     * Creates a new "SCTP connection ready" <tt>Event</tt>, which means that
+     * the endpoint passed in {@link #EVENT_SOURCE} property has now it's SCTP
+     * connection ready for sending/receiving data.
+     *
+     * @param endpoint the endpoint for which SCTP connection is now ready.
+     *
+     * @return the <tt>Event</tt> which was created.
+     */
+    public static Event endpointSctpConnReady(Endpoint endpoint)
+    {
+        Dictionary<String, Object> properties = new Hashtable<>(1);
+
+        properties.put(EVENT_SOURCE, endpoint);
+        return new Event(SCTP_CONN_READY_TOPIC, properties);
     }
 
     public static Event streamStarted(RtpChannel rtpChannel)

--- a/src/main/java/org/jitsi/videobridge/osgi/JvbBundleConfig.java
+++ b/src/main/java/org/jitsi/videobridge/osgi/JvbBundleConfig.java
@@ -218,6 +218,20 @@ public class JvbBundleConfig
                 true_);
         defaults.put(SRTPCryptoContext.CHECK_REPLAY_PNAME, false_);
 
+        // Sends "consent freshness" check every 3 seconds
+        defaults.put(
+                StackProperties.CONSENT_FRESHNESS_INTERVAL, "3000");
+        // Retry every 500ms by setting original and max wait intervals
+        defaults.put(
+                StackProperties.CONSENT_FRESHNESS_ORIGINAL_WAIT_INTERVAL,
+                "500");
+        defaults.put(
+                StackProperties.CONSENT_FRESHNESS_MAX_WAIT_INTERVAL, "500");
+        // Retry max 5 times which will take up to 2500ms, that is before
+        // the next "consent freshness" transaction starts
+        defaults.put(
+                StackProperties.CONSENT_FRESHNESS_MAX_RETRANSMISSIONS, "5");
+
         // In the majority of use-cases the clients which connect to Jitsi
         // Videobridge are not in the same network, so we don't need to
         // advertise link-local addresses.

--- a/src/main/java/org/jitsi/videobridge/osgi/JvbBundleConfig.java
+++ b/src/main/java/org/jitsi/videobridge/osgi/JvbBundleConfig.java
@@ -100,7 +100,8 @@ public class JvbBundleConfig
             // before the HTTP/JSON API because the HTTP/JSON API (1) exposes
             // the vital, non-optional, non-additional pieces of functionality
             // of the Videobridge and (2) it pulls, does not push.
-            "org/jitsi/videobridge/stats/StatsManagerBundleActivator"
+            "org/jitsi/videobridge/stats/StatsManagerBundleActivator",
+            "org/jitsi/videobridge/EndpointConnectionStatus"
         }
     };
 


### PR DESCRIPTION
This PR adds endpoint connection status monitoring which sends notifications over data channels when connectivity status changes. Endpoint connection status is considered inactive when there is no media or ICE related traffic on any of it's channels. This is tracked in new 'lastTransportActivityTime' timestamp added to every Channel. It is updated whenever RTP/RTCP packet is received or when ICE "consent freshness" check succeeds(which is now sent more often - every 3 seconds). 