### PR TITLE
Native libraries via Maven + Mavenizing Openfire plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /junit-reports/
 /.settings/
 /target/
+/openfire/target/
 *.class
 /.classpath
 *.jar

--- a/openfire/pom.xml
+++ b/openfire/pom.xml
@@ -1,0 +1,180 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>plugins</artifactId>
+        <groupId>org.igniterealtime.openfire</groupId>
+        <version>4.2.0-SNAPSHOT</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>org.jitsi</groupId>
+    <artifactId>jitsi-videobridge-openfire</artifactId>
+    <version>2.0-SNAPSHOT</version>
+    <name>Jitsi Videobridge Openfire Plugin</name>
+
+    <properties>
+        <!-- Override the default plugin name, as the default include illegal characters. -->
+        <plugin.name>jitsivideobridge</plugin.name>
+    </properties>
+
+    <build>
+        <sourceDirectory>src/java</sourceDirectory>
+        <plugins>
+            <!-- Builds the Openfire plugin jar file. -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+            <!-- Compiles the Openfire Admin Console JSP pages. -->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-jspc-maven-plugin</artifactId>
+            </plugin>
+            <!-- Fix for Mina 2.x -->
+            <!-- https://issues.apache.org/jira/browse/DIRMINA-919 -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.0.0</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jitsi</groupId>
+            <artifactId>jitsi-videobridge</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpg-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.gnu.inet</groupId>
+                    <artifactId>libidn</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xpp3</groupId>
+                    <artifactId>xpp3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>rusv</groupId>
+            <artifactId>agafua-syslog</artifactId>
+            <version>0.4</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jitsi</groupId>
+            <artifactId>jitsi-videobridge</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <classifier>native-linux-32</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jitsi</groupId>
+            <artifactId>jitsi-videobridge</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <classifier>native-linux-64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jitsi</groupId>
+            <artifactId>jitsi-videobridge</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <classifier>native-macosx</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jitsi</groupId>
+            <artifactId>jitsi-videobridge</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <classifier>native-windows-32</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jitsi</groupId>
+            <artifactId>jitsi-videobridge</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <classifier>native-windows-64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>jitsi-maven-repository-releases</id>
+            <layout>default</layout>
+            <name>Jitsi Maven Repository (Releases)</name>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <url>https://github.com/jitsi/jitsi-maven-repository/raw/master/releases/</url>
+        </repository>
+        <repository>
+            <id>jitsi-maven-repository-snapshots</id>
+            <layout>default</layout>
+            <name>Jitsi Maven Repository (Snapshots)</name>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <url>https://github.com/jitsi/jitsi-maven-repository/raw/master/snapshots/</url>
+        </repository>
+    </repositories>
+</project>

--- a/openfire/src/web/WEB-INF/web.xml
+++ b/openfire/src/web/WEB-INF/web.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<!--
+  ~ Copyright (c) 2017 Ignite Realtime Foundation. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+
+</web-app>

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,25 @@
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>
+            <id>assembly-native-libraries</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <appendAssemblyId>true</appendAssemblyId>
+              <descriptors>
+                <!-- The slightly odd artifact names help with backwards compatibility with the checkNatives() implementation. -->
+                <descriptor>src/assembly/native-linux-32.xml</descriptor>
+                <descriptor>src/assembly/native-linux-64.xml</descriptor>
+                <descriptor>src/assembly/native-macosx.xml</descriptor>
+                <descriptor>src/assembly/native-windows-32.xml</descriptor>
+                <descriptor>src/assembly/native-windows-64.xml</descriptor>
+              </descriptors>
+              <skipAssembly>false</skipAssembly>
+            </configuration>
+          </execution>
+          <execution>
             <id>assembly-linux-x64-bin-archive</id>
             <phase>package</phase>
             <goals>

--- a/src/assembly/native-linux-32.xml
+++ b/src/assembly/native-linux-32.xml
@@ -1,0 +1,18 @@
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>native-linux-32</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}/lib</directory>
+      <includes>
+        <include>native/linux/**</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/src/assembly/native-linux-64.xml
+++ b/src/assembly/native-linux-64.xml
@@ -1,0 +1,18 @@
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>native-linux-64</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}/lib</directory>
+      <includes>
+        <include>native/linux-64/**</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/src/assembly/native-macosx.xml
+++ b/src/assembly/native-macosx.xml
@@ -1,0 +1,18 @@
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>native-macosx</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}/lib</directory>
+      <includes>
+        <include>native/macosx/**</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/src/assembly/native-windows-32.xml
+++ b/src/assembly/native-windows-32.xml
@@ -1,0 +1,18 @@
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>native-windows-32</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}/lib</directory>
+      <includes>
+        <include>native/windows/**</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/src/assembly/native-windows-64.xml
+++ b/src/assembly/native-windows-64.xml
@@ -1,0 +1,18 @@
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>native-windows-64</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}/lib</directory>
+      <includes>
+        <include>native/windows-64/**</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>


### PR DESCRIPTION
This PR contains two dependent commits: one makes the native libraries as used by the Videobridge available via Maven. The second commit adds a Maven structure to the Openfire plugin that ships with JVB (leaving the existing Ant file intact, for the time being).