### PR TITLE
implement configuration for custom channel and conference ids

### DIFF
--- a/doc/rest-videobridge.md
+++ b/doc/rest-videobridge.md
@@ -11,12 +11,12 @@ Implementation
 		<td>GET</td>
 		<td>/colibri/conferences</td>
 		<td>
-			200 OK with a JSON array/list of JSON objects which represent conferences with id only.<br /> 
-			For example: 
+			200 OK with a JSON array/list of JSON objects which represent conferences with id only.<br />
+			For example:
 <pre>
-[ 
-	{ "id" : "a1b2c3" }, 
-	{ "id" : "d4e5f6" } 
+[
+	{ "id" : "a1b2c3" },
+	{ "id" : "d4e5f6" }
 ]</pre>
 		</td>
 	</tr>
@@ -27,45 +27,47 @@ Implementation
 			200 OK with a JSON object which represents the created conference if the request was with Content-Type: application/json and was a JSON object which represented a conference without id and, optionally, with contents and channels without ids. <br />
 			For example, a request could look like:
 			<pre>
-{ 
-	"contents" : 
-	[ 
+{
+    "name" : "myConferenceName",
+	"contents" :
+	[
 		{
-			 "name" : "audio", 
-			 "channels" : [ { "expire" : 60 } ] 
-		}, 
-		{ 
-			"name" : "video", 
-			"channels" : [ { "expire" : 60 } ] 
-		} 
-	] 
+			 "name" : "audio",
+			 "channels" : [ { "expire" : 60 } ]
+		},
+		{
+			"name" : "video",
+			"channels" : [ { "expire" : 60 } ]
+		}
+	]
 }</pre>
 
 The respective response could look like:
 <pre>
-{ 
-	"id" : "conference1", 
-	"contents" : 
-		[ 
-			{ 
-				"name" : "audio", 
-				"channels" : 
+{
+	"id" : "conference1",
+	"name" : "myConferenceName",
+	"contents" :
+		[
+			{
+				"name" : "audio",
+				"channels" :
 					[
-						 { "id" : "channelA" }, 
-						 { "expire" : 60 }, 
-						 { "rtp-level-relay-type" : "translator" } 
+						 { "id" : "channelA" },
+						 { "expire" : 60 },
+						 { "rtp-level-relay-type" : "translator" }
 					 ]
-			 }, 
-			 { 
-			 	"name" : "video", 
-			 	"channels" : 
-			 		[ 
-			 			{ "id" : "channelV" }, 
-			 			{ "expire" : 60 }, 
-			 			{ "rtp-level-relay-type" : "translator" } 
-		 			] 
- 			} 
-		] 
+			 },
+			 {
+			 	"name" : "video",
+			 	"channels" :
+			 		[
+			 			{ "id" : "channelV" },
+			 			{ "expire" : 60 },
+			 			{ "rtp-level-relay-type" : "translator" }
+		 			]
+ 			}
+		]
 }</pre>
 		</td>
 	</tr>
@@ -74,31 +76,32 @@ The respective response could look like:
 		<td>/colibri/conferences{id}</td>
 		<td>
 			200 OK with a JSON object which represents the conference with the specified id. <br />
-			For example: 
+			For example:
 			<pre>
-{ 
-	"id" : "{id}", 
-	"contents" : 
-		[ 
-			{ 
-				"name" : "audio", 
-				"channels" : 
-					[ 
-						{ "id" : "channelA" }, 
-						{ "expire" : 60 }, 
-						{ "rtp-level-relay-type" : "translator" } 
-					] 
-			}, 
-			{ 
-				"name" : "video", 
-					"channels" : 
-						[ 
-							{ "id" : "channelV" }, 
-							{ "expire" : 60 }, 
-							{ "rtp-level-relay-type" : "translator" } 
-						] 
-			} 
-		] 
+{
+	"id" : "{id}",
+	"name" : "myConferenceName",
+	"contents" :
+		[
+			{
+				"name" : "audio",
+				"channels" :
+					[
+						{ "id" : "channelA" },
+						{ "expire" : 60 },
+						{ "rtp-level-relay-type" : "translator" }
+					]
+			},
+			{
+				"name" : "video",
+					"channels" :
+						[
+							{ "id" : "channelV" },
+							{ "expire" : 60 },
+							{ "rtp-level-relay-type" : "translator" }
+						]
+			}
+		]
 }</pre>
 		</td>
 	</tr>
@@ -140,17 +143,23 @@ Configuration
 
 **The following configuration properties can be added in the Jitsi Videobridge configuration file(HOME/.sip-communicator/sip-communicator.properties):**
 
- * **org.jitsi.videobridge.rest.jetty.port** - 
+ * **org.jitsi.videobridge.rest.jetty.port** -
  Specifies the port on which the REST API of Videobridge is to be served over HTTP. The default value is 8080.
- * **org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePassword** - 
+ * **org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePassword** -
  Specifies the keystore password to be utilized when the REST API of Videobridge is served over HTTPS.
- * **org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePath** - 
+ * **org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePath** -
  Specifies the keystore path to be utilized when the REST API of Videobridge is served over HTTPS.
- * **org.jitsi.videobridge.rest.jetty.sslContextFactory.needClientAuth** - 
+ * **org.jitsi.videobridge.rest.jetty.sslContextFactory.needClientAuth** -
  Specifies whether client certificate authentication is to be required when the REST API of Videobridge is served over HTTPS.
- * **org.jitsi.videobridge.rest.jetty.tls.port** - 
+ * **org.jitsi.videobridge.rest.jetty.tls.port** -
  Specifies the port on which the REST API of Videobridge is to be served over HTTPS. The default value is 8443.
-
+ * **org.jitsi.videobridge.useEndpointForChannelId** -
+ If set to true, videobridge will use the endpoint as the channel id when creating new channels. This is useful if you don't
+ want to have to maintain external mappings of channel ids to participants with a custom focus controller. Default
+ value is false
+ * **org.jitsi.videobridge.useNameForConferenceId** -
+ If set to true, videobridge will use the conference "name" value as the conference id. This is useful if you don't want to have
+ to maintain an external mapping to conference ids with a custom focus controller. Default value is false
 Example
 ==============
 
@@ -362,12 +371,12 @@ Post "[]" to <bridge_base_url>/colibri/conferences/
           "endpoint": "9f537ebb-1c2a-4ee9-9940-373304f9b260",
           "direction": "sendonly",
           "sources": [
-            
+
           ],
           "channel-bundle-id": "9f537ebb-1c2a-4ee9-9940-373304f9b260",
           "rtp-level-relay-type": "translator",
           "ssrc-groups": [
-            
+
           ],
           "payload-types": [
             {
@@ -406,7 +415,7 @@ Post "[]" to <bridge_base_url>/colibri/conferences/
           "channel-bundle-id": "9f537ebb-1c2a-4ee9-9940-373304f9b260",
           "rtp-level-relay-type": "translator",
           "ssrc-groups": [
-            
+
           ],
           "payload-types": [
             {
@@ -437,7 +446,7 @@ Post "[]" to <bridge_base_url>/colibri/conferences/
             }
           ],
           "rtp-hdrexts": [
-            
+
           ]
         }
       ]
@@ -461,7 +470,7 @@ Post "[]" to <bridge_base_url>/colibri/conferences/
       "id": "9f537ebb-1c2a-4ee9-9940-373304f9b260",
       "transport": {
         "candidates": [
-          
+
         ],
         "fingerprints": [
           {

--- a/src/main/java/org/jitsi/videobridge/Content.java
+++ b/src/main/java/org/jitsi/videobridge/Content.java
@@ -276,9 +276,18 @@ public class Content
         do
         {
             String id;
-            if(!StringUtils.isNullOrEmpty(endpointId)) {
+            if(!StringUtils.isNullOrEmpty(endpointId))
+            {
+                if (channels.containsKey(endpointId))
+                {
+                    throw new Exception(String.format("Cannot create channel " +
+                            "for endpoint %s, channel already exists",
+                            endpointId));
+                }
                 id = endpointId;
-            } else {
+            }
+            else
+            {
                 id = generateChannelID();
             }
 

--- a/src/main/java/org/jitsi/videobridge/Content.java
+++ b/src/main/java/org/jitsi/videobridge/Content.java
@@ -379,14 +379,29 @@ public class Content
             Endpoint endpoint,
             int sctpPort,
             String channelBundleId,
-            Boolean initiator)
+            Boolean initiator,
+            String endpointId)
         throws Exception
     {
         SctpConnection sctpConnection;
 
         synchronized (channels)
         {
-            String id = generateChannelID();
+            String id;
+            if(!StringUtils.isNullOrEmpty(endpointId))
+            {
+                if (channels.containsKey(endpointId))
+                {
+                    throw new Exception(String.format("Cannot create channel " +
+                                    "for endpoint %s, channel already exists",
+                            endpointId));
+                }
+                id = endpointId;
+            }
+            else
+            {
+                id = generateChannelID();
+            }
 
             sctpConnection
                 = new SctpConnection(id, this, endpoint, sctpPort,

--- a/src/main/java/org/jitsi/videobridge/Content.java
+++ b/src/main/java/org/jitsi/videobridge/Content.java
@@ -259,20 +259,28 @@ public class Content
      * @param initiator the value to use for the initiator field, or
      * <tt>null</tt> to use the default value.
      * @param rtpLevelRelayType
+     * @param endpointId the id of the endpoint this channel is for, if provided
+     * the endpoint id will be used as the channel id
      * @return the created <tt>RtpChannel</tt> instance.
      * @throws Exception
      */
     public RtpChannel createRtpChannel(String channelBundleId,
                                        String transportNamespace,
                                        Boolean initiator,
-                                       RTPLevelRelayType rtpLevelRelayType)
+                                       RTPLevelRelayType rtpLevelRelayType,
+                                       String endpointId)
         throws Exception
     {
         RtpChannel channel = null;
 
         do
         {
-            String id = generateChannelID();
+            String id;
+            if(!StringUtils.isNullOrEmpty(endpointId)) {
+                id = endpointId;
+            } else {
+                id = generateChannelID();
+            }
 
             synchronized (channels)
             {

--- a/src/main/java/org/jitsi/videobridge/Content.java
+++ b/src/main/java/org/jitsi/videobridge/Content.java
@@ -275,24 +275,24 @@ public class Content
 
         do
         {
-            String id;
-            if(!StringUtils.isNullOrEmpty(endpointId))
-            {
-                if (channels.containsKey(endpointId))
-                {
-                    throw new Exception(String.format("Cannot create channel " +
-                            "for endpoint %s, channel already exists",
-                            endpointId));
-                }
-                id = endpointId;
-            }
-            else
-            {
-                id = generateChannelID();
-            }
-
             synchronized (channels)
             {
+                String id;
+                if(!StringUtils.isNullOrEmpty(endpointId))
+                {
+                    if (channels.containsKey(endpointId))
+                    {
+                        throw new Exception(String.format("Cannot create channel " +
+                                        "for endpoint %s, channel already exists",
+                                endpointId));
+                    }
+                    id = endpointId;
+                }
+                else
+                {
+                    id = generateChannelID();
+                }
+
                 if (!channels.containsKey(id))
                 {
                     switch (getMediaType())

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -103,14 +103,14 @@ public class Videobridge
      * endpoint for the channel id
      */
     public static final String USE_ENDPOINT_FOR_CHANNEL_ID
-            = "org.jitsi.videobridge.useEndpointForChannelId";
+            = "org.jitsi.videobridge.USE_ENDPOINT_FOR_CHANNEL_ID";
 
     /**
      * If a name is provided at time of conference creation
      * use the name for the conference id
      */
     public static final String USE_NAME_FOR_CONFERENCE_ID
-            = "org.jitsi.videobridge.useNameForConferenceId";
+            = "org.jitsi.videobridge.USE_NAME_FOR_CONFERENCE_ID";
 
     /**
      * The optional flag which specifies to
@@ -257,8 +257,11 @@ public class Videobridge
      * @param name world readable name of the conference to create.
      * @return a new <tt>Conference</tt> instance with an ID unique to the
      * <tt>Conference</tt> instances listed by this <tt>Videobridge</tt>
+     * @throws Exception throws an exception if a conference already
+     * exists by the name that is provided and the configuration is set to
+     * use the name as the id
      */
-    public Conference createConference(String focus, String name)
+    public Conference createConference(String focus, String name) throws Exception
     {
         return this.createConference(focus, name, /* enableLogging */ true);
     }
@@ -281,18 +284,30 @@ public class Videobridge
      * the {@link Conference}.
      * @return a new <tt>Conference</tt> instance with an ID unique to the
      * <tt>Conference</tt> instances listed by this <tt>Videobridge</tt>
+     * @throws Exception throws an exception if a conference already
+     * exists by the name that is provided and the configuration is set to
+     * use the name as the id
      */
     public Conference createConference(
-        String focus, String name, boolean enableLogging)
+        String focus, String name, boolean enableLogging) throws Exception
     {
         Conference conference = null;
 
         do
         {
             String id;
-            if(useNameForConferenceId && !StringUtils.isNullOrEmpty(name)) {
+            if(useNameForConferenceId && !StringUtils.isNullOrEmpty(name))
+            {
+                if (conferences.containsKey(name))
+                {
+                    throw new Exception(String.format("Cannot create " +
+                            "conference, conference already exists by id:" +
+                            " %s", name));
+                }
                 id = name;
-            } else {
+            }
+            else
+            {
                 id = generateConferenceID();
             }
 

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -1059,7 +1059,8 @@ public class Videobridge
                                     endpoint,
                                     sctpPort,
                                     channelBundleId,
-                                    sctpConnIq.isInitiator());
+                                    sctpConnIq.isInitiator(),
+                                useEndpointForChannelId ? sctpConnIq.getEndpoint() : null);
                         if (sctpConn == null)
                         {
                             return IQUtils.createError(

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -99,6 +99,20 @@ public class Videobridge
         = "org.jitsi.videobridge.MEDIA_RECORDING_TOKEN";
 
     /**
+     * If an endpoint is provided at time of channel creation, use the
+     * endpoint for the channel id
+     */
+    public static final String USE_ENDPOINT_FOR_CHANNEL_ID
+            = "org.jitsi.videobridge.useEndpointForChannelId";
+
+    /**
+     * If a name is provided at time of conference creation
+     * use the name for the conference id
+     */
+    public static final String USE_NAME_FOR_CONFERENCE_ID
+            = "org.jitsi.videobridge.useNameForConferenceId";
+
+    /**
      * The optional flag which specifies to
      * {@link #handleColibriConferenceIQ(ColibriConferenceIQ, int)} that
      * <tt>ColibriConferenceIQ</tt>s can be accessed by any peer(not only by the
@@ -192,6 +206,18 @@ public class Videobridge
     private int defaultProcessingOptions;
 
     /**
+     * If an endpoint is provided at time of channel creation, use the
+     * endpoint for the channel id
+     */
+    private boolean useEndpointForChannelId = false;
+
+    /**
+     * If a name is provided at time of conference creation
+     * use the name for the conference id
+     */
+    private boolean useNameForConferenceId = false;
+
+    /**
      * Indicates if this bridge instance has entered graceful shutdown mode.
      */
     private boolean shutdownInProgress;
@@ -263,7 +289,12 @@ public class Videobridge
 
         do
         {
-            String id = generateConferenceID();
+            String id;
+            if(useNameForConferenceId && !StringUtils.isNullOrEmpty(name)) {
+                id = name;
+            } else {
+                id = generateConferenceID();
+            }
 
             synchronized (conferences)
             {
@@ -794,7 +825,8 @@ public class Videobridge
                                 channelBundleId,
                                 transportNamespace,
                                 channelIQ.isInitiator(),
-                                channelIQ.getRTPLevelRelayType());
+                                channelIQ.getRTPLevelRelayType(),
+                            useEndpointForChannelId ? channelIQ.getEndpoint() : null);
 
                     if (channel == null)
                     {
@@ -1331,6 +1363,12 @@ public class Videobridge
             = ServiceUtils2.getService(
                     bundleContext,
                     ConfigurationService.class);
+
+        useEndpointForChannelId = (cfg != null) &&
+                cfg.getBoolean(USE_ENDPOINT_FOR_CHANNEL_ID, false);
+
+        useNameForConferenceId = (cfg != null) &&
+                cfg.getBoolean(USE_NAME_FOR_CONFERENCE_ID, false);
 
         defaultProcessingOptions
             = (cfg == null)

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -295,24 +295,24 @@ public class Videobridge
 
         do
         {
-            String id;
-            if(useNameForConferenceId && !StringUtils.isNullOrEmpty(name))
-            {
-                if (conferences.containsKey(name))
-                {
-                    throw new Exception(String.format("Cannot create " +
-                            "conference, conference already exists by id:" +
-                            " %s", name));
-                }
-                id = name;
-            }
-            else
-            {
-                id = generateConferenceID();
-            }
-
             synchronized (conferences)
             {
+                String id;
+                if(useNameForConferenceId && !StringUtils.isNullOrEmpty(name))
+                {
+                    if (conferences.containsKey(name))
+                    {
+                        throw new Exception(String.format("Cannot create " +
+                                "conference, conference already exists by id:" +
+                                " %s", name));
+                    }
+                    id = name;
+                }
+                else
+                {
+                    id = generateConferenceID();
+                }
+
                 if (!conferences.containsKey(id))
                 {
                     conference

--- a/src/main/java/org/jitsi/videobridge/health/Health.java
+++ b/src/main/java/org/jitsi/videobridge/health/Health.java
@@ -41,7 +41,7 @@ public class Health
      * The {@link MediaType}s of {@link RtpChannel}s supported by
      * {@link Videobridge}. For example, {@link MediaType#DATA} is not supported
      * by {@link
-     * Content#createRtpChannel(String, String, Boolean, RTPLevelRelayType)}.
+     * Content#createRtpChannel(String, String, Boolean, RTPLevelRelayType, String)}.
      */
     private static final MediaType[] MEDIA_TYPES
         = { MediaType.AUDIO, MediaType.VIDEO };
@@ -61,7 +61,7 @@ public class Health
      * {@code Videobridge} to check the health (status) of
      * @throws Exception if an error occurs while checking the health (status)
      * of the {@code videobridge} associated with {@code conference} or the
-     * check determines that the {@code Videobridge} is not healthy 
+     * check determines that the {@code Videobridge} is not healthy
      */
     private static void check(Conference conference)
         throws Exception
@@ -98,7 +98,8 @@ public class Health
                             channelBundleId,
                             /* transportNamespace */ null,
                             initiator,
-                            null);
+                            null,
+                            endpoint.getID());
 
                 // Fail as quickly as possible.
                 if (rtpChannel == null)
@@ -135,7 +136,7 @@ public class Health
      * of
      * @throws Exception if an error occurs while checking the health (status)
      * of {@code videobridge} or the check determines that {@code videobridge}
-     * is not healthy 
+     * is not healthy
      */
     public static void check(Videobridge videobridge)
         throws Exception

--- a/src/main/java/org/jitsi/videobridge/health/Health.java
+++ b/src/main/java/org/jitsi/videobridge/health/Health.java
@@ -114,7 +114,8 @@ public class Health
                         endpoint,
                         /* sctpPort */ RANDOM.nextInt(),
                         channelBundleId,
-                        initiator);
+                        initiator,
+                        endpoint.getID());
 
             // Fail as quickly as possible.
             if (sctpConnection == null)

--- a/src/main/java/org/jitsi/videobridge/rest/JSONDeserializer.java
+++ b/src/main/java/org/jitsi/videobridge/rest/JSONDeserializer.java
@@ -346,6 +346,7 @@ final class JSONDeserializer
         else
         {
             Object id = conference.get(ColibriConferenceIQ.ID_ATTR_NAME);
+            Object name = conference.get(ColibriConferenceIQ.NAME_ATTR_NAME);
             Object contents = conference.get(JSONSerializer.CONTENTS);
             Object channelBundles
                 = conference.get(JSONSerializer.CHANNEL_BUNDLES);
@@ -362,6 +363,10 @@ final class JSONDeserializer
             // id
             if (id != null)
                 conferenceIQ.setID(id.toString());
+            // name
+            if (name != null) {
+                conferenceIQ.setName(name.toString());
+            }
             // contents
             if (contents != null)
                 deserializeContents((JSONArray) contents, conferenceIQ);

--- a/src/main/java/org/jitsi/videobridge/rest/JSONSerializer.java
+++ b/src/main/java/org/jitsi/videobridge/rest/JSONSerializer.java
@@ -146,7 +146,7 @@ final class JSONSerializer
             /*
              * The JSON.simple library that is in use at the time of this
              * writing will fail to encode Enum values as JSON strings so
-             * convert the Enum value to a Java String. 
+             * convert the Enum value to a Java String.
              */
             if (value instanceof Enum)
                 value = value.toString();
@@ -225,7 +225,7 @@ final class JSONSerializer
                 /*
                  * The JSON.simple library that is in use at the time of this
                  * writing will fail to encode Enum values as JSON strings so
-                 * convert the Enum value to a Java String. 
+                 * convert the Enum value to a Java String.
                  */
                 jsonObject.put(
                         ColibriConferenceIQ.Channel.DIRECTION_ATTR_NAME,
@@ -265,7 +265,7 @@ final class JSONSerializer
                 /*
                  * The JSON.simple library that is in use at the time of this
                  * writing will fail to encode Enum values as JSON strings so
-                 * convert the Enum value to a Java String. 
+                 * convert the Enum value to a Java String.
                  */
                 jsonObject.put(
                         ColibriConferenceIQ.Channel
@@ -440,6 +440,7 @@ final class JSONSerializer
         else
         {
             String id = conference.getID();
+            String name = conference.getName();
             List<ColibriConferenceIQ.Content> contents
                 = conference.getContents();
             List<ColibriConferenceIQ.ChannelBundle> channelBundles
@@ -451,6 +452,10 @@ final class JSONSerializer
             // id
             if (id != null)
                 jsonObject.put(ColibriConferenceIQ.ID_ATTR_NAME, id);
+            // name
+            if (name != null) {
+                jsonObject.put(ColibriConferenceIQ.NAME_ATTR_NAME, name);
+            }
             // contents
             if ((contents != null) && !contents.isEmpty())
                 jsonObject.put(CONTENTS, serializeContents(contents));


### PR DESCRIPTION
Allows custom ids to be used for conference and channel if the conference "name" attribute is set and the configuration property org.jitsi.videobridge.useNameForConferenceId is set to true. Allows the endpoint to be used as the channel id if the configuration property org.jitsi.videobridge.useEndpointForChannelId is set to true and endpoint is provided.

Also properly deserialize and serialize the name attribute of the conference.

Add documentation for new properties