### PR TITLE
Config to turn on/off /colibri/* REST API endpoints

### DIFF
--- a/doc/http.md
+++ b/doc/http.md
@@ -24,3 +24,9 @@ org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePassword=changeit
 following to jvb config in etc:
 JVB_OPTS="--apis=rest,xmpp"
 AUTHBIND=yes
+
+It's also possible to disable the Colibri REST API endpoints with:
+
+```
+org.jitsi.videobridge.ENABLE_REST_COLIBRI=false
+```

--- a/src/main/java/org/jitsi/videobridge/rest/HandlerImpl.java
+++ b/src/main/java/org/jitsi/videobridge/rest/HandlerImpl.java
@@ -238,6 +238,13 @@ class HandlerImpl
     private final boolean shutdownEnabled;
 
     /**
+     * Indicates if /colibri/* REST endpoints are enabled. If not then 
+     * SC_SERVICE_UNAVAILABLE status will be returned for 
+     * {@link #COLIBRI_TARGET} requests.
+     */
+    private final boolean colibriEnabled;
+
+    /**
      * Initializes a new {@code HandlerImpl} instance within a specific
      * {@code BundleContext}.
      *
@@ -245,8 +252,11 @@ class HandlerImpl
      * instance is to be initialized
      * @param enableShutdown {@code true} if graceful shutdown is to be
      * enabled; otherwise, {@code false}
+     * @param enableColibri {@code true} if /colibri/* endpoints are to be 
+     * enabled; otherwise, {@code false}
      */
-    public HandlerImpl(BundleContext bundleContext, boolean enableShutdown)
+    public HandlerImpl(BundleContext bundleContext, boolean enableShutdown,
+        boolean enableColibri)
     {
         super(bundleContext);
 
@@ -254,6 +264,11 @@ class HandlerImpl
 
         if (shutdownEnabled)
             logger.info("Graceful shutdown over REST is enabled");
+        
+        colibriEnabled = enableColibri;
+
+        if (colibriEnabled)
+            logger.info("Colibri REST endpoints are enabled");
     }
 
     /**
@@ -848,6 +863,12 @@ class HandlerImpl
         throws IOException,
                ServletException
     {
+        if (!colibriEnabled)
+        {
+          response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+          return;
+        }
+
         if (target == null)
         {
             // TODO Auto-generated method stub

--- a/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
+++ b/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
@@ -51,6 +51,13 @@ public class RESTBundleActivator
     private static final String ENABLE_REST_SHUTDOWN_PNAME
         = "org.jitsi.videobridge.ENABLE_REST_SHUTDOWN";
 
+    /**
+     * The name of the <tt>System</tt> and <tt>ConfigurationService</tt>
+     * boolean property which enables <tt>/colibri/*</tt> REST API endpoints.
+     */
+    private static final String ENABLE_REST_COLIBRI_PNAME
+      = "org.jitsi.videobridge.ENABLE_REST_COLIBRI";
+
     private static final String JETTY_PROXY_SERVLET_HOST_HEADER_PNAME
         = Videobridge.REST_API_PNAME + ".jetty.ProxyServlet.hostHeader";
 
@@ -121,7 +128,8 @@ public class RESTBundleActivator
         return
             new HandlerImpl(
                     bundleContext,
-                    getCfgBoolean(ENABLE_REST_SHUTDOWN_PNAME, false));
+                    getCfgBoolean(ENABLE_REST_SHUTDOWN_PNAME, false),
+                    getCfgBoolean(ENABLE_REST_COLIBRI_PNAME, true));
     }
 
     /**


### PR DESCRIPTION
This PR adds a new config (`org.jitsi.videobridge.ENABLE_REST_COLIBRI`) to turn on/off the `/colibri/*` REST API endpoints.
The default value for this Config is `true`, therefore the current behavior is maintained.

When setting `org.jitsi.videobridge.ENABLE_REST_COLIBRI` to `false`, it is possible to have the JVB to serve HTTP content without exposing the Colibri REST API endpoints.