### PR TITLE
Rest configuration

### DIFF
--- a/doc/rest.md
+++ b/doc/rest.md
@@ -25,50 +25,50 @@ The following configuration properties can be added to the jitsi-videobridge con
 
 For the _private_ interface:
 
- * ```org.jitsi.videobridge.rest.jetty.port``` - 
+ * ```org.jitsi.videobridge.rest.private.jetty.port``` - 
  Specifies the port for the private HTTP interface (or -1 to disable it). The default value is ```8080```.
- * ```org.jitsi.videobridge.rest.jetty.tls.port``` - 
+ * ```org.jitsi.videobridge.rest.private.jetty.tls.port``` - 
  Specifies the port for the private HTTP interface if TLS is to be used (or -1 to disable). The default value is ```8443```.
- * ```org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePath``` - 
+ * ```org.jitsi.videobridge.rest.private.jetty.sslContextFactory.keyStorePath``` - 
  Specifies the path to the keystore to be used with HTTPS for the private interface. If this is not specified,
  HTTPS is disabled for the private interface.
- * ```org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePassword``` - 
+ * ```org.jitsi.videobridge.rest.private.jetty.sslContextFactory.keyStorePassword``` - 
  Specifies the password for the keystore of the private HTTP interface.
+ * ```org.jitsi.videobridge.rest.private.jetty.sslContextFactory.needClientAuth``` - 
+ Specifies whether client certificate authentication is to be required when HTTPS is enabled. The default value is ```false```.
+ * ```org.jitsi.videobridge.rest.private.jetty.host``` - 
+ Specifies the server host.
+
+For the _public_ interface:
+ * ```org.jitsi.videobridge.rest.jetty.port``` - 
+ Specifies the port for the public HTTP interface (or -1 to disable it). The default value is ```-1```.
+ * ```org.jitsi.videobridge.rest.jetty.tls.port``` - 
+ Specifies the port for the public HTTP interface if TLS is to be used (or -1 to disable). The default value is ```-1```.
+ * ```org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePath``` - 
+ Specifies the path to the keystore to be used with HTTPS for the public interface. If this is not specified, 
+ HTTPS is disabled for the public interface..
+ * ```org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePassword``` - 
+ Specifies the password for the keystore of the public HTTP interface.
  * ```org.jitsi.videobridge.rest.jetty.sslContextFactory.needClientAuth``` - 
  Specifies whether client certificate authentication is to be required when HTTPS is enabled. The default value is ```false```.
  * ```org.jitsi.videobridge.rest.jetty.host``` - 
  Specifies the server host.
 
-For the _public interface:
- * ```org.jitsi.videobridge.rest.public.jetty.port``` - 
- Specifies the port for the public HTTP interface (or -1 to disable it). The default value is ```-1```.
- * ```org.jitsi.videobridge.rest.public.jetty.tls.port``` - 
- Specifies the port for the public HTTP interface if TLS is to be used (or -1 to disable). The default value is ```-1```.
- * ```org.jitsi.videobridge.rest.public.jetty.sslContextFactory.keyStorePath``` - 
- Specifies the path to the keystore to be used with HTTPS for the public interface. If this is not specified, 
- HTTPS is disabled for the public interface..
- * ```org.jitsi.videobridge.rest.public.jetty.sslContextFactory.keyStorePassword``` - 
- Specifies the password for the keystore of the public HTTP interface.
- * ```org.jitsi.videobridge.rest.public.jetty.sslContextFactory.needClientAuth``` - 
- Specifies whether client certificate authentication is to be required when HTTPS is enabled. The default value is ```false```.
- * ```org.jitsi.videobridge.rest.public.jetty.host``` - 
- Specifies the server host.
-
 Specific parts of the _public_ interface can be configured with the following additional properties:
  ```
  # Configure a proxy 
- org.jitsi.videobridge.rest.public.jetty.ProxyServlet.hostHeader=example.com
- org.jitsi.videobridge.rest.public.jetty.ProxyServlet.pathSpec=/http-bind
- org.jitsi.videobridge.rest.public.jetty.ProxyServlet.proxyTo=http://localhost:5280/http-bind
+ org.jitsi.videobridge.rest.jetty.ProxyServlet.hostHeader=example.com
+ org.jitsi.videobridge.rest.jetty.ProxyServlet.pathSpec=/http-bind
+ org.jitsi.videobridge.rest.jetty.ProxyServlet.proxyTo=http://localhost:5280/http-bind
 
  # Configure serving of static content (tuned for jitsi-meet)
- org.jitsi.videobridge.rest.public.jetty.ResourceHandler.resourceBase=/usr/share/jitsi-meet
- org.jitsi.videobridge.rest.public.jetty.ResourceHandler.alias./config.js=/etc/jitsi/meet/example.com-config.js
- org.jitsi.videobridge.rest.public.jetty.ResourceHandler.alias./interface_config.js=/usr/share/jitsi-meet/interface_config.js
- org.jitsi.videobridge.rest.public.jetty.ResourceHandler.alias./logging_config.js=/usr/share/jitsi-meet/logging_config.js
- org.jitsi.videobridge.rest.public.jetty.RewriteHandler.regex=^/([a-zA-Z0-9]+)$
- org.jitsi.videobridge.rest.public.jetty.RewriteHandler.replacement=/
- org.jitsi.videobridge.rest.public.jetty.SSIResourceHandler.paths=/
+ org.jitsi.videobridge.rest.jetty.ResourceHandler.resourceBase=/usr/share/jitsi-meet
+ org.jitsi.videobridge.rest.jetty.ResourceHandler.alias./config.js=/etc/jitsi/meet/example.com-config.js
+ org.jitsi.videobridge.rest.jetty.ResourceHandler.alias./interface_config.js=/usr/share/jitsi-meet/interface_config.js
+ org.jitsi.videobridge.rest.jetty.ResourceHandler.alias./logging_config.js=/usr/share/jitsi-meet/logging_config.js
+ org.jitsi.videobridge.rest.jetty.RewriteHandler.regex=^/([a-zA-Z0-9]+)$
+ org.jitsi.videobridge.rest.jetty.RewriteHandler.replacement=/
+ org.jitsi.videobridge.rest.jetty.SSIResourceHandler.paths=/
  ```
 
 
@@ -81,26 +81,26 @@ Enable only the private interface with HTTP on the default port (8080): no conif
 ### Example 2
 Enable only the private interface with HTTPS on port 4443:
 ```
-org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePath=/path/to/keystore
-org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePassword=changeme
-org.jitsi.videobridge.rest.jetty.tls.port=4443
+org.jitsi.videobridge.rest.private.jetty.sslContextFactory.keyStorePath=/path/to/keystore
+org.jitsi.videobridge.rest.private.jetty.sslContextFactory.keyStorePassword=changeme
+org.jitsi.videobridge.rest.private.jetty.tls.port=4443
 ```
 
 ### Example 3
 Enable only the public interface with HTTP on port 80:
 ```
-org.jitsi.videobridge.rest.jetty.port=-1 #disable the private interface
-org.jitsi.videobridge.rest.jetty.public.port=80
+org.jitsi.videobridge.rest.private.jetty.port=-1 #disable the private interface
+org.jitsi.videobridge.rest.jetty.port=80
 ```
 
 ### Example 4
 Enable both the public and private interfaces with HTTPS (with the same certificate) 
 on ports 443 (public) and 8443 (private):
 ```
+org.jitsi.videobridge.rest.private.jetty.sslContextFactory.keyStorePath=/path/to/keystore
+org.jitsi.videobridge.rest.private.jetty.sslContextFactory.keyStorePassword=changeme
+
+org.jitsi.videobridge.rest.jetty.tls.port=443
 org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePath=/path/to/keystore
 org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePassword=changeme
-
-org.jitsi.videobridge.rest.jetty.public.tls.port=443
-org.jitsi.videobridge.rest.jetty.public.sslContextFactory.keyStorePath=/path/to/keystore
-org.jitsi.videobridge.rest.jetty.public.sslContextFactory.keyStorePassword=changeme
 ```

--- a/src/main/java/org/jitsi/videobridge/rest/PublicRESTBundleActivator.java
+++ b/src/main/java/org/jitsi/videobridge/rest/PublicRESTBundleActivator.java
@@ -22,7 +22,6 @@ import org.eclipse.jetty.servlet.*;
 import org.eclipse.jetty.util.resource.*;
 import org.jitsi.rest.*;
 import org.jitsi.util.*;
-import org.jitsi.videobridge.*;
 import org.jitsi.videobridge.rest.ssi.*;
 import org.osgi.framework.*;
 
@@ -44,13 +43,7 @@ public class PublicRESTBundleActivator
      * this {@link AbstractJettyBundleActivator}.
      */
     public static final String JETTY_PROPERTY_PREFIX
-        = "org.jitsi.videobridge.rest.public";
-
-    /**
-     * The old, deprecated prefix for some of the properties which configure
-     * the behavior of the public HTTP API. Kept for backward compatibility.
-     */
-    private static final String OLD_PREFIX = Videobridge.REST_API_PNAME;
+        = "org.jitsi.videobridge.rest";
 
     public static final String JETTY_PROXY_SERVLET_HOST_HEADER_PNAME
         = ".jetty.ProxyServlet.hostHeader";
@@ -215,7 +208,6 @@ public class PublicRESTBundleActivator
             = ConfigUtils.getString(
                 cfg,
                 JETTY_PROPERTY_PREFIX + JETTY_PROXY_SERVLET_PATH_SPEC_PNAME,
-                OLD_PREFIX + JETTY_PROXY_SERVLET_PATH_SPEC_PNAME,
                 null);
         ServletHolder holder = null;
 
@@ -225,7 +217,6 @@ public class PublicRESTBundleActivator
                 = ConfigUtils.getString(
                     cfg,
                     JETTY_PROPERTY_PREFIX + JETTY_PROXY_SERVLET_PROXY_TO_PNAME,
-                    OLD_PREFIX + JETTY_PROXY_SERVLET_PROXY_TO_PNAME,
                     null);
 
             if (proxyTo != null && proxyTo.length() != 0)
@@ -245,7 +236,6 @@ public class PublicRESTBundleActivator
                         cfg,
                         JETTY_PROPERTY_PREFIX
                             + JETTY_PROXY_SERVLET_HOST_HEADER_PNAME,
-                        OLD_PREFIX + JETTY_PROXY_SERVLET_HOST_HEADER_PNAME,
                         null);
 
                 if (hostHeader != null && hostHeader.length() != 0)
@@ -277,7 +267,6 @@ public class PublicRESTBundleActivator
                 cfg,
                 JETTY_PROPERTY_PREFIX
                     + JETTY_RESOURCE_HANDLER_RESOURCE_BASE_PNAME,
-                OLD_PREFIX + JETTY_RESOURCE_HANDLER_RESOURCE_BASE_PNAME,
                 null);
         ContextHandler contextHandler;
 
@@ -338,7 +327,6 @@ public class PublicRESTBundleActivator
                         = ConfigUtils.getString(
                             cfg,
                             JETTY_PROPERTY_PREFIX + property,
-                            OLD_PREFIX + property,
                             null);
 
                     return (value == null) ? null : Resource.newResource(value);
@@ -367,7 +355,6 @@ public class PublicRESTBundleActivator
         String regex = ConfigUtils.getString(
             cfg,
             JETTY_PROPERTY_PREFIX + JETTY_REWRITE_HANDLER_REGEX_PNAME,
-            OLD_PREFIX + JETTY_REWRITE_HANDLER_REGEX_PNAME,
             null);
         RewriteHandler handler = null;
 
@@ -378,7 +365,6 @@ public class PublicRESTBundleActivator
                     cfg,
                     JETTY_PROPERTY_PREFIX +
                         JETTY_REWRITE_HANDLER_REPLACEMENT_PNAME,
-                    OLD_PREFIX + JETTY_REWRITE_HANDLER_REPLACEMENT_PNAME,
                     null);
 
             if (replacement != null)

--- a/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
+++ b/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
@@ -54,11 +54,18 @@ public class RESTBundleActivator
       = "org.jitsi.videobridge.ENABLE_REST_COLIBRI";
 
     /**
+     * The prefix of the property names for the Jetty instance managed by
+     * this {@link AbstractJettyBundleActivator}.
+     */
+    public static final String JETTY_PROPERTY_PREFIX
+        = "org.jitsi.videobridge.rest.private";
+
+    /**
      * Initializes a new {@code RESTBundleActivator} instance.
      */
     public RESTBundleActivator()
     {
-        super(Videobridge.REST_API_PNAME);
+        super(JETTY_PROPERTY_PREFIX);
     }
 
     /**


### PR DESCRIPTION
Renames the properties used to configure the REST interfaces.

Makes the properties prefixed with "org.jitsi.videobridge.rest" control the public instead of the private interface. Uses the prefix "org.jitsi.videobridge.rest.private" for the private interface. Does not use the "org.jitsi.videobridge.rest.public" prefix.

The new defaults are: public: off, private: 8080 (no TLS).

The default configuration provided with jitsi-meet results in:
public on 443 (TLS), private on 8080 (no TLS)

Adds a redirection (HTTP 301) for /colibri/* and /about/* from the public interface to the private one.