### PR TITLE
Add config option to disable filtering tracks by owner

### DIFF
--- a/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -16,6 +16,8 @@
 package org.jitsi.videobridge;
 
 import org.jitsi.impl.neomedia.rtp.*;
+import org.jitsi.service.configuration.ConfigurationService;
+import org.jitsi.service.libjitsi.LibJitsi;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.util.event.*;
 
@@ -35,6 +37,18 @@ import java.util.stream.*;
  */
 public abstract class AbstractEndpoint extends PropertyChangeNotifier
 {
+    /**
+     * The name of the property used to disable filtering tracks by owner.
+     */
+    public static final String DISABLE_FILTERING_TRACKS_BY_OWNER_PNAME
+        = "org.jitsi.videobridge.DISABLE_FILTERING_TRACKS_BY_OWNER";
+
+    /**
+     * The ConfigurationService to get config values from.
+     */
+    private static final ConfigurationService cfg
+        = LibJitsi.getConfigurationService();
+
     /**
      * Filters a list of {@code tracks}, and returns the list consisting of the
      * tracks which have a given {@code owner}.
@@ -425,9 +439,21 @@ public abstract class AbstractEndpoint extends PropertyChangeNotifier
                 trackReceiver -> allTracks.addAll(
                     Arrays.asList(trackReceiver.getMediaStreamTracks())));
 
-        return
-            filterTracksByOwner(allTracks, getID())
-                .toArray(new MediaStreamTrackDesc[0]);
+        boolean disableFilteringTracks = cfg != null
+            && cfg.getBoolean(DISABLE_FILTERING_TRACKS_BY_OWNER_PNAME, false);
+
+        List<MediaStreamTrackDesc> filteredTracks;
+
+        if (disableFilteringTracks)
+        {
+            filteredTracks = allTracks;
+        }
+        else
+        {
+            filteredTracks = filterTracksByOwner(allTracks, getID());
+        }
+
+        return filteredTracks.toArray(new MediaStreamTrackDesc[0]);
     }
 
 


### PR DESCRIPTION
If you do not specify an owner for a SourcePacketExtension there is no video and log is full of these warnings:
JVB 2018-05-01 21:22:16.504 WARNING: [11116] org.jitsi.videobridge.cc.BitrateController.log() Dropping an RTP packet, because the SSRC has not been signaled:1944969955

I think there are many of us who does not need this feature and you cannot set the owner via REST API by the way and the whole implementation is based on XMPP (owner is stored as org.jxmpp.jid.Jid) so I think it makes sense to make it configurable.

Let me know what you think and feel free to make any modifications or tell me if formatting, naming, variable order, etc. needs to be changed.