### PR TITLE
fix: Disable bandwidth probing for endpoints that do not support RTX (FF).

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -355,9 +355,10 @@ public class BitrateController
             conferenceEndpoints = new ArrayList<>(conferenceEndpoints);
         }
 
-        MediaStream destStream = dest.getStream();
+        VideoMediaStreamImpl destStream
+            = (VideoMediaStreamImpl) dest.getStream();
         BandwidthEstimator bwe = destStream == null ? null
-            : ((VideoMediaStream) destStream).getOrCreateBandwidthEstimator();
+            : destStream.getOrCreateBandwidthEstimator();
 
         boolean trustBwe = this.trustBwe;
         if (trustBwe)
@@ -378,7 +379,8 @@ public class BitrateController
             bweBps = bwe.getLatestEstimate();
         }
 
-        if (bweBps < 0 || !trustBwe)
+        if (bweBps < 0 || !trustBwe
+            || !destStream.getRtxTransformer().destinationSupportsRtx())
         {
             bweBps = Long.MAX_VALUE;
         }


### PR DESCRIPTION
Currently the FF webrtc engine ignores our bandwidth probing (https://bugzilla.mozilla.org/show_bug.cgi?id=1362450), so we want to disable bandwidth probing for FF. FF also does not support RTX. This method will be used by the bridge to determine whether the destination endpoint has RTX or not. If not, then that would indicate a FF destination endpoint and it will disable adaptivity for that endpoint.

This depends on https://github.com/jitsi/libjitsi/pull/307