### PR TITLE
Property name constants should be publicly accessible.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/HarvesterConfiguration.java
+++ b/src/main/java/org/jitsi/videobridge/HarvesterConfiguration.java
@@ -43,7 +43,7 @@ public class HarvesterConfiguration
      * address mapping as one of our NAT traversal options as well as the local
      * address that we should be mapping.
      */
-    private static final String NAT_HARVESTER_LOCAL_ADDRESS
+    public static final String NAT_HARVESTER_LOCAL_ADDRESS
         = "org.jitsi.videobridge.NAT_HARVESTER_LOCAL_ADDRESS";
 
     /**
@@ -51,21 +51,21 @@ public class HarvesterConfiguration
      * address mapping as one of our NAT traversal options as well as the public
      * address that we should be using in addition to our local one.
      */
-    private static final String NAT_HARVESTER_PUBLIC_ADDRESS
+    public static final String NAT_HARVESTER_PUBLIC_ADDRESS
         = "org.jitsi.videobridge.NAT_HARVESTER_PUBLIC_ADDRESS";
 
     /**
      * Contains the name of the property flag that may indicate that AWS address
      * harvesting should be explicitly disabled.
      */
-    private static final String DISABLE_AWS_HARVESTER
+    public static final String DISABLE_AWS_HARVESTER
         = "org.jitsi.videobridge.DISABLE_AWS_HARVESTER";
 
     /**
      * Contains the name of the property flag that may indicate that AWS address
      * harvesting should be forced without first trying to auto detect it.
      */
-    private static final String FORCE_AWS_HARVESTER
+    public static final String FORCE_AWS_HARVESTER
         = "org.jitsi.videobridge.FORCE_AWS_HARVESTER";
 
     /**
@@ -74,7 +74,7 @@ public class HarvesterConfiguration
      * Setting this property enables searching for our public address using
      * the specified stun servers.
      */
-    private static final String STUN_MAPPING_HARVESTER_ADDRESSES
+    public static final String STUN_MAPPING_HARVESTER_ADDRESSES
         = "org.jitsi.videobridge.STUN_MAPPING_HARVESTER_ADDRESSES";
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -62,7 +62,7 @@ public class Videobridge
      * options passed as the second argument to
      * {@link #handleColibriConferenceIQ(ColibriConferenceIQ, int)}.
      */
-    private static final String DEFAULT_OPTIONS_PROPERTY_NAME
+    public static final String DEFAULT_OPTIONS_PROPERTY_NAME
         = "org.jitsi.videobridge.defaultOptions";
 
     /**
@@ -75,7 +75,7 @@ public class Videobridge
     * The name of the property which specifies the path to the directory in
     * which media recordings will be stored.
     */
-    static final String ENABLE_MEDIA_RECORDING_PNAME
+    public static final String ENABLE_MEDIA_RECORDING_PNAME
         = "org.jitsi.videobridge.ENABLE_MEDIA_RECORDING";
 
     /**
@@ -88,14 +88,14 @@ public class Videobridge
      * The name of the property which controls whether media recording is
      * enabled.
      */
-    static final String MEDIA_RECORDING_PATH_PNAME
+    public static final String MEDIA_RECORDING_PATH_PNAME
         = "org.jitsi.videobridge.MEDIA_RECORDING_PATH";
 
     /**
      * The name of the property which specifies the token used to authenticate
      * requests to enable media recording.
      */
-    static final String MEDIA_RECORDING_TOKEN_PNAME
+    public static final String MEDIA_RECORDING_TOKEN_PNAME
         = "org.jitsi.videobridge.MEDIA_RECORDING_TOKEN";
 
     /**
@@ -138,7 +138,7 @@ public class Videobridge
      * shutdown mode. For XMPP API this is "from" JID. In case of REST
      * the source IP is being copied into the "from" field of the IQ.
      */
-    static final String SHUTDOWN_ALLOWED_SOURCE_REGEXP_PNAME
+    public static final String SHUTDOWN_ALLOWED_SOURCE_REGEXP_PNAME
         = "org.jitsi.videobridge.shutdown.ALLOWED_SOURCE_REGEXP";
 
     /**
@@ -146,7 +146,7 @@ public class Videobridge
      * For XMPP API this is "from" JID. In case of REST the source IP is being
      * copied into the "from" field of the IQ.
      */
-    static final String AUTHORIZED_SOURCE_REGEXP_PNAME
+    public static final String AUTHORIZED_SOURCE_REGEXP_PNAME
         = "org.jitsi.videobridge.AUTHORIZED_SOURCE_REGEXP";
 
     /**


### PR DESCRIPTION
This is a fix for https://github.com/jitsi/jitsi-videobridge/issues/347

When using a constant to refer to a property, this is typically done to avoid typos and add configuration. Keeping such constants non-public is counterproductive, as it forces people to revert to manually typing the property name (and typically hides javadoc).

Constants that are used to store property names should be publicly accessible.