### PR TITLE
Javadoc fix.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java
+++ b/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java
@@ -38,7 +38,7 @@ import org.xmpp.packet.Packet;
 
 /**
  * Implements <tt>org.xmpp.component.Component</tt> to provide Jitsi Videobridge
- * as an internal Jabber component.
+ * as a Jabber component.
  *
  * @author Lyubomir Marinov
  */


### PR DESCRIPTION
The superclass, ComponentBase, is an implementation of an *external*, not internal, component.