### PR TITLE
Splits the REST interface into a private and public part

### DIFF
--- a/doc/rest-colibri.md
+++ b/doc/rest-colibri.md
@@ -1,3 +1,11 @@
+Introduction
+==============
+
+This document describes the REST APIs and the JSON format used with
+the REST version of the [COLIBRI protocol](https://xmpp.org/extensions/xep-0340.html).
+
+See [this document](rest.md) for how to configure the HTTP(S) interfaces of jitsi-videobridge.
+
 Implementation
 ==============
 
@@ -133,23 +141,6 @@ The respective response could look like:
 		</td>
 	</tr>
 </table>
-
-Configuration
-==============
-**To enable the REST API you have to start Jitsi video bridge with parameter --apis=rest (or --apis=rest,xmpp to enable both REST and XMPP).**
-
-**The following configuration properties can be added in the Jitsi Videobridge configuration file(HOME/.sip-communicator/sip-communicator.properties):**
-
- * **org.jitsi.videobridge.rest.jetty.port** - 
- Specifies the port on which the REST API of Videobridge is to be served over HTTP. The default value is 8080.
- * **org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePassword** - 
- Specifies the keystore password to be utilized when the REST API of Videobridge is served over HTTPS.
- * **org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePath** - 
- Specifies the keystore path to be utilized when the REST API of Videobridge is served over HTTPS.
- * **org.jitsi.videobridge.rest.jetty.sslContextFactory.needClientAuth** - 
- Specifies whether client certificate authentication is to be required when the REST API of Videobridge is served over HTTPS.
- * **org.jitsi.videobridge.rest.jetty.tls.port** - 
- Specifies the port on which the REST API of Videobridge is to be served over HTTPS. The default value is 8443.
 
 Example
 ==============

--- a/doc/rest.md
+++ b/doc/rest.md
@@ -51,6 +51,23 @@ For both the _private_ and the _public_ interfaces:
  * ```org.jitsi.videobridge.rest.jetty.host``` - 
  Specifies the server host.
 
+Specific parts of the _public_ interface can be configured with the following additional properties:
+ ```
+ # Configure a proxy 
+ org.jitsi.videobridge.rest.jetty.ProxyServlet.hostHeader=example.com
+ org.jitsi.videobridge.rest.jetty.ProxyServlet.pathSpec=/http-bind
+ org.jitsi.videobridge.rest.jetty.ProxyServlet.proxyTo=http://localhost:5280/http-bind
+
+ # Configure serving of static content (tuned for jitsi-meet)
+ org.jitsi.videobridge.rest.jetty.ResourceHandler.resourceBase=/usr/share/jitsi-meet
+ org.jitsi.videobridge.rest.jetty.ResourceHandler.alias./config.js=/etc/jitsi/meet/example.com-config.js
+ org.jitsi.videobridge.rest.jetty.ResourceHandler.alias./interface_config.js=/usr/share/jitsi-meet/interface_config.js
+ org.jitsi.videobridge.rest.jetty.ResourceHandler.alias./logging_config.js=/usr/share/jitsi-meet/logging_config.js
+ org.jitsi.videobridge.rest.jetty.RewriteHandler.regex=^/([a-zA-Z0-9]+)$
+ org.jitsi.videobridge.rest.jetty.RewriteHandler.replacement=/
+ org.jitsi.videobridge.rest.jetty.SSIResourceHandler.paths=/
+ ```
+
 
 Examples
 ==============

--- a/doc/rest.md
+++ b/doc/rest.md
@@ -2,7 +2,8 @@ Introduction
 ==============
 Jitsi-videobridge supports two HTTP(S) interfaces, a _public_ and a _private_ one. 
 The two interfaces use different ports. The _private_ interface exposes
-HTTP endpoints which are not meant to be publicly accessible, such as:
+HTTP endpoints which are not meant to be publicly accessible (but might be used
+by other components of the infrastructure, e.g. a signaling server), such as:
 
 * The [COLIBRI control interface](rest-colibri.md) (```/colibri/```)
 * The health-check interface (```/about/health```)

--- a/doc/rest.md
+++ b/doc/rest.md
@@ -1,0 +1,86 @@
+Introduction
+==============
+Jitsi-videobridge supports two HTTP(S) interfaces, a _public_ and a _private_ one. 
+The two interfaces use different ports. The _private_ interface exposes
+HTTP endpoints which are not meant to be publicly accessible, such as:
+
+* The [COLIBRI control interface](rest-colibri.md) (```/colibri/```)
+* The health-check interface (```/about/health```)
+* The version interface (```/about/version```)
+
+The _public_ interface inludes:
+
+* Support for serving static files (e.g. the HTML/js for jitsi-meet)
+* Support for proxying (for e.g. proxying BOSH connections to a prosody instance)
+
+**For any of the HTTP interfaces to be enabled, jitsi-videobridge needs to be started with the ```--apis=rest```
+parameter (or ```--apis=rest,xmpp``` to also enable the XMPP interface to COLIBRI).** This is enough to enable the
+private interface, but for the public interface additional properties are required (see below).
+
+Configuration
+==============
+
+The following configuration properties can be added to the jitsi-videobridge configuration file to control the behaviour of the HTTP interfaces
+
+For the _private_ interface:
+
+ * ```org.jitsi.videobridge.rest.jetty.port``` - 
+ Specifies the port for the private HTTP interface (or -1 to disable it). The default value is ```8080```.
+ * ```org.jitsi.videobridge.rest.jetty.tls.port``` - 
+ Specifies the port for the private HTTP interface if TLS is to be used (or -1 to disable). The default value is ```8443```.
+ * ```org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePath``` - 
+ Specifies the path to the keystore to be used with HTTPS for the private interface. If this is not specified,
+ HTTPS is disabled for the private interface.
+ * ```org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePassword``` - 
+ Specifies the password for the keystore of the private HTTP interface.
+
+For the _public interface:
+ * ```org.jitsi.videobridge.rest.jetty.public.port``` - 
+ Specifies the port for the public HTTP interface (or -1 to disable it). The default value is ```-1```.
+ * ```org.jitsi.videobridge.rest.jetty.public.tls.port``` - 
+ Specifies the port for the public HTTP interface if TLS is to be used (or -1 to disable). The default value is ```-1```.
+ * ```org.jitsi.videobridge.rest.jetty.public.sslContextFactory.keyStorePath``` - 
+ Specifies the path to the keystore to be used with HTTPS for the public interface. If this is not specified, 
+ HTTPS is disabled for the public interface..
+ * ```org.jitsi.videobridge.rest.jetty.public.sslContextFactory.keyStorePassword``` - 
+ Specifies the password for the keystore of the public HTTP interface.
+
+For both the _private_ and the _public_ interfaces:
+ * ```org.jitsi.videobridge.rest.jetty.sslContextFactory.needClientAuth``` - 
+ Specifies whether client certificate authentication is to be required when HTTPS is enabled. The default value is ```false```.
+ * ```org.jitsi.videobridge.rest.jetty.host``` - 
+ Specifies the server host.
+
+
+Examples
+==============
+
+### Example 1
+Enable only the private interface with HTTP on the default port: no conifguration properties are required.
+
+### Example 2
+Enable only the private interface with HTTPS on port 4443:
+```
+org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePath=/path/to/keystore
+org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePassword=changeme
+org.jitsi.videobridge.rest.jetty.tls.port=4443
+```
+
+### Example 3
+Enable only the public interface with HTTP on port 80:
+```
+org.jitsi.videobridge.rest.jetty.port=-1 #disable the private interface
+org.jitsi.videobridge.rest.jetty.public.port=80
+```
+
+### Example 4
+Enable both the public and private interfaces with HTTPS (with the same certificate) 
+on ports 443 (public) and 8443 (private):
+```
+org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePath=/path/to/keystore
+org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePassword=changeme
+
+org.jitsi.videobridge.rest.jetty.public.tls.port=443
+org.jitsi.videobridge.rest.jetty.public.sslContextFactory.keyStorePath=/path/to/keystore
+org.jitsi.videobridge.rest.jetty.public.sslContextFactory.keyStorePassword=changeme
+```

--- a/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
+++ b/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
@@ -112,84 +112,100 @@ public class RESTBundleActivator
 
     /**
      * Initializes a new {@link Handler} instance which is to handle the
-     * &quot;/colibri&quot; target for a specific {@code Server} instance.
+     * &quot;/colibri&quot; target and adds it to the appropriate lists of
+     * handlers (specified in {@code privateHandlers} and
+     * {@code publicHandlers}) according to the desired public or private
+     * exposure.
      *
      * @param bundleContext the {@code BundleContext} in which the new instance
      * is to be initialized
-     * @param server the {@code Server} for which the new instance is to handle
-     * the &quot;/colibri&quot; target
-     * @return a new {@code Handler} instance which is to handle the
-     * &quot;/colibri&quot; target for {@code server}
+     * @param privateHandlers the list to which to add any newly initialized
+     * {@link Handler}s if they are to be accessible on the private
+     * interface/port, or {@code null} if the private interface is disabled and
+     * no handlers are to be initialized for it.
+     * @param publicHandlers the list to which to add any newly initialized
+     * {@link Handler}s if they are to be accessible on the public
+     * interface/port, or {@code null} if the public interface is disabled and
+     * no handlers are to be initialized for it.
      */
-    private Handler initializeColibriHandler(
+    private void initializeColibriHandlers(
             BundleContext bundleContext,
-            Server server)
+            List<Handler> privateHandlers,
+            List<Handler> publicHandlers)
     {
-        return
-            new HandlerImpl(
-                    bundleContext,
-                    getCfgBoolean(ENABLE_REST_SHUTDOWN_PNAME, false),
-                    getCfgBoolean(ENABLE_REST_COLIBRI_PNAME, true));
+        // The colibri control interface is private only.
+        if (privateHandlers != null)
+        {
+            privateHandlers.add(new HandlerImpl(
+                bundleContext,
+                getCfgBoolean(ENABLE_REST_SHUTDOWN_PNAME, false),
+                getCfgBoolean(ENABLE_REST_COLIBRI_PNAME, true)));
+        }
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected Handler initializeHandler(
+    protected Handler[] initializeHandlers(
             BundleContext bundleContext,
-            Server server)
+            Server privateServer,
+            Server publicServer)
         throws Exception
     {
         // The main content served by Server. It may include, for example, the
         // /colibri target of the REST API, purely static content, and
         // ProxyServlet.
-        Handler handler = super.initializeHandler(bundleContext, server);
+        Handler[] handlers
+            = super.initializeHandlers(
+                bundleContext, privateServer, publicServer);
 
-        // When handling requests, the main content may be superseded by
-        // RewriteHandler.
-        HandlerWrapper rewriteHandler
-            = initializeRewriteHandler(bundleContext, server);
-
-        if (rewriteHandler != null)
+        for (int i = 0; i < 2; i++)
         {
-            rewriteHandler.setHandler(handler);
-            handler = rewriteHandler;
+            if (handlers[i] != null)
+            {
+                // When handling requests, the main content may be superseded by
+                // RewriteHandler. Note that currently we use the same set of
+                // rules for both the private and public servers, but we
+                // create separate Handler instances, because it is not clear
+                // whether it is safe to share a Handler between two Servers.
+                HandlerWrapper wrapper = initializeRewriteHandler(bundleContext);
+                if (wrapper != null)
+                {
+                    wrapper.setHandler(handlers[i]);
+                    handlers[i] = wrapper;
+                }
+            }
         }
 
-        return handler;
+        return handlers;
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected Handler initializeHandlerList(
+    protected Handler[] initializeHandlerLists(
             BundleContext bundleContext,
-            Server server)
+            Server privateServer,
+            Server publicServer)
         throws Exception
     {
-        List<Handler> handlers = new ArrayList<>();
+        List<Handler> privateHandlers
+            = privateServer == null ? null : new ArrayList<Handler>();
+        List<Handler> publicHandlers
+            = publicServer == null ? null : new ArrayList<Handler>();
 
         // The /colibri target of the REST API.
-        Handler colibriHandler
-            = initializeColibriHandler(bundleContext, server);
-
-        if (colibriHandler != null)
-            handlers.add(colibriHandler);
+        initializeColibriHandlers(
+                bundleContext, privateHandlers, publicHandlers);
 
         // Purely static content.
-        Handler resourceHandler
-            = initializeResourceHandler(bundleContext, server);
+        initializeResourceHandler(
+                bundleContext, privateHandlers, publicHandlers);
 
-        if (resourceHandler != null)
-            handlers.add(resourceHandler);
-
-        Handler aliasHandler
-            = initializeResourceHandlerAliases(bundleContext, server);
-
-        if (aliasHandler != null)
-            handlers.add(aliasHandler);
+        initializeResourceHandlerAliases(
+                bundleContext, privateHandlers, publicHandlers);
 
         // ServletHandler to serve, for example, ProxyServlet.
 
@@ -197,13 +213,13 @@ public class RESTBundleActivator
         // they always mark HTTP Request as handled if it reaches a Servlet
         // regardless of whether the Servlet actually did anything.
         // Consequently, it is advisable to keep Servlets as the last Handler.
-        Handler servletHandler
-            = initializeServletHandler(bundleContext, server);
+        initializeServletHandler(bundleContext, privateHandlers, publicHandlers);
 
-        if (servletHandler != null)
-            handlers.add(servletHandler);
-
-        return initializeHandlerList(handlers);
+        return new Handler[]
+            {
+                initializeHandlerList(privateHandlers),
+                initializeHandlerList(publicHandlers)
+            };
     }
 
     /**
@@ -281,83 +297,109 @@ public class RESTBundleActivator
 
     /**
      * Initializes a new {@link Handler} instance which is to serve purely
-     * static content for a specific {@code Server} instance.
+     * static content and adds it to the appropriate lists of handlers
+     * (specified in {@code privateHandlers} and {@code publicHandlers})
+     * according to the desired public or private exposure.
      *
      * @param bundleContext the {@code BundleContext} in which the new instance
-     * is to be initialized
-     * @param server the {@code Server} for which the new instance is to serve
-     * purely static content
-     * @return a new {@code Handler} instance which is to serve purely static
-     * content for {@code server}
+     * is to be initialized.
+     * @param privateHandlers the list to which to add any newly initialized
+     * {@link Handler}s if they are to be accessible on the private
+     * interface/port, or {@code null} if the private interface is disabled and
+     * no handlers are to be initialized for it.
+     * @param publicHandlers the list to which to add any newly initialized
+     * {@link Handler}s if they are to be accessible on the public
+     * interface/port, or {@code null} if the public interface is disabled and
+     * no handlers are to be initialized for it.
      */
-    private Handler initializeResourceHandler(
+    private void initializeResourceHandler(
             BundleContext bundleContext,
-            Server server)
+            List<Handler> privateHandlers,
+            List<Handler> publicHandlers)
     {
-        String resourceBase
-            = getCfgString(JETTY_RESOURCE_HANDLER_RESOURCE_BASE_PNAME, null);
-        ContextHandler contextHandler;
-
-        if (resourceBase == null || resourceBase.length() == 0)
+        if (publicHandlers != null)
         {
-            contextHandler = null;
+            String resourceBase
+                = getCfgString(JETTY_RESOURCE_HANDLER_RESOURCE_BASE_PNAME,
+                               null);
+            ContextHandler contextHandler;
+
+            if (resourceBase == null || resourceBase.length() == 0)
+            {
+                contextHandler = null;
+            }
+            else
+            {
+                ResourceHandler resourceHandler = new SSIResourceHandler(cfg);
+
+                resourceHandler.setResourceBase(resourceBase);
+
+                // Enable alisases so we can handle symlinks.
+                contextHandler = new ContextHandler();
+                contextHandler.setHandler(resourceHandler);
+                contextHandler
+                    .addAliasCheck(new ContextHandler.ApproveAliases());
+            }
+
+            if (contextHandler != null)
+            {
+                publicHandlers.add(contextHandler);
+            }
         }
-        else
-        {
-            ResourceHandler resourceHandler = new SSIResourceHandler(cfg);
-
-            resourceHandler.setResourceBase(resourceBase);
-
-            // Enable alisases so we can handle symlinks.
-            contextHandler = new ContextHandler();
-            contextHandler.setHandler(resourceHandler);
-            contextHandler.addAliasCheck(new ContextHandler.ApproveAliases());
-        }
-
-        return contextHandler;
     }
 
     /**
      * Initializes a new {@link Handler} instance which is to serve purely
-     * static content for a specific {@code Server} instance and only the
-     * aliases configured.
+     * static content and adds it to the appropriate lists of handlers
+     * (specified in {@code privateHandlers} and {@code publicHandlers})
+     * according to the desired public or private exposure.
      *
      * @param bundleContext the {@code BundleContext} in which the new instance
-     * is to be initialized
-     * @param server the {@code Server} for which the new instance is to serve
-     * purely static content
-     * @return a new {@code Handler} instance which is to serve purely static
-     * content for {@code server}
+     * is to be initialized.
+     * @param privateHandlers the list to which to add any newly initialized
+     * {@link Handler}s if they are to be accessible on the private
+     * interface/port, or {@code null} if the private interface is disabled and
+     * no handlers are to be initialized for it.
+     * @param publicHandlers the list to which to add any newly initialized
+     * {@link Handler}s if they are to be accessible on the public
+     * interface/port, or {@code null} if the public interface is disabled and
+     * no handlers are to be initialized for it.
      */
-    private Handler initializeResourceHandlerAliases(
+    private void initializeResourceHandlerAliases(
             BundleContext bundleContext,
-            Server server)
+            List<Handler> privateHandlers,
+            List<Handler> publicHandlers)
     {
-        return
-            new ResourceHandler()
-            {
-                /**
-                 * Checks whether there is configured alias/link for the path
-                 * and, if there is, uses the configured value as resource to
-                 * return.
-                 *
-                 * @param path the path to check
-                 * @return the resource to server.
-                 * @throws MalformedURLException
-                 */
-                @Override
-                public Resource getResource(String path)
-                    throws MalformedURLException
+        if (publicHandlers != null)
+        {
+            publicHandlers.add(
+                new ResourceHandler()
                 {
-                    String value
-                        = getCfgString(
-                                JETTY_RESOURCE_HANDLER_ALIAS_PREFIX + "."
-                                    + path,
-                                null);
+                    /**
+                     * Checks whether there is configured alias/link for the
+                     * path and, if there is, uses the configured value as
+                     * resource to return.
+                     *
+                     * @param path the path to check
+                     * @return the resource to server.
+                     * @throws MalformedURLException
+                     */
+                    @Override
+                    public Resource getResource(String path)
+                        throws MalformedURLException
+                    {
+                        String value
+                            = getCfgString(
+                            JETTY_RESOURCE_HANDLER_ALIAS_PREFIX + "."
+                                + path,
+                            null);
 
-                    return (value == null) ? null : Resource.newResource(value);
+                        return (value == null) ? null : Resource
+                            .newResource(value);
+                    }
                 }
-            };
+            );
+        }
     }
 
     /**
@@ -367,16 +409,11 @@ public class RESTBundleActivator
      *
      * @param bundleContext the {@code BundleContext} in which the new instance
      * is to be initialized
-     * @param server the {@code Server} for which the new instance is to match
-     * requests against a set of rules and modify them accordingly for any rules
-     * that match
      * @return a new {@code HandlerWrapper} instance which is to match requests
      * against a set of rules and modify them accordingly for any rules that
      * match
      */
-    private HandlerWrapper initializeRewriteHandler(
-            BundleContext bundleContext,
-            Server server)
+    private HandlerWrapper initializeRewriteHandler(BundleContext bundleContext)
     {
         String regex = getCfgString(JETTY_REWRITE_HANDLER_REGEX_PNAME, null);
         RewriteHandler handler = null;
@@ -402,40 +439,51 @@ public class RESTBundleActivator
 
     /**
      * Initializes a new {@link ServletHandler} instance which is to map
-     * requests to servlets.
+     * requests to servlets, and adds it to the appropriate lists of
+     * handlers (specified in {@code privateHandlers} and
+     * {@code publicHandlers}) according to the desired public or private
+     * exposure.
      *
      * @param bundleContext the {@code BundleContext} in which the new instance
      * is to be initialized
-     * @param server the {@code Server} for which the new instance is to map
-     * requests to servlets
-     * @return a new {@code ServletHandler} instance which is to map requests to
-     * servlets for {@code server}
+     * @param privateHandlers the list to which to add any newly initialized
+     * {@link Handler}s if they are to be accessible on the private
+     * interface/port, or {@code null} if the private interface is disabled and
+     * no handlers are to be initialized for it.
+     * @param publicHandlers the list to which to add any newly initialized
+     * {@link Handler}s if they are to be accessible on the public
+     * interface/port, or {@code null} if the public interface is disabled and
+     * no handlers are to be initialized for it.
      */
-    private Handler initializeServletHandler(
+    private void initializeServletHandler(
             BundleContext bundleContext,
-            Server server)
+            List<Handler> privateHandlers,
+            List<Handler> publicHandlers)
     {
-        ServletHolder servletHolder;
-        ServletContextHandler servletContextHandler
-            = new ServletContextHandler();
-        boolean b = false;
+        // All of the current servlets need to be (only) publicly accessible
+        if (publicHandlers != null)
+        {
+            ServletHolder servletHolder;
+            ServletContextHandler servletContextHandler
+                = new ServletContextHandler();
+            boolean b = false;
 
-        // ProxyServletImpl i.e. http-bind.
-        servletHolder = initializeProxyServlet(servletContextHandler);
-        if (servletHolder != null)
-            b = true;
+            // ProxyServletImpl i.e. http-bind.
+            servletHolder = initializeProxyServlet(servletContextHandler);
+            if (servletHolder != null)
+                b = true;
 
-        // LongPollingServlet
-        servletHolder = initializeLongPollingServlet(servletContextHandler);
-        if (servletHolder != null)
-            b = true;
+            // LongPollingServlet
+            servletHolder = initializeLongPollingServlet(servletContextHandler);
+            if (servletHolder != null)
+                b = true;
 
-        if (b)
-            servletContextHandler.setContextPath("/");
-        else
-            servletContextHandler = null;
-
-        return servletContextHandler;
+            if (b)
+            {
+                servletContextHandler.setContextPath("/");
+                publicHandlers.add(servletContextHandler);
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
+++ b/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
@@ -99,10 +99,10 @@ public class RESTBundleActivator
     protected void doStop(BundleContext bundleContext)
         throws Exception
     {
-        if (server != null)
+        if (privateServer != null)
         {
             // FIXME graceful Jetty shutdown
-            // When shutdown request is accepted, empty response is sent back
+            // When a shutdown request is accepted, empty response is sent back
             // instead of 200, because Jetty is not being shutdown gracefully.
             Thread.sleep(1000);
         }

--- a/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
+++ b/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
@@ -48,26 +48,26 @@ public class RESTBundleActivator
      * boolean property which enables graceful shutdown through REST API.
      * It is disabled by default.
      */
-    private static final String ENABLE_REST_SHUTDOWN_PNAME
+    public static final String ENABLE_REST_SHUTDOWN_PNAME
         = "org.jitsi.videobridge.ENABLE_REST_SHUTDOWN";
 
     /**
      * The name of the <tt>System</tt> and <tt>ConfigurationService</tt>
      * boolean property which enables <tt>/colibri/*</tt> REST API endpoints.
      */
-    private static final String ENABLE_REST_COLIBRI_PNAME
+    public static final String ENABLE_REST_COLIBRI_PNAME
       = "org.jitsi.videobridge.ENABLE_REST_COLIBRI";
 
-    private static final String JETTY_PROXY_SERVLET_HOST_HEADER_PNAME
+    public static final String JETTY_PROXY_SERVLET_HOST_HEADER_PNAME
         = Videobridge.REST_API_PNAME + ".jetty.ProxyServlet.hostHeader";
 
-    private static final String JETTY_PROXY_SERVLET_PATH_SPEC_PNAME
+    public static final String JETTY_PROXY_SERVLET_PATH_SPEC_PNAME
         = Videobridge.REST_API_PNAME + ".jetty.ProxyServlet.pathSpec";
 
-    private static final String JETTY_PROXY_SERVLET_PROXY_TO_PNAME
+    public static final String JETTY_PROXY_SERVLET_PROXY_TO_PNAME
         = Videobridge.REST_API_PNAME + ".jetty.ProxyServlet.proxyTo";
 
-    private static final String JETTY_RESOURCE_HANDLER_RESOURCE_BASE_PNAME
+    public static final String JETTY_RESOURCE_HANDLER_RESOURCE_BASE_PNAME
         = Videobridge.REST_API_PNAME + ".jetty.ResourceHandler.resourceBase";
 
     /**
@@ -78,10 +78,10 @@ public class RESTBundleActivator
     public static final String JETTY_RESOURCE_HANDLER_ALIAS_PREFIX
         = Videobridge.REST_API_PNAME + ".jetty.ResourceHandler.alias";
 
-    private static final String JETTY_REWRITE_HANDLER_REGEX_PNAME
+    public static final String JETTY_REWRITE_HANDLER_REGEX_PNAME
         = Videobridge.REST_API_PNAME + ".jetty.RewriteHandler.regex";
 
-    private static final String JETTY_REWRITE_HANDLER_REPLACEMENT_PNAME
+    public static final String JETTY_REWRITE_HANDLER_REPLACEMENT_PNAME
         = Videobridge.REST_API_PNAME + ".jetty.RewriteHandler.replacement";
 
     /**

--- a/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
+++ b/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
@@ -160,7 +160,7 @@ public class RESTBundleActivator
             = super.initializeHandlers(
                 bundleContext, privateServer, publicServer);
 
-        for (int i = 0; i < 2; i++)
+        for (int i = 0; i < handlers.length; i++)
         {
             if (handlers[i] != null)
             {


### PR DESCRIPTION
The public part contains the proxy and serving static content, while the private part contains /colibri and /about/{health,version}. 

This is in preparation of the addition of a WebSocket interface for conference endpoints to connect to.