### PR TITLE
Set a default lastActivityTime on Conference creation

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -272,6 +272,8 @@ public class Conference
                 = videobridge.getStatistics();
             videobridgeStatistics.totalConferencesCreated.incrementAndGet();
         }
+
+        touch();
     }
 
     /**


### PR DESCRIPTION
Summary:
Conferences have a default lastActivityTime of zero.
It could be possible for VideobridgeExpireThread
to run immediately after a conference is created,
thereby expiring the conference.