### PR TITLE
Update rest-videobridge.md

### DIFF
--- a/doc/rest-videobridge.md
+++ b/doc/rest-videobridge.md
@@ -155,7 +155,7 @@ Example
 ==============
 
 1. Create the conference by posting an empty json object:
-Post "[]" to <bridge_base_url>/colibri/conferences/
+Post "{}" to <bridge_base_url>/colibri/conferences/
 
 2. Bridge will respond with a json response that contains the colibri conference id:
 ```json


### PR DESCRIPTION
On the "Create the conference" example, the post content must be an empty  object "{}" and not an empty array "[]"
