### PR TITLE
Bandwidth estimation and probing for bandwidth fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-20170328.160147-268</version>
+      <version>1.0-20170407.231649-270</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -273,8 +273,10 @@ public class RtpChannel
          */
         initialLocalSSRC = Videobridge.RANDOM.nextLong() & 0xffffffffL;
 
-        conferenceSpeechActivity
-            = getContent().getConference().getSpeechActivity();
+        Conference conference = content.getConference();
+        conference.addPropertyChangeListener(propertyChangeListener);
+
+        conferenceSpeechActivity = conference.getSpeechActivity();
         if (conferenceSpeechActivity != null)
         {
             /*

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -742,7 +742,15 @@ public class VideoChannel
                     .getRtcpFeedbackMessageSender();
 
                 if (rtcpFeedbackMessageSender != null)
+                {
+                    if (logger.isTraceEnabled())
+                    {
+                        logger.trace("send_fir,stream="
+                            + getStream().hashCode()
+                            + ",reason=scheduled");
+                    }
                     rtcpFeedbackMessageSender.sendFIR(ssrc);
+                }
             }
         };
 

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -389,7 +389,8 @@ public class VideoChannel
         String propertyName = ev.getPropertyName();
 
         if (Endpoint.PINNED_ENDPOINTS_PROPERTY_NAME.equals(propertyName)
-            || Endpoint.SELECTED_ENDPOINTS_PROPERTY_NAME.equals(propertyName))
+            || Endpoint.SELECTED_ENDPOINTS_PROPERTY_NAME.equals(propertyName)
+            || Conference.ENDPOINTS_PROPERTY_NAME.equals(propertyName))
         {
             bitrateController.update(null, -1);
         }

--- a/src/main/java/org/jitsi/videobridge/cc/BandwidthProbing.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BandwidthProbing.java
@@ -78,6 +78,14 @@ public class BandwidthProbing
     {
         super.run();
 
+        MediaStream destStream = dest.getStream();
+        if (destStream == null
+            || (destStream.getDirection() != null
+                && !destStream.getDirection().allowsSending()))
+        {
+            return;
+        }
+
         List<SimulcastController> simulcastControllerList
             = dest.getBitrateController().getSimulcastControllers();
 

--- a/src/main/java/org/jitsi/videobridge/cc/BandwidthProbing.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BandwidthProbing.java
@@ -135,7 +135,8 @@ public class BandwidthProbing
         for (SimulcastController simulcastController : simulcastControllerList)
         {
             long currentBps = simulcastController.getSource()
-                .getBps(simulcastController.getCurrentIndex());
+                .getBps(simulcastController.getCurrentIndex(),
+                    true /* performTimeoutCheck */);
 
             if (currentBps > 0)
             {
@@ -149,9 +150,11 @@ public class BandwidthProbing
             }
 
             totalTargetBps += simulcastController
-                .getSource().getBps(simulcastController.getTargetIndex());
+                .getSource().getBps(simulcastController.getTargetIndex(),
+                    true /* performTimeoutCheck */);
             totalOptimalBps += simulcastController
-                .getSource().getBps(simulcastController.getOptimalIndex());
+                .getSource().getBps(simulcastController.getOptimalIndex(),
+                    true /* performTimeoutCheck */);
         }
 
         // How much padding do we need?

--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -804,7 +804,18 @@ public class BitrateController
         @Override
         public void close()
         {
-            // TODO decrease counters.
+            for (SimulcastController simulcastController
+                : ssrcToBitrateController.values())
+            {
+                try
+                {
+                    simulcastController.close();
+                }
+                catch (Exception ignored)
+                {
+
+                }
+            }
         }
 
         /**

--- a/src/main/java/org/jitsi/videobridge/cc/SimulcastController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/SimulcastController.java
@@ -275,10 +275,21 @@ class SimulcastController
             }
         }
 
-        if (sendFIR)
+        MediaStream sourceStream
+            = sourceTrack.getMediaStreamTrackReceiver().getStream();
+        if (sendFIR && sourceStream != null)
         {
-            ((RTPTranslatorImpl) sourceTrack.getMediaStreamTrackReceiver()
-                .getStream().getRTPTranslator())
+
+            if (logger.isTraceEnabled())
+            {
+                logger.trace("send_fir,stream="
+                    + sourceStream.hashCode()
+                    + ",reason=target_changed"
+                    + ",current_tl0=" + currentTL0Idx
+                    + ",target_tl0=" + targetTL0Idx);
+            }
+
+            ((RTPTranslatorImpl) sourceStream.getRTPTranslator())
                 .getRtcpFeedbackMessageSender().sendFIR(
                 (int) targetSSRC);
         }
@@ -552,7 +563,8 @@ class SimulcastController
 
             if (logger.isDebugEnabled())
             {
-                logger.debug("tl0_changed,hash=" + hashCode()
+                logger.debug("tl0_changed,hash="
+                    + SimulcastController.this.hashCode()
                     + " old_tl0=" + this.tl0Idx
                     + ",new_tl0=" + newTL0Idx);
             }
@@ -683,7 +695,8 @@ class SimulcastController
 
                     if (currentIdx != this.currentIdx && logger.isDebugEnabled())
                     {
-                        logger.debug("current_idx_changed,hash=" + hashCode()
+                        logger.debug("current_idx_changed,hash="
+                            + SimulcastController.this.hashCode()
                             + " old_idx=" + this.currentIdx
                             + ",new_idx=" + currentIdx);
                     }

--- a/src/main/java/org/jitsi/videobridge/cc/SimulcastController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/SimulcastController.java
@@ -265,7 +265,8 @@ class SimulcastController
             // otherwise, check if anything higher is streaming.
             for (int i = currentTL0Idx + 1; i < targetTL0Idx + 1; i++)
             {
-                if (sourceEncodings[i].isActive())
+                RTPEncodingDesc tl0 = sourceEncodings[i].getBaseLayer();
+                if (tl0.isActive() && tl0.getIndex() > currentTL0Idx)
                 {
                     sendFIR = true;
                     break;


### PR DESCRIPTION
This PR contains fixes and features related to adaptivity (bandwidth estimations, bandwidth probing, simulcast). This PR depends on https://github.com/jitsi/libjitsi/pull/297

1. Various fixes in the padding budget calculation:
  a. We don't take into account expired endpoints
  b. we're more careful as to what we consider inactive, and this affects the padding calculation.
2. Simulcast related fixes, specifically about requesting key frames:
  a. when we detect that a stream has been suspended, we only ask for a key frame if the suspended stream is forwarded
  b. when temporal filtering is enabled we carelessly where requesting keyframes on temporal layer changes
3. makes a bunch of stuff configurable through java sys properties.