### PR TITLE
Git should ignore nested Intellij IDEA project files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@
 *.jar
 /.project
 *.swp
-.idea/
-jitsi-videobridge.iml
+**/.idea/
+*.iml


### PR DESCRIPTION
Intellij tends to create project files in subdirectories (notably for the Openfire plugin, that is nested in this project. Those files should also be ignored by Git.