### PR TITLE
Fix for NPE in simulcast receiver.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/simulcast/SimulcastReceiver.java
+++ b/src/main/java/org/jitsi/videobridge/simulcast/SimulcastReceiver.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.simulcast;
 
+import org.jitsi.impl.neomedia.rtp.*;
 import org.jitsi.service.configuration.*;
 import org.jitsi.impl.neomedia.*;
 import org.jitsi.service.neomedia.*;
@@ -198,7 +199,13 @@ public class SimulcastReceiver
         // that matches the targetOrder parameter best.
         SimulcastStream next = simStreams[0];
 
-        if (sender.getStreamRTPManager().getRemoteClockEstimator()
+        StreamRTPManager streamRTPManager = sender.getStreamRTPManager();
+        if (streamRTPManager == null)
+        {
+            return next;
+        }
+
+        if (streamRTPManager.getRemoteClockEstimator()
             .getRemoteClock(next.getPrimarySSRC()) == null)
         {
             return next;
@@ -210,7 +217,7 @@ public class SimulcastReceiver
         {
             SimulcastStream ss = simStreams[i];
 
-            if (ss.isStreaming() && sender.getStreamRTPManager()
+            if (ss.isStreaming() && streamRTPManager
                 .getRemoteClockEstimator()
                 .getRemoteClock(ss.getPrimarySSRC()) != null)
             {


### PR DESCRIPTION
https://github.com/jitsi/jitsi-videobridge/commit/245ed9d3342e65c67cd3e9659c9c344760ca7713 introduces an NPE under certain occasions. This commit fixes it.