### PR TITLE
added rtcp-fb payload type parameters field suppoty to rest protocol

### DIFF
--- a/doc/rest-colibri.md
+++ b/doc/rest-colibri.md
@@ -367,9 +367,8 @@ Post "[]" to <bridge_base_url>/colibri/conferences/
               "clockrate": 48000,
               "channels": 2,
               "parameters": {
-                "fmtp": [
-                  "111 minptime=10; useinbandfec=1"
-                ]
+                "minptime": 10,
+                "useinbandfec": 1
               }
             }
           ],
@@ -397,7 +396,12 @@ Post "[]" to <bridge_base_url>/colibri/conferences/
           "channel-bundle-id": "9f537ebb-1c2a-4ee9-9940-373304f9b260",
           "rtp-level-relay-type": "translator",
           "ssrc-groups": [
-            
+          {
+            "semantics": "FID",
+            "sources": [
+              2,
+              3
+            ]}
           ],
           "payload-types": [
             {
@@ -405,30 +409,42 @@ Post "[]" to <bridge_base_url>/colibri/conferences/
               "name": "H264",
               "clockrate": 90000,
               "channels": 0,
-              "parameters": {
-                "rtcp-fb": [
-                  "127 ccm fir",
-                  "127 nack",
-                  "127 nack pli"
-                ]
-              }
+              "parameters": {},
+              "rtcp-fbs": [ {
+                "type": "ccm",
+                "subtype": "fir"
+              }, {
+                "type": "nack"
+              }, {
+                "type": "nack",
+                "subtype": "pli"
+              } ]
             },
             {
               "id": 100,
               "name": "VP8",
               "clockrate": 90000,
               "channels": 0,
-              "parameters": {
-                "rtcp-fb": [
-                  "100 ccm fir",
-                  "100 nack",
-                  "100 goog-remb"
-                ]
-              }
+              "parameters": {},
+              "rtcp-fbs": [ {
+                "type": "ccm",
+                "subtype": "fir"
+              }, {
+                "type": "nack"
+              }, {
+                "type": "goog-remb"
+              } ]
             }
           ],
           "rtp-hdrexts": [
-            
+            {
+              "id": 2,
+              "uri": "urn:ietf:params:rtp-hdrext:toffset"
+            },
+            {
+              "id": 3,
+              "uri": "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+            }
           ]
         }
       ]

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,11 @@
       <groupId>xpp3</groupId>
       <artifactId>xpp3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>1.1.0.Final</version>
+    </dependency>
     <!-- runtime -->
     <dependency>
       <groupId>rusv</groupId>

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -654,10 +654,7 @@ public class VideoChannel
                 enableRedFilter = false;
             }
 
-            for (RtcpFbPacketExtension rtcpFb :
-                        payloadType.getChildExtensionsOfType(
-                                RtcpFbPacketExtension.class))
-            {
+            for (RtcpFbPacketExtension rtcpFb : payloadType.getRtcpFeedbackTypeList()) {
                 if ("ccm".equals(rtcpFb.getAttribute("type"))
                         && "fir".equals(rtcpFb.getAttribute("subtype")))
                 {

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -654,7 +654,9 @@ public class VideoChannel
                 enableRedFilter = false;
             }
 
-            for (RtcpFbPacketExtension rtcpFb : payloadType.getRtcpFeedbackTypeList()) {
+            for (RtcpFbPacketExtension rtcpFb :
+                    payloadType.getRtcpFeedbackTypeList())
+            {
                 if ("ccm".equals(rtcpFb.getAttribute("type"))
                         && "fir".equals(rtcpFb.getAttribute("subtype")))
                 {

--- a/src/main/java/org/jitsi/videobridge/rest/JSONDeserializer.java
+++ b/src/main/java/org/jitsi/videobridge/rest/JSONDeserializer.java
@@ -578,16 +578,23 @@ final class JSONDeserializer
 
     public static void deserializeRtcpFbs(
             JSONArray rtcpFbs,
-            PayloadTypePacketExtension payloadTypeIQ) {
-        if (rtcpFbs != null && rtcpFbs instanceof JSONArray) {
-            for (Object iter : rtcpFbs) {
+            PayloadTypePacketExtension payloadTypeIQ)
+    {
+        if (rtcpFbs != null && rtcpFbs instanceof JSONArray)
+        {
+            for (Object iter : rtcpFbs)
+            {
                 JSONObject rtcpFb = (JSONObject) iter;
-                String type = (String) rtcpFb.get(RtcpFbPacketExtension.TYPE_ATTR_NAME);
-                String subtype = (String) rtcpFb.get(RtcpFbPacketExtension.SUBTYPE_ATTR_NAME);
-                if (type != null) {
+                String type = (String)
+                        rtcpFb.get(RtcpFbPacketExtension.TYPE_ATTR_NAME);
+                String subtype = (String)
+                        rtcpFb.get(RtcpFbPacketExtension.SUBTYPE_ATTR_NAME);
+                if (type != null)
+                {
                     RtcpFbPacketExtension ext = new RtcpFbPacketExtension();
                     ext.setFeedbackType(type);
-                    if (subtype != null) {
+                    if (subtype != null)
+                    {
                         ext.setFeedbackSubtype(subtype);
                     }
                     payloadTypeIQ.addRtcpFeedbackType(ext);

--- a/src/main/java/org/jitsi/videobridge/rest/JSONDeserializer.java
+++ b/src/main/java/org/jitsi/videobridge/rest/JSONDeserializer.java
@@ -580,7 +580,7 @@ final class JSONDeserializer
             JSONArray rtcpFbs,
             PayloadTypePacketExtension payloadTypeIQ)
     {
-        if (rtcpFbs != null && rtcpFbs instanceof JSONArray)
+        if (rtcpFbs != null)
         {
             for (Object iter : rtcpFbs)
             {

--- a/src/main/java/org/jitsi/videobridge/rest/JSONDeserializer.java
+++ b/src/main/java/org/jitsi/videobridge/rest/JSONDeserializer.java
@@ -576,6 +576,26 @@ final class JSONDeserializer
         }
     }
 
+    public static void deserializeRtcpFbs(
+            JSONArray rtcpFbs,
+            PayloadTypePacketExtension payloadTypeIQ) {
+        if (rtcpFbs != null && rtcpFbs instanceof JSONArray) {
+            for (Object iter : rtcpFbs) {
+                JSONObject rtcpFb = (JSONObject) iter;
+                String type = (String) rtcpFb.get(RtcpFbPacketExtension.TYPE_ATTR_NAME);
+                String subtype = (String) rtcpFb.get(RtcpFbPacketExtension.SUBTYPE_ATTR_NAME);
+                if (type != null) {
+                    RtcpFbPacketExtension ext = new RtcpFbPacketExtension();
+                    ext.setFeedbackType(type);
+                    if (subtype != null) {
+                        ext.setFeedbackSubtype(subtype);
+                    }
+                    payloadTypeIQ.addRtcpFeedbackType(ext);
+                }
+            }
+        }
+    }
+
     public static RTPHdrExtPacketExtension deserializeHeaderExtension(
             JSONObject headerExtension,
             ColibriConferenceIQ.Channel channelIQ)
@@ -649,6 +669,12 @@ final class JSONDeserializer
             // parameters
             if (parameters != null)
                 deserializeParameters((JSONObject) parameters, payloadTypeIQ);
+
+            Object rtcpFbs = payloadType.get(JSONSerializer.RTCP_FBS);
+
+            if (rtcpFbs != null && rtcpFbs instanceof JSONArray) {
+                deserializeRtcpFbs((JSONArray) rtcpFbs, payloadTypeIQ);
+            }
 
             channelIQ.addPayloadType(payloadTypeIQ);
         }

--- a/src/main/java/org/jitsi/videobridge/rest/JSONSerializer.java
+++ b/src/main/java/org/jitsi/videobridge/rest/JSONSerializer.java
@@ -17,7 +17,7 @@ package org.jitsi.videobridge.rest;
 
 import java.util.*;
 
-import com.sun.istack.internal.NotNull;
+import com.sun.istack.internal.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
@@ -708,7 +708,8 @@ final class JSONSerializer
 
     public static JSONArray serializeRtcpFbs(
             @NotNull
-            Collection<RtcpFbPacketExtension> rtcpFbs) {
+            Collection<RtcpFbPacketExtension> rtcpFbs)
+    {
         JSONArray rtcpFbsJSON = new JSONArray();
         /*
          * A rtcp-fb is an JSONObject with type / subtype data.
@@ -726,11 +727,15 @@ final class JSONSerializer
             String type = ext.getFeedbackType();
             String subtype = ext.getFeedbackSubtype();
 
-            if (type != null) {
+            if (type != null)
+            {
                 JSONObject rtcpFbJSON = new JSONObject();
                 rtcpFbJSON.put(RtcpFbPacketExtension.TYPE_ATTR_NAME, type);
-                if (subtype != null) {
-                    rtcpFbJSON.put(RtcpFbPacketExtension.SUBTYPE_ATTR_NAME, subtype);
+                if (subtype != null)
+                {
+                    rtcpFbJSON.put(
+                            RtcpFbPacketExtension.SUBTYPE_ATTR_NAME,
+                            subtype);
                 }
                 rtcpFbsJSON.add(rtcpFbJSON);
             }
@@ -764,8 +769,10 @@ final class JSONSerializer
                         PARAMETERS,
                         serializeParameters(parameters));
             }
-            final List<RtcpFbPacketExtension> rtcpFeedbackTypeList = payloadType.getRtcpFeedbackTypeList();
-            if ((rtcpFeedbackTypeList != null) && !rtcpFeedbackTypeList.isEmpty()) {
+            final List<RtcpFbPacketExtension> rtcpFeedbackTypeList =
+                    payloadType.getRtcpFeedbackTypeList();
+            if ((rtcpFeedbackTypeList != null) &&
+                    !rtcpFeedbackTypeList.isEmpty()) {
                 payloadTypeJSONObject.put(
                         RTCP_FBS,
                         serializeRtcpFbs(rtcpFeedbackTypeList));

--- a/src/main/java/org/jitsi/videobridge/rest/JSONSerializer.java
+++ b/src/main/java/org/jitsi/videobridge/rest/JSONSerializer.java
@@ -17,7 +17,6 @@ package org.jitsi.videobridge.rest;
 
 import java.util.*;
 
-import com.sun.istack.internal.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
@@ -25,6 +24,8 @@ import net.java.sip.communicator.impl.protocol.jabber.extensions.jingle.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.videobridge.stats.*;
 import org.json.simple.*;
+
+import javax.validation.constraints.*;
 
 /**
  * Implements (utility) functions to serialize instances of
@@ -708,7 +709,7 @@ final class JSONSerializer
 
     public static JSONArray serializeRtcpFbs(
             @NotNull
-            Collection<RtcpFbPacketExtension> rtcpFbs)
+                    Collection<RtcpFbPacketExtension> rtcpFbs)
     {
         JSONArray rtcpFbsJSON = new JSONArray();
         /*

--- a/src/main/java/org/jitsi/videobridge/rest/JSONSerializer.java
+++ b/src/main/java/org/jitsi/videobridge/rest/JSONSerializer.java
@@ -772,7 +772,8 @@ final class JSONSerializer
             final List<RtcpFbPacketExtension> rtcpFeedbackTypeList =
                     payloadType.getRtcpFeedbackTypeList();
             if ((rtcpFeedbackTypeList != null) &&
-                    !rtcpFeedbackTypeList.isEmpty()) {
+                    !rtcpFeedbackTypeList.isEmpty())
+            {
                 payloadTypeJSONObject.put(
                         RTCP_FBS,
                         serializeRtcpFbs(rtcpFeedbackTypeList));


### PR DESCRIPTION
according with next issue
https://github.com/jitsi/jitsi-videobridge/issues/568

added possibility to serialize / de-serialize rtcp-fb parameters for REST (colibri) protocol.