### PR TITLE
logs: Fine tunes the RBE traces.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-20170927.165735-317</version>
+      <version>1.0-20171013.160715-320</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -906,12 +906,6 @@ public class RtpChannel
                         mediaType,
                         getSrtpControl());
 
-            if (logger.isTraceEnabled())
-            {
-                logger.trace("channel_stream," + hashCode()
-                        + "," + stream.hashCode());
-            }
-
              // Add the PropertyChangeListener to the MediaStream prior to
              // performing further initialization so that we do not miss changes
              // to the values of properties we may be interested in.


### PR DESCRIPTION
This reverts commit c6095487f482b5cad21990cbd41c1c6970f7b166 which is unnecessary AND fine tunes the RBE traces. It depends on https://github.com/jitsi/libjitsi/pull/374.