### PR TITLE
ref(events): introduce MSG_TRANSPORT_READY_TOPIC

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -1559,12 +1559,6 @@ public class Conference
                  * implement it as well.
                  */
                 endpoint.sctpConnectionReady(sctpConnection);
-                // Trigger SCTP connection ready event
-                if (eventAdmin != null)
-                {
-                    eventAdmin.postEvent(
-                            EventFactory.endpointSctpConnReady(endpoint));
-                }
             }
         }
     }

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -503,6 +503,8 @@ public class Endpoint
             {
                 dataStream = sctpConnection.getDefaultDataStream();
                 dataStream.setDataCallback(this);
+
+                messageTransport.notifyTransportChannelConnected();
             }
             catch (IOException e)
             {

--- a/src/main/java/org/jitsi/videobridge/EndpointConnectionStatus.java
+++ b/src/main/java/org/jitsi/videobridge/EndpointConnectionStatus.java
@@ -133,7 +133,7 @@ public class EndpointConnectionStatus
      */
     public EndpointConnectionStatus()
     {
-        super(new String[] { EventFactory.SCTP_CONN_READY_TOPIC });
+        super(new String[] { EventFactory.MSG_TRANSPORT_READY_TOPIC});
     }
 
     /**
@@ -398,7 +398,7 @@ public class EndpointConnectionStatus
         // Verify the topic just in case
         // FIXME eventually add this verification to the base class
         String topic = event.getTopic();
-        if (!EventFactory.SCTP_CONN_READY_TOPIC.equals(topic))
+        if (!EventFactory.MSG_TRANSPORT_READY_TOPIC.equals(topic))
         {
             logger.warn("Received event for unexpected topic: " + topic);
             return;

--- a/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
+++ b/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge;
 
+import org.jitsi.eventadmin.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.util.*;
 import org.jitsi.videobridge.rest.*;
@@ -143,6 +144,20 @@ class EndpointMessageTransport
         this.logger
             = Logger.getLogger(
                     classLogger, endpoint.getConference().getLogger());
+    }
+
+    /**
+     * Fires the message transport ready event for the associated endpoint.
+     */
+    void notifyTransportChannelConnected()
+    {
+        EventAdmin eventAdmin = endpoint.getConference().getEventAdmin();
+
+        if (eventAdmin != null)
+        {
+            eventAdmin.postEvent(
+                EventFactory.endpointMessageTransportReady(endpoint));
+        }
     }
 
     /**
@@ -705,6 +720,8 @@ class EndpointMessageTransport
             webSocketLastActive = true;
             sendMessage(ws, SERVER_HELLO_STR, "initial ServerHello");
         }
+
+        notifyTransportChannelConnected();
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/EventFactory.java
+++ b/src/main/java/org/jitsi/videobridge/EventFactory.java
@@ -73,18 +73,18 @@ public class EventFactory
         = "org/jitsi/videobridge/Endpoint/CREATED";
 
     /**
+     * The name of the topic of a "message transport ready" event triggered on
+     * an endpoint instance when it's message transport connection is ready for
+     * sending/receiving data.
+     */
+    public static final String MSG_TRANSPORT_READY_TOPIC
+        = "org/jitsi/videobridge/Endpoint/MSG_TRANSPORT_READY_TOPIC";
+
+    /**
      * The name of the topic of a "stream started" event.
      */
     public static final String STREAM_STARTED_TOPIC
         = "org/jitsi/videobridge/Endpoint/STREAM_STARTED";
-
-    /**
-     * The name of the topic of a "SCTP connection ready" event triggered on
-     * an endpoint instance when it's SCTP connection is ready for
-     * sending/receiving data.
-     */
-    public static final String SCTP_CONN_READY_TOPIC
-        = "org/jitsi/videobridge/Endpoint/SCTP_CONN_READY";
 
     /**
      * The name of the topic of a "transport channel created" event.
@@ -219,20 +219,21 @@ public class EventFactory
     }
 
     /**
-     * Creates a new "SCTP connection ready" <tt>Event</tt>, which means that
-     * the endpoint passed in {@link #EVENT_SOURCE} property has now it's SCTP
-     * connection ready for sending/receiving data.
+     * Creates a new "message transport ready" <tt>Event</tt>, which means that
+     * the endpoint passed in {@link #EVENT_SOURCE} property has now it's
+     * message transport connection established and ready for sending/receiving
+     * data.
      *
-     * @param endpoint the endpoint for which SCTP connection is now ready.
+     * @param endpoint the endpoint for which the message transport is now ready
      *
      * @return the <tt>Event</tt> which was created.
      */
-    public static Event endpointSctpConnReady(Endpoint endpoint)
+    public static Event endpointMessageTransportReady(Endpoint endpoint)
     {
         Dictionary<String, Object> properties = new Hashtable<>(1);
 
         properties.put(EVENT_SOURCE, endpoint);
-        return new Event(SCTP_CONN_READY_TOPIC, properties);
+        return new Event(MSG_TRANSPORT_READY_TOPIC, properties);
     }
 
     public static Event streamStarted(RtpChannel rtpChannel)


### PR DESCRIPTION
The event will be fired when either WebSocket or SCTP endpoint message transport is ready. This will fix broadcasting of the initial endpoint connection status when WebSockets are used (and random build failures).