### PR TITLE
Do not use WeakReference on Endpoint and Conference

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -78,7 +78,7 @@ public class Conference
     /**
      * The <tt>Endpoint</tt>s participating in this <tt>Conference</tt>.
      */
-    private final List<WeakReference<Endpoint>> endpoints = new LinkedList<>();
+    private final List<Endpoint> endpoints = new LinkedList<>();
 
     /**
      * The {@link EventAdmin} instance (to be) used by this {@code Conference}
@@ -803,12 +803,11 @@ public class Conference
 
         synchronized (endpoints)
         {
-            for (Iterator<WeakReference<Endpoint>> i = endpoints.iterator();
-                    i.hasNext();)
+            for (Iterator<Endpoint> i = endpoints.iterator(); i.hasNext();)
             {
-                Endpoint e = i.next().get();
+                Endpoint e = i.next();
 
-                if (e == null)
+                if (e.isExpired())
                 {
                     i.remove();
                     changed = true;
@@ -826,7 +825,7 @@ public class Conference
                 // Conference and will unregister itself from the endpoint
                 // sooner or later.
                 endpoint.addPropertyChangeListener(propertyChangeListener);
-                endpoints.add(new WeakReference<>(endpoint));
+                endpoints.add(endpoint);
                 changed = true;
 
                 EventAdmin eventAdmin = getEventAdmin();
@@ -894,13 +893,11 @@ public class Conference
         synchronized (this.endpoints)
         {
             endpoints = new ArrayList<>(this.endpoints.size());
-            for (Iterator<WeakReference<Endpoint>> i
-                        = this.endpoints.iterator();
-                    i.hasNext();)
+            for (Iterator<Endpoint> i = this.endpoints.iterator(); i.hasNext();)
             {
-                Endpoint endpoint = i.next().get();
+                Endpoint endpoint = i.next();
 
-                if (endpoint == null)
+                if (endpoint.isExpired())
                 {
                     i.remove();
                     changed = true;
@@ -1326,12 +1323,11 @@ public class Conference
 
         synchronized (endpoints)
         {
-            for (Iterator<WeakReference<Endpoint>> i = endpoints.iterator();
-                    i.hasNext();)
+            for (Iterator<Endpoint> i = endpoints.iterator(); i.hasNext();)
             {
-                Endpoint e = i.next().get();
+                Endpoint e = i.next();
 
-                if (e == null || e == endpoint)
+                if (e.isExpired() || e == endpoint)
                 {
                     i.remove();
                     removed = true;

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -555,11 +555,10 @@ public class Conference
         if (maybeRemoveEndpoint)
         {
             // It looks like there is a chance that the Endpoint may have
-            // expired. Endpoints are held by this Conference via WeakReferences
-            // but WeakReferences are unpredictable. We have functionality
-            // though which could benefit from discovering that an Endpoint has
-            // expired as quickly as possible (e.g. ConferenceSpeechActivity).
-            // Consequently, try to expedite the removal of expired Endpoints.
+            // expired. We have functionality though which could benefit from
+            // discovering that an Endpoint has expired as quickly as possible
+            // (e.g. ConferenceSpeechActivity). Consequently, try to expedite
+            // the removal of expired Endpoints.
             if (endpoint.getSctpConnection() == null
                     && endpoint.getChannelCount(null) == 0)
             {

--- a/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
+++ b/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
@@ -185,7 +185,7 @@ public class ConferenceSpeechActivity
      * The <tt>Endpoint</tt> which is the dominant speaker in
      * {@link #conference}.
      */
-    private WeakReference<Endpoint> dominantEndpoint;
+    private Endpoint dominantEndpoint;
 
     /**
      * The indicator which signals to {@link #eventDispatcher} that
@@ -205,7 +205,7 @@ public class ConferenceSpeechActivity
      * {@link #conference} with the dominant (speaker) <tt>Endpoint</tt> at the
      * beginning of the list i.e. the dominant speaker history.
      */
-    private List<WeakReference<Endpoint>> endpoints;
+    private List<Endpoint> endpoints;
 
     /**
      * The indicator which signals to {@link #eventDispatcher} that the
@@ -306,7 +306,7 @@ public class ConferenceSpeechActivity
 
                     if (!endpoint.equals(dominantEndpoint))
                     {
-                        this.dominantEndpoint = new WeakReference<>(endpoint);
+                        this.dominantEndpoint = endpoint;
                         maybeStartEventDispatcher = true;
                     }
                 }
@@ -551,8 +551,8 @@ public class ConferenceSpeechActivity
             }
             else
             {
-                dominantEndpoint = this.dominantEndpoint.get();
-                if (dominantEndpoint == null)
+                dominantEndpoint = this.dominantEndpoint;
+                if (dominantEndpoint.isExpired())
                     this.dominantEndpoint = null;
             }
         }
@@ -612,16 +612,15 @@ public class ConferenceSpeechActivity
 
                     endpoints = new ArrayList<>(conferenceEndpoints.size());
                     for (Endpoint endpoint : conferenceEndpoints)
-                        endpoints.add(new WeakReference<>(endpoint));
+                        endpoints.add(endpoint);
                 }
             }
 
             // The return value is the list of Endpoints of this instance.
             ret = new ArrayList<>(endpoints.size());
-            for (Iterator<WeakReference<Endpoint>> i = endpoints.iterator();
-                    i.hasNext();)
+            for (Iterator<Endpoint> i = endpoints.iterator(); i.hasNext();)
             {
-                Endpoint endpoint = i.next().get();
+                Endpoint endpoint = i.next();
 
                 if (endpoint != null)
                     ret.add(endpoint);
@@ -808,7 +807,7 @@ public class ConferenceSpeechActivity
                 endpoints = new ArrayList<>(conferenceEndpoints.size());
                 for (Endpoint endpoint : conferenceEndpoints)
                 {
-                    endpoints.add(new WeakReference<>(endpoint));
+                    endpoints.add(endpoint);
                 }
                 endpointsChanged = true;
             }
@@ -818,12 +817,11 @@ public class ConferenceSpeechActivity
                  * Remove the Endpoints of this instance which are no longer in
                  * the conference.
                  */
-                for (Iterator<WeakReference<Endpoint>> i = endpoints.iterator();
-                        i.hasNext();)
+                for (Iterator<Endpoint> i = endpoints.iterator(); i.hasNext();)
                 {
-                    Endpoint endpoint = i.next().get();
+                    Endpoint endpoint = i.next();
 
-                    if (endpoint == null)
+                    if (endpoint.isExpired())
                     {
                         i.remove();
                         endpointsChanged = true;
@@ -846,7 +844,7 @@ public class ConferenceSpeechActivity
                 {
                     for (Endpoint endpoint : conferenceEndpoints)
                     {
-                        endpoints.add(new WeakReference<>(endpoint));
+                        endpoints.add(endpoint);
                     }
                     endpointsChanged = true;
                 }
@@ -865,7 +863,7 @@ public class ConferenceSpeechActivity
 
                 for (int i = 0, count = endpoints.size(); i < count; ++i)
                 {
-                    if (dominantEndpoint.equals(endpoints.get(i).get()))
+                    if (dominantEndpoint.equals(endpoints.get(i)))
                     {
                         dominantEndpointIndex = i;
                         break;
@@ -874,7 +872,7 @@ public class ConferenceSpeechActivity
                 if ((dominantEndpointIndex != -1)
                         && (dominantEndpointIndex != 0))
                 {
-                    WeakReference<Endpoint> weakReference
+                    Endpoint weakReference
                         = endpoints.remove(dominantEndpointIndex);
 
                     endpoints.add(0, weakReference);

--- a/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
+++ b/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
@@ -863,25 +863,8 @@ public class ConferenceSpeechActivity
 
             if (dominantEndpoint != null)
             {
-                int dominantEndpointIndex = -1;
-
-                for (int i = 0, count = endpoints.size(); i < count; ++i)
-                {
-                    if (dominantEndpoint.equals(endpoints.get(i)))
-                    {
-                        dominantEndpointIndex = i;
-                        break;
-                    }
-                }
-                if ((dominantEndpointIndex != -1)
-                        && (dominantEndpointIndex != 0))
-                {
-                    Endpoint weakReference
-                        = endpoints.remove(dominantEndpointIndex);
-
-                    endpoints.add(0, weakReference);
-                    endpointsChanged = true;
-                }
+                endpoints.remove(dominantEndpoint);
+                endpoints.add(0, dominantEndpoint);
             }
 
             /*

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -172,11 +172,10 @@ public class Endpoint
     private List<String> pinnedEndpoints = new LinkedList<>();
 
     /**
-     * Weak references to the currently selected <tt>Endpoint</tt>s at this
+     * The list of currently selected <tt>Endpoint</tt>s at this
      * <tt>Endpoint</tt>.
      */
-    private Set<WeakReference<Endpoint>> weakSelectedEndpoints
-            = new HashSet<>();
+    private Set<Endpoint> selectedEndpoints = new HashSet<>();
 
     /**
      * The {@link Logger} to be used by this instance to print debug
@@ -383,20 +382,6 @@ public class Endpoint
     }
 
     /**
-     Helper method that unwraps the <tt>Endpoint</tt> from the weak reference
-     and performs the necessary checks.
-
-     @return The unwrapped Endpoint object or null if the Endpoint was release
-     of it has been expired
-     */
-    private Endpoint checkEndpointWeakReference(WeakReference<Endpoint> wr)
-    {
-        Endpoint e = wr == null ? null : wr.get();
-
-        return e == null || e.expired ? null : e;
-    }
-
-    /**
      * Gets the currently selected <tt>Endpoint</tt>s at this <tt>Endpoint</tt>
      *
      * @return the currently selected <tt>Endpoint</tt>s at this
@@ -405,10 +390,9 @@ public class Endpoint
     public Set<Endpoint> getSelectedEndpoints()
     {
         Set<Endpoint> result = new HashSet<>();
-        for (WeakReference<Endpoint> wr : weakSelectedEndpoints)
+        for (Endpoint endpoint : selectedEndpoints)
         {
-            Endpoint endpoint = checkEndpointWeakReference(wr);
-            if (endpoint != null)
+            if (!endpoint.isExpired())
             {
                 result.add(endpoint);
             }
@@ -437,6 +421,18 @@ public class Endpoint
         WeakReference<Conference> wr = weakConference;
 
         return (wr == null) ? null : wr.get();
+    }
+
+    /**
+     * Checks whether or not this <tt>Endpoint</tt> is considered "expired"
+     * ({@link #expire()} method has been called).
+     *
+     * @return <tt>true</tt> if this instance is "expired" or <tt>false</tt>
+     * otherwise.
+     */
+    public boolean isExpired()
+    {
+        return expired;
     }
 
     /**
@@ -745,7 +741,7 @@ public class Endpoint
 
             if (changed)
             {
-                updateWeakSelectedEndpoints(newSelectedEndpoints);
+                this.selectedEndpoints = new HashSet<>(newSelectedEndpoints);
             }
         }
 
@@ -800,24 +796,6 @@ public class Endpoint
         }
 
         return selectedEndpointIDs;
-    }
-
-    /**
-     * A helper method that updates the <tt>weakSelectedEndpoints<tt/>.
-     * Wraps the elements of <tt>newSelectedEndpoints<tt/> to weak references.
-     * @param newSelectedEndpoints The set to use in weakSelectedEndpoints
-     */
-    private void updateWeakSelectedEndpoints(
-            Set<Endpoint> newSelectedEndpoints)
-    {
-        Set<WeakReference<Endpoint>> newSet = new HashSet<>();
-
-        for (Endpoint endpoint : newSelectedEndpoints)
-        {
-            newSet.add(new WeakReference<Endpoint>(endpoint));
-        }
-
-        weakSelectedEndpoints = newSet;
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/eventadmin/influxdb/LoggingHandler.java
+++ b/src/main/java/org/jitsi/videobridge/eventadmin/influxdb/LoggingHandler.java
@@ -272,10 +272,10 @@ public class LoggingHandler
         }
 
         Conference conference = endpoint.getConference();
-        if (conference == null)
+        if (conference.isExpired())
         {
             logger.debug("Could not log endpoint created event because " +
-                "the conference is null.");
+                "the conference has expired.");
             return;
         }
 
@@ -301,10 +301,10 @@ public class LoggingHandler
         }
 
         Conference conference = endpoint.getConference();
-        if (conference == null)
+        if (conference.isExpired())
         {
             logger.debug("Could not log endpoint display name changed " +
-                " event because the conference is null.");
+                " event because the conference has expired.");
             return;
         }
 


### PR DESCRIPTION
Both Conference and Endpoint have "expired" properties which can be used to determine if instances are valid, so using WeakReference only adds extra complexity.

I need these changes for another work which will require to store expired Endpoint instances until Conference is not expired and it may break logic which depends on WeakReferences<Endpoint>.