### PR TITLE
Fix typo on simulcast.md

### DIFF
--- a/doc/simulcast.md
+++ b/doc/simulcast.md
@@ -133,7 +133,7 @@ mode and that we have no further improvements planned for it.
 
 ## Signaling
 
-Simulcast routing is enabled through COLIBRI sinaling. We signal simulcast to
+Simulcast routing is enabled through COLIBRI signaling. We signal simulcast to
 the bridge through COLIBRI like this:
 
 	<content name='video'>


### PR DESCRIPTION
I found a minor typo on `doc/simulcast.md` (line 136). Thanks for the awesome opensource :)