### PR TITLE
fix(sim): Retries to scale-up, if we failed to send the target order.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/simulcast/SimulcastSender.java
+++ b/src/main/java/org/jitsi/videobridge/simulcast/SimulcastSender.java
@@ -95,6 +95,11 @@ public class SimulcastSender
     private final Logger logger;
 
     /**
+     * Remembers whether we switched to the desired simulcast order.
+     */
+    private boolean retry = false;
+
+    /**
      * Ctor.
      *
      * @param simulcastSenderManager the <tt>SimulcastSender</tt> that owns this
@@ -385,7 +390,7 @@ public class SimulcastSender
             SendMode sm = this.sendMode;
             if (sm != null)
             {
-                this.sendMode.receive(newTargetOrder);
+                retry = !this.sendMode.receive(newTargetOrder);
             }
         }
     }
@@ -413,6 +418,10 @@ public class SimulcastSender
         }
         else
         {
+            if (retry)
+            {
+                retry = !this.sendMode.receive(targetOrder);
+            }
             return sendMode.accept(pkt);
         }
     }
@@ -482,7 +491,7 @@ public class SimulcastSender
             sendMode = new SwitchingSendMode(this);
         }
 
-        this.sendMode.receive(targetOrder);
+        retry = !this.sendMode.receive(targetOrder);
     }
 
     /**
@@ -571,7 +580,7 @@ public class SimulcastSender
                 return;
             }
 
-            sm.receive(targetOrder);
+            retry = !sm.receive(targetOrder);
         }
     }
 }

--- a/src/main/java/org/jitsi/videobridge/simulcast/sendmodes/SendMode.java
+++ b/src/main/java/org/jitsi/videobridge/simulcast/sendmodes/SendMode.java
@@ -55,7 +55,7 @@ public abstract class SendMode
      *
      * @param targetOrder
      */
-    public void receive(int targetOrder)
+    public boolean receive(int targetOrder)
     {
         SimulcastStream closestMatch = this.simulcastSender
             .getSimulcastReceiver().getSimulcastStream(
@@ -63,6 +63,8 @@ public abstract class SendMode
                     .getSimulcastEngine().getVideoChannel().getStream());
 
         receive(closestMatch);
+
+        return closestMatch.getOrder() == targetOrder;
     }
     /**
      * Gets a boolean indicating whether the packet has to be accepted or not.


### PR DESCRIPTION
When we don’t have a remote clock for the higher layer stream, we avoid upscaling in order to avoid breaking timestamp rewriting. This PR implements a retry logic that attempts to upscale if the the upscale was unsuccessful.