### PR TITLE
Update callstats.io authentication to support shared secret and public/private keys

### DIFF
--- a/doc/callstats.md
+++ b/doc/callstats.md
@@ -3,8 +3,9 @@ in /etc/jitsi/videobridge/sip-communicator.properties
 
     # the callstats credentials
     io.callstats.sdk.CallStats.appId=
-    io.callstats.sdk.CallStats.keyId=
-    io.callstats.sdk.CallStats.keyPath=
+    io.callstats.sdk.CallStats.appSecret=
+    #io.callstats.sdk.CallStats.keyId=
+    #io.callstats.sdk.CallStats.keyPath=
 
     # the id of the videobridge
     io.callstats.sdk.CallStats.bridgeId=
@@ -13,6 +14,8 @@ in /etc/jitsi/videobridge/sip-communicator.properties
     org.jitsi.videobridge.ENABLE_STATISTICS=true
     org.jitsi.videobridge.STATISTICS_INTERVAL.callstats.io=30000
     org.jitsi.videobridge.STATISTICS_TRANSPORT=callstats.io
+
+Callstats.io supports authentication via shared secret and public/private keys.
 
 You can use [pem-to-jwk](https://www.npmjs.com/package/pem-to-jwk) to convert PEM encoded EC private key to JWK.  
 To generate a jwk file that needs to be supplied as

--- a/doc/callstats.md
+++ b/doc/callstats.md
@@ -3,9 +3,9 @@ in /etc/jitsi/videobridge/sip-communicator.properties
 
     # the callstats credentials
     io.callstats.sdk.CallStats.appId=
-    io.callstats.sdk.CallStats.appSecret=
-    #io.callstats.sdk.CallStats.keyId=
-    #io.callstats.sdk.CallStats.keyPath=
+    io.callstats.sdk.CallStats.keyId=
+    io.callstats.sdk.CallStats.keyPath=
+    #io.callstats.sdk.CallStats.appSecret=
 
     # the id of the videobridge
     io.callstats.sdk.CallStats.bridgeId=

--- a/src/main/java/org/jitsi/videobridge/stats/CallStatsIOTransport.java
+++ b/src/main/java/org/jitsi/videobridge/stats/CallStatsIOTransport.java
@@ -261,19 +261,19 @@ public class CallStatsIOTransport
             cfg, PNAME_CALLSTATS_IO_BRIDGE_ID, DEFAULT_BRIDGE_ID);
         
         /**
-         * prefer appSecret over keyId/keyPath
+         * prefer keyId/keyPath over appSecret
          */
-        if(appSecret == null)
+        if(keyId == null || keyPath == null)
         {
-            logger.warn("appSecret missing, will try using keyId and keyPath");
+            logger.warn("KeyID/keyPath missing, will try using appSecret");
 
-            if(keyId == null || keyPath == null)
+            if(appSecret == null)
             {
-                logger.warn("KeyID/keyPath missing. Skipping callstats init");
+                logger.warn("appSecret missing. Skipping callstats init");
                 return;
             }
         }
-
+        
         ServerInfo serverInfo = createServerInfo(bundleContext);
 
         final CallStats callStats = new CallStats();
@@ -306,16 +306,7 @@ public class CallStatsIOTransport
                     }
                 };
 
-        if(appSecret != null)
-        {
-            callStats.initialize(
-                    appId,
-                    appSecret, 
-                    bridgeId, 
-                    serverInfo, 
-                    callStatsInitListener);
-        }
-        else
+        if(keyId != null && keyPath != null)
         {
             callStats.initialize(
                     appId,
@@ -323,6 +314,15 @@ public class CallStatsIOTransport
                             String.valueOf(appId), keyId, bridgeId, keyPath),
                     bridgeId,
                     serverInfo,
+                    callStatsInitListener);
+        }
+        else
+        {
+            callStats.initialize(
+                    appId,
+                    appSecret, 
+                    bridgeId, 
+                    serverInfo, 
                     callStatsInitListener);
         }
     }


### PR DESCRIPTION
Support both shared secret and public/private keys. 
If both are set, prefer shared secret (callstats.io default).