### PR TITLE
Provide more info when the data channel transfer fails

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -294,8 +294,9 @@ public class Conference
      * a message originating from the bridge and being sent to all endpoints in
      * the call, for that see broadcastMessageOnDataChannels below
      *
-     * @param msg
-     * @param endpoints
+     * @param msg the message to be sent
+     * @param endpoints the list of <tt>Endpoint</tt>s to which the message will
+     * be sent.
      */
     public void sendMessageOnDataChannels(String msg, List<Endpoint> endpoints)
     {
@@ -307,7 +308,9 @@ public class Conference
             }
             catch (IOException e)
             {
-                logger.error("Failed to send message on data channel.", e);
+                logger.error(
+                    "Failed to send message on data channel to: "
+                        + endpoint.getID() + ", msg: " + msg, e);
             }
         }
     }
@@ -1500,7 +1503,9 @@ public class Conference
                     }
                     catch (IOException e)
                     {
-                        logger.error("Failed to send message on data channel.",
+                        logger.error(
+                                "Failed to send dominant speaker update"
+                                    + " on data channel to " + endpoint.getID(),
                                 e);
                     }
                 }

--- a/src/main/java/org/jitsi/videobridge/EndpointConnectionStatus.java
+++ b/src/main/java/org/jitsi/videobridge/EndpointConnectionStatus.java
@@ -352,8 +352,10 @@ public class EndpointConnectionStatus
         }
         else
         {
-            logger.warn("Attempt to send connectivity status update for " +
-                    "endpoint without parent conference instance(expired?)");
+            logger.warn(
+                    "Attempt to send connectivity status update for"
+                        + " endpoint " + subjectEndpoint.getID()
+                        + " without parent conference instance (expired?)");
         }
     }
 

--- a/src/main/java/org/jitsi/videobridge/SctpConnection.java
+++ b/src/main/java/org/jitsi/videobridge/SctpConnection.java
@@ -722,10 +722,20 @@ public class SctpConnection
     {
         synchronized (syncRoot)
         {
-            if (logger.isDebugEnabled())
+            //if (logger.isDebugEnabled())
+            //{
+            // FIXME restore back to debug
+            //       once we fix the problem with SCTP connection being dropped
+            Endpoint endpoint = getEndpoint();
+            String endpointId = endpoint != null ? endpoint.getID() : "?";
+            // SCTP_SENDER_DRY_EVENT is logged too often. It means that the data
+            // queue is now empty and we don't care.
+            if (SctpNotification.SCTP_SENDER_DRY_EVENT != notification.sn_type)
             {
-                logger.debug(
-                        "socket=" + socket + "; notification=" + notification);
+                logger.info(
+                        "SCTP[ID=" + getID()
+                            + ", endpoint=" + endpointId
+                            + "; notification=" + notification);
             }
 
             switch (notification.sn_type)

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -471,7 +471,9 @@ public class VideoChannel
             }
             catch (IOException ex)
             {
-                logger.error("Failed to send message on data channel.", ex);
+                logger.error(
+                        "Failed to send \"in last-N\" update to: "
+                            + endpoint.getID(), ex);
             }
         }
     }


### PR DESCRIPTION
More details about the message and Endpoint will be logged when SCTP transfer fails. Also SCTP stack events will be logged.