### PR TITLE
Configurable relayId

### DIFF
--- a/src/main/java/org/jitsi/videobridge/octo/OctoRelay.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoRelay.java
@@ -50,6 +50,8 @@ public class OctoRelay
      * e.g. "10.0.0.1:20000"
      */
     private String relayId;
+    
+    private String publicAddress;
 
     /**
      * Initializes a new {@link OctoRelay} instance, binding on a specific
@@ -64,7 +66,8 @@ public class OctoRelay
             = new DatagramSocket(
                     new InetSocketAddress(InetAddress.getByName(address), port));
         socket = new MultiplexingDatagramSocket(s, true /* persistent */);
-        relayId = address + ":" + port;
+        String id = address + ":" + port;
+        setRelayId(id);
     }
 
     /**
@@ -88,6 +91,22 @@ public class OctoRelay
     public String getId()
     {
         return relayId;
+    }
+    
+    /**
+    * Set the relayId
+    **/
+    public void setRelayId(String id){
+        relayId = id;
+    }
+    
+    /**
+    * Set the public address to be used as part of relayId
+    **/
+    public void setPublicAddress(String address){
+         publicAddress = address;
+         String id = publicAddress + ":" + port;
+         setRelayId(id);
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/octo/OctoRelayService.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoRelayService.java
@@ -42,6 +42,13 @@ public class OctoRelayService
      */
     public static final String ADDRESS_PNAME
         = "org.jitsi.videobridge.octo.BIND_ADDRESS";
+        
+    /**
+     * The name of the configuration property which controls the public address which 
+     * will be used as part of relayId.
+     */
+    public static final String PUBLIC_ADDRESS_PNAME
+        = "org.jitsi.videobridge.octo.PUBLIC_ADDRESS";
 
     /**
      * The name of the property which controls the port number which the Octo
@@ -81,6 +88,7 @@ public class OctoRelayService
                     bundleContext, ConfigurationService.class);
 
         String address = cfg.getString(ADDRESS_PNAME, null);
+        String publicAddress = cfg.getString(PUBLIC_ADDRESS_PNAME, address);
         int port = cfg.getInt(PORT_PNAME, -1);
 
         if (address != null && NetworkUtils.isValidPortNumber(port))
@@ -88,7 +96,7 @@ public class OctoRelayService
             try
             {
                 relay = new OctoRelay(address, port);
-
+                relay.setPublicAddress(publicAddress);
                 bundleContext
                     .registerService(OctoRelayService.class.getName(), this,
                                      null);


### PR DESCRIPTION
Many cloud providers, like `Scaleway` do not allows to bind directly to public ip, for those relayId may be configurable and can be different from bindAddress. 
E.g. bind to 0.0.0.0:42000 but relayId will be `11.11.11.11:42000`.
