### PR TITLE
Should not use non-standard newline character.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/eventadmin/metrics/MetricLoggingHandler.java
+++ b/src/main/java/org/jitsi/videobridge/eventadmin/metrics/MetricLoggingHandler.java
@@ -122,8 +122,8 @@ public class MetricLoggingHandler
     public static final String METRIC_UPLOAD_AVG_JITTER
         = "Avg upload jitter";
 
-    /** 
-     * Total number or endpoints connected to a conference 
+    /**
+     * Total number or endpoints connected to a conference
      */
     public static final String METRIC_ENDPOINTS = "Endpoints";
 


### PR DESCRIPTION
This is a fix for https://github.com/jitsi/jitsi-videobridge/issues/345

The code uses U+2028 on two lines, where the other lines use regular LF's. The U+2028 has reported to cause problems on the development environment of some: https://github.com/jitsi/jitsi-videobridge/issues/178#issuecomment-255527321

Replaced U+2028 with regular LF.