### PR TITLE
Openfire plugin issues

### DIFF
--- a/openfire/src/java/org/jitsi/videobridge/openfire/JvbOpenfireBundleConfig.java
+++ b/openfire/src/java/org/jitsi/videobridge/openfire/JvbOpenfireBundleConfig.java
@@ -47,6 +47,12 @@ public class JvbOpenfireBundleConfig extends JvbBundleConfig
         return listsToMatrix( result );
     }
 
+    /**
+     * Converts an array-of-arrays into a list-of-lists.
+     *
+     * @param matrix an array-of-arrays.
+     * @return A list-of-lists.
+     */
     public static List<List<String>> matrixToLists( String[][] matrix )
     {
         final List<List<String>> result = new ArrayList<>();
@@ -61,6 +67,12 @@ public class JvbOpenfireBundleConfig extends JvbBundleConfig
         return result;
     }
 
+    /**
+     * Converts a list-of-lists into an array-of-arrays.
+     *
+     * @param lists a list-of-lists.
+     * @return an array-of-arrays.
+     */
     public static String[][] listsToMatrix( List<List<String>> lists )
     {
         final String[][] result = new String[ lists.size() ][];

--- a/openfire/src/java/org/jitsi/videobridge/openfire/JvbOpenfireBundleConfig.java
+++ b/openfire/src/java/org/jitsi/videobridge/openfire/JvbOpenfireBundleConfig.java
@@ -7,8 +7,9 @@ import java.util.*;
 /**
  * OSGi bundles description for the Openfire Jitsi Videobridge plugin.
  *
- * This implementation takes the bundle that ships with the Jitsi Videobridge plugin, and filters out the bundles that
- * are not applicable to the Openfire plugin.
+ * This implementation takes the bundle that ships with the Jitsi Videobridge
+ * plugin, and filters out the bundles that are not applicable to the Openfire
+ * plugin.
  *
  * @author Guus der Kinderen, guus.der.kinderen@gmail.com
  */
@@ -24,7 +25,8 @@ public class JvbOpenfireBundleConfig extends JvbBundleConfig
 
         // Very first activator: logging!
         final List<String> logging = new ArrayList<>();
-        logging.add( "org.jitsi.videobridge.openfire.SLF4JBridgeHandlerBundleActivator" );
+        logging.add(
+            "org.jitsi.videobridge.openfire.SLF4JBridgeHandlerBundleActivator");
         logging.add( "org.slf4j.osgi.logservice.impl.Activator" );
         result.add( 0, logging );
 
@@ -33,9 +35,10 @@ public class JvbOpenfireBundleConfig extends JvbBundleConfig
         while ( iterator.hasNext() )
         {
             final List<String> bundles = iterator.next();
-            if ( bundles.remove( "org/jitsi/videobridge/rest/RESTBundleActivator" ) && bundles.isEmpty() )
+            if (bundles.remove("org/jitsi/videobridge/rest/RESTBundleActivator")
+                && bundles.isEmpty() )
             {
-                // Delete the bundle if we removed the only activator that was in it.
+                // Delete the bundle if we removed the only activator.
                 iterator.remove();
             }
         }
@@ -49,7 +52,8 @@ public class JvbOpenfireBundleConfig extends JvbBundleConfig
         final List<List<String>> result = new ArrayList<>();
         for ( final String[] array : matrix )
         {
-            // Can't use Arrays.asList(), as the returned list does not implement List#remove()
+            // Can't use Arrays.asList(), as the returned list does not
+            // implement List#remove()
             final List<String> entries = new ArrayList<>();
             Collections.addAll( entries, array );
             result.add( entries );

--- a/openfire/src/java/org/jitsi/videobridge/openfire/PluginImpl.java
+++ b/openfire/src/java/org/jitsi/videobridge/openfire/PluginImpl.java
@@ -409,7 +409,7 @@ public class PluginImpl
 
     /**
      * An XML property was set. The parameter map <tt>params</tt> will contain
-     * the the value of the property under the key <tt>value</tt>.
+     * the value of the property under the key <tt>value</tt>.
      *
      * @param property the name of the property.
      * @param params event parameters.

--- a/openfire/src/java/org/jitsi/videobridge/openfire/SLF4JBridgeHandlerBundleActivator.java
+++ b/openfire/src/java/org/jitsi/videobridge/openfire/SLF4JBridgeHandlerBundleActivator.java
@@ -1,0 +1,28 @@
+package org.jitsi.videobridge.openfire;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+/**
+ * Adds the SLF4JBridgeHandler in an OSGi bundle.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class SLF4JBridgeHandlerBundleActivator implements BundleActivator
+{
+    @Override
+    public void start( BundleContext context ) throws Exception
+    {
+        // Remove existing handlers attached to j.u.l root logger
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+
+        SLF4JBridgeHandler.install();
+    }
+
+    @Override
+    public void stop( BundleContext context ) throws Exception
+    {
+        SLF4JBridgeHandler.uninstall();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,16 @@
       <artifactId>slf4j-jdk14</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>osgi-over-slf4j</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
       <groupId>xpp3</groupId>
       <artifactId>xpp3</artifactId>
     </dependency>


### PR DESCRIPTION
This is a follow-up to #328.

It adds:

- silent ignores of non-root files in the native libraries (which were ignored too, before my earlier changes)
- logging being forced through the Openfire-provided logging framework (instead of std-out). Fixes #329 
- compliance with Jitsi coding conventions.