### PR TITLE
[Debian package] Move launcher to /usr/bin

### DIFF
--- a/doc/rest-colibri.md
+++ b/doc/rest-colibri.md
@@ -75,15 +75,15 @@ The respective response could look like:
  			} 
 		] 
 }</pre>
-		</td>
-	</tr>
-	<tr>
+	</td>
+</tr>
+<tr>
 		<td>GET</td>
 		<td>/colibri/conferences{id}</td>
 		<td>
 			200 OK with a JSON object which represents the conference with the specified id. <br />
 			For example: 
-			<pre>
+<pre>
 { 
 	"id" : "{id}", 
 	"contents" : 

--- a/resources/install/build-debian.xml
+++ b/resources/install/build-debian.xml
@@ -108,10 +108,8 @@
               todir="${debian.dir}/etc/jitsi/videobridge"
               overwrite="true"/>
         <copy file="resources/install/${include-dir}/jvb.sh"
-              todir="${debian.dir}/usr/share/jitsi-videobridge"
+              tofile="${debian.dir}/usr/bin/jvb"
               overwrite="true"/>
-        <chmod file="${debian.dir}/usr/share/jitsi-videobridge/jvb.sh"
-               perm="755"/>
         <copy file="resources/graceful_shutdown.sh"
               todir="${debian.dir}/usr/share/jitsi-videobridge"
               overwrite="true"/>
@@ -122,6 +120,16 @@
               overwrite="true"/>
         <chmod file="${debian.dir}/usr/share/jitsi-videobridge/collect-dump-logs.sh"
                perm="755"/>
+
+        <chown owner="root">
+            <fileset dir="${debian.dir}/usr/bin"></fileset>
+        </chown>
+        <chgrp group="root">
+            <fileset dir="${debian.dir}/usr/bin"></fileset>
+        </chgrp>
+        <chmod perm="755">
+            <fileset dir="${debian.dir}/usr/bin"></fileset>
+        </chmod>
 
         <!-- callstats-java-sdk -->
         <copy file="config/log4j2.xml"
@@ -257,11 +265,12 @@ override_dh_auto_clean:
 
 override_dh_install-arch:
 ifeq ($(DEB_HOST_ARCH),amd64)
-&#009;dh_install resources/install/linux-64/jvb.sh usr/share/jitsi-videobridge
+&#009;dh_install resources/install/linux-64/jvb.sh usr/bin
 else
-&#009;dh_install resources/install/linux/jvb.sh usr/share/jitsi-videobridge
+&#009;dh_install resources/install/linux/jvb.sh usr/bin
 endif
-&#009;chmod +x debian/jitsi-videobridge/usr/share/jitsi-videobridge/jvb.sh
+&#009;chmod +x debian/jitsi-videobridge/usr/bin/jvb.sh
+&#009;chown root:root debian/jitsi-videobridge/usr/bin/jvb.sh
 
 </echo>
 

--- a/resources/install/debian/init.d
+++ b/resources/install/debian/init.d
@@ -21,7 +21,7 @@ if [ -f /etc/jitsi/videobridge/config ]; then
 fi
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/share/jitsi-videobridge/jvb.sh
+DAEMON=/usr/bin/jvb
 NAME=jvb
 USER=jvb
 PIDFILE=/var/run/jitsi-videobridge.pid

--- a/resources/install/debian/install
+++ b/resources/install/debian/install
@@ -1,3 +1,4 @@
+debian/usr/bin/*    /usr/bin/
 debian/usr/share/jitsi-videobridge/*	/usr/share/jitsi-videobridge/
 debian/etc/jitsi/videobridge/logging.properties	/etc/jitsi/videobridge/
 debian/etc/jitsi/videobridge/log4j2.xml	/etc/jitsi/videobridge/

--- a/resources/install/linux-64/jvb.sh
+++ b/resources/install/linux-64/jvb.sh
@@ -15,13 +15,13 @@ if [[ "$1" == "--help"  || $# -lt 1 ]]; then
     exit 1
 fi
 
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+BASE_LIB_DIR="$(echo ~jvb)"
 
 mainClass="org.jitsi.videobridge.Main"
-cp=$(JARS=($SCRIPT_DIR/jitsi-videobridge*.jar $SCRIPT_DIR/lib/*.jar); IFS=:; echo "${JARS[*]}")
-libs="$SCRIPT_DIR/lib/native/linux-64"
-logging_config="$SCRIPT_DIR/lib/logging.properties"
-videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"
+cp="$BASE_LIB_DIR/*:$BASE_LIB_DIR/lib/*"
+libs="$BASE_LIB_DIR/lib/native/linux-64"
+logging_config="$BASE_LIB_DIR/lib/logging.properties"
+videobridge_rc="$BASE_LIB_DIR/lib/videobridge.rc"
 
 # if there is a logging config file in lib folder use it (running from source)
 if [ -f $logging_config ]; then


### PR DESCRIPTION
Starts to work on #497.
The launcher is moved from `/usr/share/jitsi-videobridge/jvb.sh` into `/usr/bin/jvb`.
This is *far* from perfect, since it only works for linux-64, but I want to gather comments before going on.
If the way to do it seems wrong, please raise your hand.

(Sorry for other commits, I've rebased too late)