### PR TITLE
Reduce synchronization

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Channel.java
+++ b/src/main/java/org/jitsi/videobridge/Channel.java
@@ -711,17 +711,26 @@ public abstract class Channel
             Endpoint newValue
                 = getContent().getConference()
                         .getOrCreateEndpoint(newEndpointId);
-
-            if (oldValue != newValue)
-            {
-                this.endpoint = newValue;
-
-                onEndpointChanged(oldValue, newValue);
-            }
+            setEndpoint(newValue);
         }
         finally
         {
             touch(); // It seems this Channel is still active.
+        }
+    }
+
+    /**
+     * Sets the {@link Endpoint} of this {@link Channel} to a particular
+     * instance.
+     * @param endpoint the new {@link Endpoint} instance.
+     */
+    public void setEndpoint(Endpoint endpoint)
+    {
+        Endpoint oldEndpoint = this.endpoint;
+        if (oldEndpoint != endpoint)
+        {
+            this.endpoint = endpoint;
+            onEndpointChanged(oldEndpoint, endpoint);
         }
     }
 

--- a/src/main/java/org/jitsi/videobridge/Channel.java
+++ b/src/main/java/org/jitsi/videobridge/Channel.java
@@ -684,13 +684,13 @@ public abstract class Channel
     }
 
     /**
-     * Sets the identifier of the endpoint of the conference participant
+     * Sets the identifier of the newEndpointId of the conference participant
      * associated with this <tt>Channel</tt>.
      *
-     * @param endpoint the identifier of the endpoint of the conference
+     * @param newEndpointId the identifier of the newEndpointId of the conference
      * participant associated with this <tt>Channel</tt>
      */
-    public void setEndpoint(String endpoint)
+    public void setEndpoint(String newEndpointId)
     {
         try
         {
@@ -699,17 +699,18 @@ public abstract class Channel
             // Is the endpoint really changing?
             if (oldValue == null)
             {
-                if (endpoint == null)
+                if (newEndpointId == null)
                     return;
             }
-            else if (oldValue.getID().equals(endpoint))
+            else if (oldValue.getID().equals(newEndpointId))
             {
                 return;
             }
 
             // The endpoint is really changing.
             Endpoint newValue
-                = getContent().getConference().getOrCreateEndpoint(endpoint);
+                = getContent().getConference()
+                        .getOrCreateEndpoint(newEndpointId);
 
             if (oldValue != newValue)
             {

--- a/src/main/java/org/jitsi/videobridge/SctpConnection.java
+++ b/src/main/java/org/jitsi/videobridge/SctpConnection.java
@@ -254,7 +254,7 @@ public class SctpConnection
 
         logger
             = Logger.getLogger(classLogger, content.getConference().getLogger());
-        setEndpoint(endpoint.getID());
+        setEndpoint(endpoint);
         packetQueue
             = new RawPacketQueue(
                 false,


### PR DESCRIPTION
Avoids obtaining two locks in Content#createSctpConnection.