### PR TITLE
fix: Request keyframes from last-n endpoints for newly joined video channels

### DIFF
--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -610,11 +610,14 @@ public class VideoChannel
             if (lastNController.getLastN() >= 0 ||
                     lastNController.getCurrentLastN() >= 0)
             {
+                final List<String> forwardedEndpoints =
+                        lastNController.getForwardedEndpoints();
                 lastNController.initializeConferenceEndpoints();
                 sendLastNEndpointsChangeEventOnDataChannel(
-                        lastNController.getForwardedEndpoints(),
+                        forwardedEndpoints,
                         null,
                         null);
+                getContent().askForKeyframesById(forwardedEndpoints);
             }
 
             updateInLastN(this);


### PR DESCRIPTION
As users join a meeting with last-n enabled they need to request
keyframes from the currently forwarded endpoints in order to
begin receiving video. Prior to this change a user joining the
meeting, that did not result in an update to the last-n endpoints,
would not receive keyframes for the forwarded endpoints. The
result was the newly joined user being unable to display video
until a dominant speaker event, pinned endpoint event, or
the next keyframe interval occurred.