### PR TITLE
fix: Do not attempt to rewrite the TL0PICIDX of non-scalable streams.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/SimulcastController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/SimulcastController.java
@@ -910,14 +910,24 @@ public class SimulcastController
                         }
 
 
-                        if (((MediaStreamImpl) bitrateController
+                        int tid = ((MediaStreamImpl) bitrateController
                             .getVideoChannel().getStream())
-                            .getTemporalID(buf, off, len) == 0)
-                        {
-                            tl0PicIdx++;
-                        }
+                            .getTemporalID(buf, off, len);
 
-                        int dstTL0PICIDX = tl0PicIdx;
+                        int dstTL0PICIDX;
+                        if (tid > -1)
+                        {
+                            if (tid == 0)
+                            {
+                                tl0PicIdx++;
+                            }
+
+                            dstTL0PICIDX = tl0Idx;
+                        }
+                        else
+                        {
+                            dstTL0PICIDX = -1;
+                        }
 
                         destFrame = seenFrameAllocator.getOrCreate();
                         destFrame.reset(srcTs, seqNumTranslation, tsTranslation,


### PR DESCRIPTION
Anything that's not a desktop Chrome browser (e.g. FF, mobile app) does
not support simulcast atm. Attempting to rewrite the TL0PICIDX of these
non-scalable streams results in the logs being spammed with the message
"Failed to set the VP8 TL0PICIDX". This commit fixes this by not
attempting to rewrite the TL0PICIDX of non-scalable streams.