### PR TITLE
Prevent forcefully enabling the dynamic host harvester

### DIFF
--- a/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
+++ b/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java
@@ -756,7 +756,7 @@ public class IceUdpTransportManager
             = ServiceUtils.getService(
                     getBundleContext(),
                     ConfigurationService.class);
-        boolean enableDynamicHostHarvester = true;
+        boolean disableDynamicHostHarvester = false;
 
         if (rtcpmux)
         {
@@ -779,13 +779,17 @@ public class IceUdpTransportManager
                 for (CandidateHarvester harvester : singlePortHarvesters)
                 {
                     iceAgent.addCandidateHarvester(harvester);
-                    enableDynamicHostHarvester = false;
+                    disableDynamicHostHarvester = true;
                 }
             }
         }
 
-        // Use dynamic ports iff we're not using "single port".
-        iceAgent.setUseHostHarvester(enableDynamicHostHarvester);
+        // Disable dynamic ports (UDP) if we're using "single port" (UPD), as
+        // there's no need for a client to try a similar UDP candidate twice.
+        if (disableDynamicHostHarvester)
+        {
+            iceAgent.setUseHostHarvester(false);
+        }
     }
 
     /**


### PR DESCRIPTION
When the single-port UDP harvester is available, there's no need to offer the dynamic-port UDP harvester to the client, as there's little chance that the client would have a different result using either.

However, this does not mean that when _not_ using single-port UDP harvester, the dynamic-port UDP harvester should be forcefully _enabled_. The dynamic-port harvester is enabled by default. By forcefully enabling it, its configuration option (`org.ice4j.ice.harvest.USE_DYNAMIC_HOST_HARVESTER`) is overridden, which is undesirable (as it prevents one from disabling this harvester).