### PR TITLE
VP8 FIR and bitrate allocation fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-20170315.020639-260</version>
+      <version>1.0-20170316.220142-262</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/BitrateController.java
@@ -268,8 +268,7 @@ public class BitrateController
                         RTPEncodingDesc[] rtpEncodings
                             = allocation.track.getRTPEncodings();
 
-                        ctrl = new SimulcastController(
-                            allocation.track, 0, targetIdx, optimalIdx);
+                        ctrl = new SimulcastController(allocation.track);
 
                         // Route all encodings to the specified bitrate
                         // controller.

--- a/src/main/java/org/jitsi/videobridge/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/BitrateController.java
@@ -635,7 +635,7 @@ public class BitrateController
                 rates[i] = encodings[i].getLastStableBitrateBps();
             }
 
-            optimalIdx = selected ? encodings.length - 1 : 0;
+            optimalIdx = selected ? encodings.length - 1 : (forwarded ? 0 : -1);
         }
 
         /**


### PR DESCRIPTION
The VP8 FIR fixes are in LJ. This PR fixes an issue with the bitrate allocation algorithm where the optimal quality for endpoints outside the lastN set should be -1.