### PR TITLE
Exceptions should not be completely ignored

### DIFF
--- a/openfire/src/java/org/jitsi/videobridge/openfire/PluginImpl.java
+++ b/openfire/src/java/org/jitsi/videobridge/openfire/PluginImpl.java
@@ -105,7 +105,8 @@ public class PluginImpl
             }
             catch (ComponentException ce)
             {
-                // TODO Auto-generated method stub
+                Log.warn( "An unexpected exception occurred while " +
+                          "destroying the plugin.", ce );
             }
             componentManager = null;
             subdomain = null;

--- a/src/main/java/org/jitsi/videobridge/Content.java
+++ b/src/main/java/org/jitsi/videobridge/Content.java
@@ -928,14 +928,9 @@ public class Content
             recorder.start(format, recordingPath);
             started = true;
         }
-        catch (IOException ioe)
+        catch (IOException | MediaException ioe)
         {
             logger.error("Failed to start recorder: " + ioe);
-            started = false;
-        }
-        catch (MediaException me)
-        {
-            logger.error("Failed to start recorder: " + me);
             started = false;
         }
 

--- a/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
+++ b/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
@@ -1524,7 +1524,9 @@ public class IceUdpTransportManager
                                 rtpChannel.getDatagramFilter(false /* RTP */));
                 }
                 catch (SocketException se) // never thrown
-                {}
+                {
+                    logger.error( "An unexpected exception occurred.", se );
+                }
             }
 
             Socket iceSocket1 = rtcpmux ? iceSocket0 : iceSockets[1];
@@ -1542,7 +1544,9 @@ public class IceUdpTransportManager
                                 rtpChannel.getDatagramFilter(true /* RTCP */));
                 }
                 catch (SocketException se) // never thrown
-                {}
+                {
+                    logger.error( "An unexpected exception occurred.", se );
+                }
             }
 
             if (channelSocket0 != null || channelSocket1 != null)
@@ -1597,7 +1601,9 @@ public class IceUdpTransportManager
                                 rtpChannel.getDatagramFilter(false /* RTP */));
                 }
                 catch (SocketException se) // never thrown
-                {}
+                {
+                    logger.error( "An unexpected exception occurred.", se );
+                }
             }
 
             DatagramSocket iceSocket1 = rtcpmux ? iceSocket0 : iceSockets[1];
@@ -1616,7 +1622,9 @@ public class IceUdpTransportManager
                                 rtpChannel.getDatagramFilter(true /* RTCP */));
                 }
                 catch (SocketException se) // never thrown
-                {}
+                {
+                    logger.error( "An unexpected exception occurred.", se );
+                }
             }
 
             if (channelSocket0 != null || channelSocket1 != null)
@@ -1942,6 +1950,7 @@ public class IceUdpTransportManager
                         }
                         catch (IllegalArgumentException e)
                         {
+                            logger.debug( "Unable to parse: " + aSetupStr, e );
                             // The value of aSetup will remain null and will
                             // thus signal the exception.
                         }

--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -1723,6 +1723,7 @@ public class RtpChannel
                 catch (SizeExceededException see)
                 {
                     // Never thrown with checkLimit=false.
+                    logger.error( "An unexpected exception occurred.", see );
                 }
             }
         }

--- a/src/main/java/org/jitsi/videobridge/ratecontrol/LastNBitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/ratecontrol/LastNBitrateController.java
@@ -192,6 +192,7 @@ public class LastNBitrateController
                     catch (Exception e)
                     {
                         // Whatever, use the default
+                        logger.debug("Cannot parse: " + rembMultConstantStr, e);
                     }
                 }
 

--- a/src/main/java/org/jitsi/videobridge/rest/JSONDeserializer.java
+++ b/src/main/java/org/jitsi/videobridge/rest/JSONDeserializer.java
@@ -93,13 +93,9 @@ final class JSONDeserializer
             {
                 candidateIQ = candidateIQClass.newInstance();
             }
-            catch (IllegalAccessException iae)
+            catch (IllegalAccessException | InstantiationException iae)
             {
                 throw new UndeclaredThrowableException(iae);
-            }
-            catch (InstantiationException ie)
-            {
-                throw new UndeclaredThrowableException(ie);
             }
             // attributes
             deserializeAbstractPacketExtensionAttributes(

--- a/src/main/java/org/jitsi/videobridge/stats/PubSubStatsTransport.java
+++ b/src/main/java/org/jitsi/videobridge/stats/PubSubStatsTransport.java
@@ -322,15 +322,8 @@ public class PubSubStatsTransport
                     service
                         = bundleContext.getService(ev.getServiceReference());
                 }
-                catch (IllegalArgumentException ex)
-                {
-                    logger.debug( "An unexpected exception occurred.", ex );
-                }
-                catch (IllegalStateException ex)
-                {
-                    logger.debug( "An unexpected exception occurred.", ex );
-                }
-                catch (SecurityException ex)
+                catch ( IllegalArgumentException
+                        | IllegalStateException | SecurityException ex )
                 {
                     logger.debug( "An unexpected exception occurred.", ex );
                 }

--- a/src/main/java/org/jitsi/videobridge/stats/PubSubStatsTransport.java
+++ b/src/main/java/org/jitsi/videobridge/stats/PubSubStatsTransport.java
@@ -324,12 +324,15 @@ public class PubSubStatsTransport
                 }
                 catch (IllegalArgumentException ex)
                 {
+                    logger.debug( "An unexpected exception occurred.", ex );
                 }
                 catch (IllegalStateException ex)
                 {
+                    logger.debug( "An unexpected exception occurred.", ex );
                 }
                 catch (SecurityException ex)
                 {
+                    logger.debug( "An unexpected exception occurred.", ex );
                 }
                 if (service instanceof ComponentImpl)
                 {


### PR DESCRIPTION
This is a fix for https://github.com/jitsi/jitsi-videobridge/issues/342

When an exception occurs, it should not be ignored completely. If handling is not needed, the exception should be logged (if only at the lowest of log levels). This greatly reduces confusion while debugging a situation where a bug occurs caused by an exception that the original developer believed was "impossible".