### PR TITLE
Exclude SLF4J multiple bindings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,16 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-stats</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-jdk14</artifactId>
+        </exclusion>
+      </exclusions>
       <version>1.0-20171010.224039-4</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
This patch resolves the multiple SLF4J bindings error for current version (https://github.com/jitsi/jitsi-videobridge/commit/82d5c7a25d215de59360b2584c033bf3e700ac42) of JVB upon compile. Tested on Ubuntu 16.04.