### PR TITLE
Fix for #553 No PLI generated with recvonly video channel

### DIFF
--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -361,6 +361,13 @@ public class VideoChannel
         return accept;
     }
 
+    @Override
+    public void setEndpoint(String newEndpointId)
+    {
+        super.setEndpoint(newEndpointId);
+        bitrateController.update(null, -1);
+    }
+
     /**
      * Gets the {@link BitrateController} which controls which endpoints'
      * video streams are to be forwarded on this {@link VideoChannel} (i.e.


### PR DESCRIPTION
Fix for https://github.com/jitsi/jitsi-videobridge/issues/553

When using the rest api, no PLIs are sent by the video bridge to existing endpoints when a new channel is allocated. Client A allocates a recvonly audio channel and a sendrecv video channel. Client B allocates a recvonly audio channel and a recvonly video channel. When client B patches the bridge with its answer colibri, the video bridge should send a PLI to client A. This happens when BitrateController.update() is called during VideoChannel initialization. However this doesn't happen in the described scenario.

The call to BitrateController.update() in VideoChannel.initialize() does not generate a PLI, since the endpoint property of the dest VideoChannel is null. BitrateController.prioritize() returns null if the dest endpoint is unset. The other possible call to BitrateController.update() happens in VideoChannel.setRtpEncodingParameters(). However, since the recvonly channel has no sources, the "changed" boolean will always be false, and never call BitrateController.update(). 

It has bee suggested to add a dummy ssrc to recvonly channels to mitigate the issue. VideoChannel.setRtpEncodingParameters() will then call BitrateController.update(), but it still doesn't generate a PLI since the sourceEncodings[0].isActive() call in SimulcastController.setTargetIndex() returns false for the dummy stream.

This PR adds a call to bitrateController.update() after VideoChannel.setEndpoint(), resulting in a sent PLI. This may, or may not be the way you want to solve it, but I'm sending this PR so that you can get an indication on why this is currently not working as expected.