### PR TITLE
Native jars should be flat

### DIFF
--- a/src/assembly/native-linux-32.xml
+++ b/src/assembly/native-linux-32.xml
@@ -9,9 +9,10 @@
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
-      <directory>${project.basedir}/lib</directory>
+      <directory>${project.basedir}/lib/native/linux</directory>
+      <outputDirectory></outputDirectory>
       <includes>
-        <include>native/linux/**</include>
+        <include>*</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/src/assembly/native-linux-64.xml
+++ b/src/assembly/native-linux-64.xml
@@ -9,9 +9,10 @@
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
-      <directory>${project.basedir}/lib</directory>
+      <directory>${project.basedir}/lib/native/linux-64</directory>
+      <outputDirectory></outputDirectory>
       <includes>
-        <include>native/linux-64/**</include>
+        <include>*</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/src/assembly/native-macosx.xml
+++ b/src/assembly/native-macosx.xml
@@ -9,9 +9,10 @@
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
-      <directory>${project.basedir}/lib</directory>
+      <directory>${project.basedir}/lib/native/macosx</directory>
+      <outputDirectory></outputDirectory>
       <includes>
-        <include>native/macosx/**</include>
+        <include>*</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/src/assembly/native-windows-32.xml
+++ b/src/assembly/native-windows-32.xml
@@ -9,9 +9,10 @@
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
-      <directory>${project.basedir}/lib</directory>
+      <directory>${project.basedir}/lib/native/windows</directory>
+      <outputDirectory></outputDirectory>
       <includes>
-        <include>native/windows/**</include>
+        <include>*</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/src/assembly/native-windows-64.xml
+++ b/src/assembly/native-windows-64.xml
@@ -9,9 +9,10 @@
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
-      <directory>${project.basedir}/lib</directory>
+      <directory>${project.basedir}/lib/native/windows-64</directory>
+      <outputDirectory></outputDirectory>
       <includes>
-        <include>native/windows-64/**</include>
+        <include>*</include>
       </includes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
The jar files that contain the native libraries used to be 'flat' archives (all native library files were in the root of the archive). This changes unintentionally. That's being corrected here.