### PR TITLE
Update the bitrate controller when the stream starts

### DIFF
--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -288,6 +288,10 @@ public class VideoChannel
         boolean previouslyStarted = getStream().isStarted();
         super.maybeStartStream();
 
+        // If a recvonly channel is created, existing streams won't be forwarded to it until the next
+        // keyframe comes in. bitrateController.update gets called before ICE has completed so the
+        // keyframe comes in before this channel is actually started. So update the bitrate controller when
+        // the stream starts which will request a keyframe from other channels if needed.
         if(getStream().isStarted() && !previouslyStarted)
         {
             bitrateController.update(null, -1);

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -282,6 +282,22 @@ public class VideoChannel
      * {@inheritDoc}
      */
     @Override
+    protected void maybeStartStream()
+        throws IOException
+    {
+        boolean previouslyStarted = getStream().isStarted();
+        super.maybeStartStream();
+
+        if(getStream().isStarted() && !previouslyStarted)
+        {
+            bitrateController.update(null, -1);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public boolean setRtpEncodingParameters(
         List<SourcePacketExtension> sources,
         List<SourceGroupPacketExtension> sourceGroups)


### PR DESCRIPTION
This fixes an issue with keyframes being requested too early when a stream is starting (#553, #598). Specifically sometimes when a user enters after a stream is being shared, the FIR is sent and the keyframe comes through before its ICE connection is finished setting up.

Related PR in libjtisi: https://github.com/jitsi/libjitsi/pull/404