### PR TITLE
Component should expose its videobridge instance

### DIFF
--- a/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java
+++ b/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java
@@ -202,7 +202,13 @@ public class ComponentImpl
         return NAME;
     }
 
-    private Videobridge getVideobridge()
+    /**
+     * Returns the {@link Videobridge} instance that is managing conferences
+     * for this component. Returns <tt>null</tt> if no instance is running.
+     *
+     * @return the videobridge instance, <tt>null</tt> when none is running.
+     */
+    public Videobridge getVideobridge()
     {
         BundleContext bundleContext = getBundleContext();
         Videobridge videobridge;


### PR DESCRIPTION
This is a fix for https://github.com/jitsi/jitsi-videobridge/issues/335

The Component implementation that wraps the Videobridge instance should expose that Videobridge instance publicly, instead of privately.

Obtaining the Videobridge instance can be achieved with other data that is publicly exposed by the component (notably getBundleContext() and ServiceUtils2.getService), and the implementation already contains a private method that exposes the instance. This method can be made publicly accessible, which would remove the need to duplicate its implementation.