### PR TITLE
logd() should log to debug, not info.

### DIFF
--- a/lib/logging.properties
+++ b/lib/logging.properties
@@ -8,7 +8,7 @@ net.java.sip.communicator.util.ScLogFormatter.programname=JVB
 
 .level=INFO
 
-org.jitsi.videobridge.xmpp.ComponentImpl.level=DEBUG
+org.jitsi.videobridge.xmpp.ComponentImpl.level=FINE
 
 # All of the INFO level logs from MediaStreamImpl are unnecessary in the context of jitsi-videobridge.
 org.jitsi.impl.neomedia.MediaStreamImpl.level=WARNING

--- a/lib/logging.properties
+++ b/lib/logging.properties
@@ -8,6 +8,8 @@ net.java.sip.communicator.util.ScLogFormatter.programname=JVB
 
 .level=INFO
 
+org.jitsi.videobridge.xmpp.ComponentImpl.level=DEBUG
+
 # All of the INFO level logs from MediaStreamImpl are unnecessary in the context of jitsi-videobridge.
 org.jitsi.impl.neomedia.MediaStreamImpl.level=WARNING
 

--- a/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java
+++ b/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java
@@ -90,7 +90,9 @@ public class ComponentImpl
      */
     private static void logd(String s)
     {
-        logger.info(s);
+        if ( logger.isDebugEnabled() ) {
+            logger.debug(s);
+        }
     }
 
     /**


### PR DESCRIPTION
The current implementation causes all XMPP traffic to be printed to INFO, instead of the intended DEBUG level. Verbosity should reduced.