### PR TITLE
Notify endpoints if they are currently selected

### DIFF
--- a/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -434,4 +434,23 @@ public abstract class AbstractEndpoint extends PropertyChangeNotifier
      */
     public abstract void sendMessage(String msg)
         throws IOException;
+
+    /**
+     * Notify this endpoint that another endpoint has set it
+     * as a 'selected' endpoint, meaning its HD stream has another
+     * consumer.
+     */
+    public void incrementSelectedCount()
+    {
+        // No-op
+    }
+
+    /**
+     * Notify this endpoint that another endpoint has stopped consuming
+     * its HD stream.
+     */
+    public void decrementSelectedCount()
+    {
+        // No-op
+    }
 }

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -1435,6 +1435,26 @@ public class Conference
         {
             speechActivityPropertyChange(ev);
         }
+        else if (Endpoint.SELECTED_ENDPOINTS_PROPERTY_NAME.equals(ev.getPropertyName()))
+        {
+            Set<String> oldSelectedEndpoints = (Set<String>)ev.getOldValue();
+            Set<String> newSelectedEndpoints = (Set<String>)ev.getNewValue();
+            // Any endpoints in the oldSelectedEndpoints list which AREN'T
+            // in the newSelectedEndpoints list should have their count decremented
+            oldSelectedEndpoints.stream()
+                .filter(oldSelectedEp -> !newSelectedEndpoints.contains(oldSelectedEp))
+                .map(this::getEndpoint)
+                .filter(Objects::nonNull)
+                .forEach(AbstractEndpoint::decrementSelectedCount);
+
+            // Any endpoints in the newSelectedEndpoints list which AREN'T
+            // in the oldSelectedEndpoints list should have their count incremented
+            newSelectedEndpoints.stream()
+                .filter(newSelectedEp -> !oldSelectedEndpoints.contains(newSelectedEp))
+                .map(this::getEndpoint)
+                .filter(Objects::nonNull)
+                .forEach(AbstractEndpoint::incrementSelectedCount);
+        }
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -15,15 +15,14 @@
  */
 package org.jitsi.videobridge;
 
+import org.jitsi.util.*;
+import org.jitsi.videobridge.rest.*;
+
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
-import org.jitsi.util.*;
-import org.jitsi.videobridge.rest.*;
-import org.json.simple.*;
-
-import static org.jitsi.videobridge.EndpointMessageBuilder.createSelectedUpdateMessage;
+import static org.jitsi.videobridge.EndpointMessageBuilder.*;
 
 /**
  * Represents an endpoint of a participant in a <tt>Conference</tt>.

--- a/src/main/java/org/jitsi/videobridge/EndpointMessageBuilder.java
+++ b/src/main/java/org/jitsi/videobridge/EndpointMessageBuilder.java
@@ -99,6 +99,13 @@ public class EndpointMessageBuilder
         = "SelectedEndpointsChangedEvent";
 
     /**
+     * The {@link Videobridge#COLIBRI_CLASS} value indicating a
+     * {@code SelectedUpdateEvent}.
+     */
+    public static final String COLIBRI_CLASS_SELECTED_UPDATE
+        = "SelectedUpdateEvent";
+
+    /**
      * The string which encodes a COLIBRI {@code ServerHello} message.
      */
     public static final String COLIBRI_CLASS_SERVER_HELLO = "ServerHello";
@@ -176,6 +183,22 @@ public class EndpointMessageBuilder
 
         return msg.toString();
     }
+
+    /**
+     * Create a {@link EndpointMessageBuilder#COLIBRI_CLASS_SELECTED_UPDATE}
+     * colibri message
+     * @param isSelected whether or not this endpoint has been marked as a
+     * selected endpoint
+     * @return a JSON string serialization of the created message
+     */
+    public static String createSelectedUpdateMessage(boolean isSelected)
+    {
+        JSONObject selectedUpdate = new JSONObject();
+        selectedUpdate.put("colibriClass", COLIBRI_CLASS_SELECTED_UPDATE);
+        selectedUpdate.put("isSelected", isSelected);
+        return selectedUpdate.toJSONString();
+    }
+
 
     private static String getJsonString(Collection<String> strings)
     {


### PR DESCRIPTION
Start tracking which endpoints are 'selected' and notify the endpoints
if they just transitioned from being selected by no participants
to being selected by at least one or vice versa.