### PR TITLE
debian: add missing dependency on procps

### DIFF
--- a/resources/install/debian/control
+++ b/resources/install/debian/control
@@ -10,7 +10,7 @@ Homepage: https://jitsi.org/videobridge
 Package: jitsi-videobridge
 Architecture: any
 Pre-Depends: openjdk-8-jre-headless
-Depends: ${misc:Depends}
+Depends: ${misc:Depends}, procps
 Recommends: authbind
 Description: WebRTC compatible Selective Forwarding Unit (SFU)
  Jitsi Videobridge is a WebRTC compatible Selective Forwarding Unit


### PR DESCRIPTION
The postinstall script calls out to sysctl: https://github.com/jitsi/jitsi-videobridge/blob/master/resources/install/debian/postinst#L150
which is foung in the procps package.

As unusual as it may sound, there are systems which do not have the procps package installed,
such as the debian-slim Docker images.