### PR TITLE
fix: Update the bitrate controller of new participant.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -336,6 +336,8 @@ public class VideoChannel
     {
         super.initialize(rtpLevelRelayType);
 
+        bitrateController.update(null, -1);
+
         ((VideoMediaStream) getStream()).getOrCreateBandwidthEstimator()
             .addListener(new BandwidthEstimator.Listener()
             {


### PR DESCRIPTION
Consider the case where there is no audio (so no active speaker events),
and a there's a single video sender, all other participants only
receive video.

When a new participants join, nothing updates the bitrate controller, so the
new participant has no simulcast controller, which results in nothing
being forwarded towards this participant, until the next participant
joins.

So, when a new participant joins the call, his/her bitrate controller needs
to be explicitely updated.