### PR TITLE
doc: Updates the single port documentation.

### DIFF
--- a/doc/single-port.md
+++ b/doc/single-port.md
@@ -8,48 +8,19 @@ support these (such as (currently) jigasi), Jitsi Videobridge will
 automatically fallback to using the dynamically allocated ports (configurable
 using the --min-port and --max-port arguments to jvb.sh).
 
-#Configuration
+# Configuration
 Single port mode is enabled by default, with the port number being 10000. To
 change the port, set the following property (set to -1 to disable):
 
-### *org.jitsi.videobridge.SINGLE_PORT_HARVESTER_PORT=1234*
+### ```org.jitsi.videobridge.SINGLE_PORT_HARVESTER_PORT=1234```
 Type: integer
 Default: 10000
 
-
-
 By default, Jitsi Videobridge will try to use this port on all IP addresses
-across all (non-loopback) network interfaces. This can be fine-controlled using
-the generic ice4j properties:
+across all (non-loopback) network interfaces. This can be controlled using
+the ice4j properties described [here](https://github.com/jitsi/ice4j/blob/master/doc/configuration.md)
 
+### ```org.ice4j.ice.harvest.AbstractUdpHarvester.SO_RCVBUF```
 
-### *org.ice4j.ice.harvest.ALLOWED_INTERFACES*
-Default: all interfaces are allowed.
-
-This property can be used to specify a ";"-separated list of interfaces which are
-allowed to be used for candidate allocations.
-
-### *org.ice4j.ice.harvest.BLOCKED_INTERFACES*
-Default: no interfaces are blocked.
-
-This property can be used to specify a ";"-separated list of interfaces which are
-not allowed to be used for candidate allocations.
-
-### *org.ice4j.ice.harvest.ALLOWED_ADDRESSES*
-Default: all addresses are allowed.
-
-This property can be used to specify a ";"-separated list of IP addresses which
-are allowed to be used for candidate allocations.
-
-### *org.ice4j.ice.harvest.BLOCKED_ADDRESSES*
-Default: no addresses are blocked.
-
-This property can be used to specify a ";"-separated list of IP addresses which
-are not allowed to be used for candidate allocations.
-
-### *org.ice4j.ipv6.DISABLED*
-Type: boolean
-
-Default: false
-
-This property can be used to disable binding on IPv6 addresses.
+Configures the receive buffer size for the sockets used for the single-port mode.
+See the [ice4j documentation](https://github.com/jitsi/ice4j/blob/master/doc/configuration.md)


### PR DESCRIPTION
Points to ice4j for documentation of existing properties.