### PR TITLE
fix: release resources when shutting down.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ice4j</artifactId>
-      <version>2.0.0-20171114.204540-5</version>
+      <version>2.0.0-20180516.224537-8</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
+++ b/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
@@ -299,6 +299,37 @@ public class IceUdpTransportManager
     }
 
     /**
+     * Stops the static <tt>Harvester</tt> instances used by all
+     * <tt>IceUdpTransportManager</tt> instances, that is
+     * {@link #tcpHarvester} and {@link #singlePortHarvesters}.
+     *
+     * @param cfg the {@link ConfigurationService} which provides values to
+     * configurable properties of the behavior/logic of the method
+     * implementation
+     */
+    public static void closeStaticConfiguration(ConfigurationService cfg)
+    {
+        synchronized (IceUdpTransportManager.class)
+        {
+            if (!staticConfigurationInitialized)
+            {
+                return;
+            }
+            staticConfigurationInitialized = false;
+
+            if (singlePortHarvesters != null)
+            {
+                singlePortHarvesters.forEach(AbstractUdpListener::close);
+            }
+
+            if (tcpHarvester != null)
+            {
+                tcpHarvester.close();
+            }
+        }
+    }
+
+    /**
      * The single (if any) <tt>Channel</tt> instance, whose sockets are
      * currently configured to accept DTLS packets.
      */

--- a/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
+++ b/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
@@ -320,12 +320,17 @@ public class IceUdpTransportManager
             if (singlePortHarvesters != null)
             {
                 singlePortHarvesters.forEach(AbstractUdpListener::close);
+                singlePortHarvesters = null;
             }
 
             if (tcpHarvester != null)
             {
                 tcpHarvester.close();
+                tcpHarvester = null;
             }
+
+            // Reset the flag to initial state.
+            healthy = true;
         }
     }
 

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -1629,7 +1629,11 @@ public class Videobridge
         // Shut down harvesters.
         IceUdpTransportManager.closeStaticConfiguration(cfg);
 
-        // Clear all system properties that were ice4j properties.
+        // Clear all system properties that were ice4j properties. This is done
+        // to deal with any properties that are conditionally set during
+        // initialization. If the conditions have changed upon restart (of the
+        // component, rather than the JVM), it would not be enough to "not set"
+        // the system property (as it would have survived the restart).
         if (cfg != null)
         {
             List<String> ice4jPropertyNames

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -1598,8 +1598,36 @@ public class Videobridge
     void stop(BundleContext bundleContext)
         throws Exception
     {
-        videobridgeExpireThread.stop(bundleContext);
-        this.bundleContext = null;
+        try
+        {
+            ConfigurationService cfg
+                = ServiceUtils2.getService(
+                    bundleContext,
+                    ConfigurationService.class);
+
+            stopIce4j(bundleContext, cfg);
+        }
+        finally
+        {
+            videobridgeExpireThread.stop(bundleContext);
+            this.bundleContext = null;
+        }
+    }
+
+    /**
+     * Implements the ice4j-related portion of {@link #stop(BundleContext)}.
+     *
+     * @param bundleContext the {@code BundleContext} in which this
+     * {@code Videobridge} is to start
+     * @param cfg the {@code ConfigurationService} registered in
+     * {@code bundleContext}. Explicitly provided for the sake of performance.
+     */
+    private void stopIce4j(
+        BundleContext bundleContext,
+        ConfigurationService cfg)
+    {
+        // Shut down harvesters.
+        IceUdpTransportManager.closeStaticConfiguration(cfg);
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -1628,6 +1628,46 @@ public class Videobridge
     {
         // Shut down harvesters.
         IceUdpTransportManager.closeStaticConfiguration(cfg);
+
+        // Clear all system properties that were ice4j properties.
+        if (cfg != null)
+        {
+            List<String> ice4jPropertyNames
+                = cfg.getPropertyNamesByPrefix("org.ice4j.", false);
+
+            if (ice4jPropertyNames != null && !ice4jPropertyNames.isEmpty())
+            {
+                for (String propertyName : ice4jPropertyNames)
+                {
+                    System.clearProperty(propertyName);
+                }
+            }
+
+            // These properties are moved to ice4j. This is to make sure that we
+            // still support the old names.
+            String oldPrefix = "org.jitsi.videobridge";
+            String newPrefix = "org.ice4j.ice.harvest";
+            for (String propertyName : new String[]{
+                HarvesterConfiguration.NAT_HARVESTER_LOCAL_ADDRESS,
+                HarvesterConfiguration.NAT_HARVESTER_PUBLIC_ADDRESS,
+                HarvesterConfiguration.DISABLE_AWS_HARVESTER,
+                HarvesterConfiguration.FORCE_AWS_HARVESTER,
+                HarvesterConfiguration.STUN_MAPPING_HARVESTER_ADDRESSES})
+            {
+                String propertyValue = cfg.getString(propertyName);
+
+                if (propertyValue != null)
+                {
+                    String newPropertyName
+                        = newPrefix
+                        + propertyName.substring(oldPrefix.length());
+                    System.clearProperty(newPropertyName);
+                }
+            }
+
+            System.clearProperty(VideoChannel.ENABLE_LIPSYNC_HACK_PNAME);
+            System.clearProperty(RtxTransformer.DISABLE_NACK_TERMINATION_PNAME);
+        }
     }
 
     /**


### PR DESCRIPTION
When the bridge is being closed, resources should be released explicitly. This commit closes down harvesters, which in turn unbinds from the network interface.