### PR TITLE
feat: Adds new stats to track bwe limited-seconds and participant-seconds.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-20180607.160234-352</version>
+      <version>1.0-20180705.203709-354</version>
     </dependency>
 
     <dependency>

--- a/resources/link-conditioner.sh
+++ b/resources/link-conditioner.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+PLR=${PLR:-'0.1'}
+DELAY=${DELAY:-100}
+BW=${BW:-'10Mbit/s'}
+PORT=10000
+
+condition_egress() {
+   # Create an anchor and reload pf conf.
+   (cat /etc/pf.conf && echo "dummynet-anchor \"jitsi-videobridge\"" && echo "anchor \"jitsi-videobridge\"") | sudo pfctl -f -
+
+   # Pipe all UDP traffic from port PORT through the egress pipe.
+   echo "dummynet out quick proto udp from any port $PORT to any pipe 1" | sudo pfctl -a jitsi-videobridge -f -
+
+   # Configure the egress pipe.
+   sudo dnctl pipe 1 config bw $BW plr $PLR delay $DELAY
+}
+
+condition_ingress() {
+   # Create an anchor and reload pf conf.
+   (cat /etc/pf.conf && echo "dummynet-anchor \"jitsi-videobridge\"" && echo "anchor \"jitsi-videobridge\"") | sudo pfctl -f -
+
+   # Pipe all UDP traffic to port PORT through the ingress pipe.
+   echo "dummynet out quick proto udp from any to any port $PORT pipe 2" | sudo pfctl -a jitsi-videobridge -f -
+
+   # Configure the ingress pipe.
+   sudo dnctl pipe 2 config bw $BW plr $PLR delay $DELAY
+}
+
+condition_flush() {
+   sudo dnctl -f flush
+   sudo pfctl -f /etc/pf.conf
+}
+
+main() {
+   case "$1" in
+      ingress)
+         condition_ingress
+         ;;
+      egress)
+         condition_egress
+         ;;
+      flush)
+         condition_flush
+         ;;
+   esac
+}
+
+main "$@"

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -312,7 +312,12 @@ public class Conference
     public void appendDiagnosticInformation(DiagnosticContext diagnosticContext)
     {
         Objects.requireNonNull(diagnosticContext);
-        diagnosticContext.put("conf_name", name.toString());
+
+        if (name != null)
+        {
+            diagnosticContext.put("conf_name", name.toString());
+        }
+
         diagnosticContext.put("conf_creation_time_ms", creationTimeMs);
     }
 

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -312,7 +312,7 @@ public class Conference
     public void appendDiagnosticInformation(DiagnosticContext diagnosticContext)
     {
         Objects.requireNonNull(diagnosticContext);
-        diagnosticContext.put("conf_name", name);
+        diagnosticContext.put("conf_name", name.toString());
         diagnosticContext.put("conf_creation_time_ms", creationTimeMs);
     }
 

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -479,24 +479,27 @@ public class VideoChannel
             if (bwe != null)
             {
                 BandwidthEstimator.Statistics bweStats = bwe.getStatistics();
-                bweStats.update(System.currentTimeMillis());
+                if (bweStats != null)
+                {
+                    bweStats.update(System.currentTimeMillis());
 
-                Videobridge.Statistics videobridgeStats
-                    = getContent().getConference().getVideobridge()
-                    .getStatistics();
+                    Videobridge.Statistics videobridgeStats
+                        = getContent().getConference().getVideobridge()
+                        .getStatistics();
 
-                long lossLimitedMs = bweStats.getLossLimitedMs();
-                long lossDegradedMs = bweStats.getLossDegradedMs();
-                long participantMs = bweStats.getLossFreeMs()
-                    + lossDegradedMs + lossLimitedMs;
+                    long lossLimitedMs = bweStats.getLossLimitedMs();
+                    long lossDegradedMs = bweStats.getLossDegradedMs();
+                    long participantMs = bweStats.getLossFreeMs()
+                        + lossDegradedMs + lossLimitedMs;
 
-                videobridgeStats.totalLossControlledParticipantMs
-                    .addAndGet(participantMs);
-                videobridgeStats.totalLossLimitedParticipantMs
-                    .addAndGet(lossLimitedMs);
+                    videobridgeStats.totalLossControlledParticipantMs
+                        .addAndGet(participantMs);
+                    videobridgeStats.totalLossLimitedParticipantMs
+                        .addAndGet(lossLimitedMs);
 
-                videobridgeStats.totalLossDegradedParticipantMs
-                    .addAndGet(lossDegradedMs);
+                    videobridgeStats.totalLossDegradedParticipantMs
+                        .addAndGet(lossDegradedMs);
+                }
             }
         }
 

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -473,27 +473,31 @@ public class VideoChannel
         MediaStream mediaStream = getStream();
         if (mediaStream instanceof VideoMediaStream)
         {
-            BandwidthEstimator.Statistics bweStats
-                = ((VideoMediaStream) mediaStream)
-                .getOrCreateBandwidthEstimator().getStatistics();
-            bweStats.update(System.currentTimeMillis());
+            BandwidthEstimator bwe = ((VideoMediaStream) mediaStream)
+                .getOrCreateBandwidthEstimator();
 
-            Videobridge.Statistics videobridgeStats
-                = getContent().getConference().getVideobridge()
-                .getStatistics();
+            if (bwe != null)
+            {
+                BandwidthEstimator.Statistics bweStats = bwe.getStatistics();
+                bweStats.update(System.currentTimeMillis());
 
-            long lossLimitedMs = bweStats.getLossLimitedMs();
-            long lossDegradedMs = bweStats.getLossDegradedMs();
-            long participantMs = bweStats.getLossFreeMs()
-                + lossDegradedMs + lossLimitedMs;
+                Videobridge.Statistics videobridgeStats
+                    = getContent().getConference().getVideobridge()
+                    .getStatistics();
 
-            videobridgeStats.totalLossControlledParticipantMs
-                .addAndGet(participantMs);
-            videobridgeStats.totalLossLimitedParticipantMs
-                .addAndGet(lossLimitedMs);
+                long lossLimitedMs = bweStats.getLossLimitedMs();
+                long lossDegradedMs = bweStats.getLossDegradedMs();
+                long participantMs = bweStats.getLossFreeMs()
+                    + lossDegradedMs + lossLimitedMs;
 
-            videobridgeStats.totalLossDegradedParticipantMs
-                .addAndGet(lossDegradedMs);
+                videobridgeStats.totalLossControlledParticipantMs
+                    .addAndGet(participantMs);
+                videobridgeStats.totalLossLimitedParticipantMs
+                    .addAndGet(lossLimitedMs);
+
+                videobridgeStats.totalLossDegradedParticipantMs
+                    .addAndGet(lossDegradedMs);
+            }
         }
 
         return true;

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -482,18 +482,18 @@ public class VideoChannel
                 = getContent().getConference().getVideobridge()
                 .getStatistics();
 
-            long lossLimitedSeconds = bweStats.getLossLimitedMs() / 1000;
-            long lossDegradedSeconds = bweStats.getLossDegradedMs() / 1000;
-            long participantSeconds = bweStats.getLossFreeMs() / 1000
-                + lossDegradedSeconds + lossLimitedSeconds;
+            long lossLimitedMs = bweStats.getLossLimitedMs();
+            long lossDegradedMs = bweStats.getLossDegradedMs();
+            long participantMs = bweStats.getLossFreeMs()
+                + lossDegradedMs + lossLimitedMs;
 
-            videobridgeStats.totalParticipantSeconds
-                .addAndGet(participantSeconds);
-            videobridgeStats.totalLossLimitedParticipantSeconds
-                .addAndGet(lossLimitedSeconds);
+            videobridgeStats.totalLossControlledParticipantMs
+                .addAndGet(participantMs);
+            videobridgeStats.totalLossLimitedParticipantMs
+                .addAndGet(lossLimitedMs);
 
-            videobridgeStats.totalLossDegradedParticipantSeconds
-                .addAndGet(lossDegradedSeconds);
+            videobridgeStats.totalLossDegradedParticipantMs
+                .addAndGet(lossDegradedMs);
         }
 
         return true;

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -1834,6 +1834,24 @@ public class Videobridge
         public AtomicLong totalConferenceSeconds = new AtomicLong();
 
         /**
+         * The total duration in seconds of all participants on this
+         * {@link Videobridge}.
+         */
+        public AtomicLong totalParticipantSeconds = new AtomicLong();
+
+        /**
+         * The total duration in seconds of all completed conferences on this
+         * {@link Videobridge}.
+         */
+        public AtomicLong totalLossLimitedParticipantSeconds = new AtomicLong();
+
+        /**
+         * The total duration in seconds of all completed conferences on this
+         * {@link Videobridge}.
+         */
+        public AtomicLong totalLossDegradedParticipantSeconds = new AtomicLong();
+
+        /**
          * The total number of ICE transport managers on this videobridge which
          * successfully connected over UDP.
          */

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -1834,22 +1834,24 @@ public class Videobridge
         public AtomicLong totalConferenceSeconds = new AtomicLong();
 
         /**
-         * The total duration in seconds of all participants on this
-         * {@link Videobridge}.
+         * The total number of participant-milliseconds that are loss-controlled
+         * (i.e. the sum of the lengths is seconds) on this {@link Videobridge}.
          */
-        public AtomicLong totalParticipantSeconds = new AtomicLong();
+        public AtomicLong totalLossControlledParticipantMs = new AtomicLong();
 
         /**
-         * The total duration in seconds of all completed conferences on this
-         * {@link Videobridge}.
+         * The total number of participant-milliseconds that are loss-limited
+         * on this {@link Videobridge}.
          */
-        public AtomicLong totalLossLimitedParticipantSeconds = new AtomicLong();
+        public AtomicLong totalLossLimitedParticipantMs = new AtomicLong();
 
         /**
-         * The total duration in seconds of all completed conferences on this
-         * {@link Videobridge}.
+         * The total number of participant-milliseconds that are loss-degraded
+         * on this {@link Videobridge}. We chose the unit to be millis because
+         * we expect that a lot of our calls spend very few ms (<500) in the
+         * lossDegraded state for example, and they might get cut to 0.
          */
-        public AtomicLong totalLossDegradedParticipantSeconds = new AtomicLong();
+        public AtomicLong totalLossDegradedParticipantMs = new AtomicLong();
 
         /**
          * The total number of ICE transport managers on this videobridge which

--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -602,7 +602,7 @@ public class BitrateController
                         // gets forwarded to a specific receiver.
                         timeSeriesLogger.trace(diagnosticContext
                                 .makeTimeSeriesPoint("track_quality", nowMs)
-                                .addKey("track_id", sourceTrack.hashCode())
+                                .addField("track_id", sourceTrack.hashCode())
                                 .addField("current_idx", trackCurrentIdx)
                                 .addField("target_idx", trackTargetIdx)
                                 .addField("optimal_idx", trackOptimalIdx)

--- a/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -206,6 +206,27 @@ public class VideobridgeStatistics
         = "total_conference_seconds";
 
     /**
+     * The name of the stat indicating the total number of participant-seconds
+     * (i.e. the sum of the lengths is seconds).
+     */
+    private static final String TOTAL_PARTICIPANT_SECONDS
+        = "total_participant_seconds";
+
+    /**
+     * The name of the stat indicating the total number of participant-seconds
+     * that are loss-limited.
+     */
+    private static final String TOTAL_LOSS_LIMITED_PARTICIPANT_SECONDS
+        = "total_loss_limited_participant_seconds";
+
+    /**
+     * The name of the stat indicating the total number of participant-seconds
+     * that are loss-degraded.
+     */
+    private static final String TOTAL_LOSS_DEGRADED_PARTICIPANT_SECONDS
+        = "total_loss_degraded_participant_seconds";
+
+    /**
      * The name of the stat indicating the total number of media connections
      * established over UDP.
      */
@@ -423,7 +444,10 @@ public class VideobridgeStatistics
             totalFailedConferences = 0, totalPartiallyFailedConferences = 0,
             totalNoTransportChannels = 0, totalNoPayloadChannels = 0,
             totalChannels = 0;
-        long totalConferenceSeconds = 0;
+        long totalConferenceSeconds = 0,
+            totalParticipantSeconds = 0,
+            totalLossLimitedParticipantSeconds = 0,
+            totalLossDegradedParticipantSeconds = 0;
         int totalUdpConnections = 0, totalTcpConnections = 0;
         long totalDataChannelMessagesReceived = 0;
         long totalDataChannelMessagesSent = 0;
@@ -445,6 +469,11 @@ public class VideobridgeStatistics
             totalConferencesCompleted
                 += jvbStats.totalConferencesCompleted.get();
             totalConferenceSeconds += jvbStats.totalConferenceSeconds.get();
+            totalParticipantSeconds += jvbStats.totalParticipantSeconds.get();
+            totalLossLimitedParticipantSeconds
+                += jvbStats.totalLossLimitedParticipantSeconds.get();
+            totalLossDegradedParticipantSeconds
+                += jvbStats.totalLossDegradedParticipantSeconds.get();
             totalFailedConferences += jvbStats.totalFailedConferences.get();
             totalPartiallyFailedConferences
                 += jvbStats.totalPartiallyFailedConferences.get();
@@ -655,6 +684,11 @@ public class VideobridgeStatistics
             unlockedSetStat(TOTAL_UDP_CONNECTIONS, totalUdpConnections);
             unlockedSetStat(TOTAL_TCP_CONNECTIONS, totalTcpConnections);
             unlockedSetStat(TOTAL_CONFERENCE_SECONDS, totalConferenceSeconds);
+            unlockedSetStat(TOTAL_PARTICIPANT_SECONDS, totalParticipantSeconds);
+            unlockedSetStat(TOTAL_LOSS_LIMITED_PARTICIPANT_SECONDS,
+                    totalLossLimitedParticipantSeconds);
+            unlockedSetStat(TOTAL_LOSS_DEGRADED_PARTICIPANT_SECONDS,
+                    totalLossDegradedParticipantSeconds);
             unlockedSetStat(TOTAL_CHANNELS, totalChannels);
             unlockedSetStat(CONFERENCES, conferences);
             unlockedSetStat(NUMBEROFPARTICIPANTS, endpoints);

--- a/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -207,10 +207,10 @@ public class VideobridgeStatistics
 
     /**
      * The name of the stat indicating the total number of participant-seconds
-     * (i.e. the sum of the lengths is seconds).
+     * that are loss-controlled (i.e. the sum of the lengths is seconds).
      */
-    private static final String TOTAL_PARTICIPANT_SECONDS
-        = "total_participant_seconds";
+    private static final String TOTAL_LOSS_CONTROLLED_PARTICIPANT_SECONDS
+        = "total_loss_controlled_participant_seconds";
 
     /**
      * The name of the stat indicating the total number of participant-seconds
@@ -445,7 +445,7 @@ public class VideobridgeStatistics
             totalNoTransportChannels = 0, totalNoPayloadChannels = 0,
             totalChannels = 0;
         long totalConferenceSeconds = 0,
-            totalParticipantSeconds = 0,
+            totalLossControlledParticipantSeconds = 0,
             totalLossLimitedParticipantSeconds = 0,
             totalLossDegradedParticipantSeconds = 0;
         int totalUdpConnections = 0, totalTcpConnections = 0;
@@ -469,11 +469,12 @@ public class VideobridgeStatistics
             totalConferencesCompleted
                 += jvbStats.totalConferencesCompleted.get();
             totalConferenceSeconds += jvbStats.totalConferenceSeconds.get();
-            totalParticipantSeconds += jvbStats.totalParticipantSeconds.get();
+            totalLossControlledParticipantSeconds
+                += jvbStats.totalLossControlledParticipantMs.get() / 1000;
             totalLossLimitedParticipantSeconds
-                += jvbStats.totalLossLimitedParticipantSeconds.get();
+                += jvbStats.totalLossLimitedParticipantMs.get() / 1000;
             totalLossDegradedParticipantSeconds
-                += jvbStats.totalLossDegradedParticipantSeconds.get();
+                += jvbStats.totalLossDegradedParticipantMs.get() / 1000;
             totalFailedConferences += jvbStats.totalFailedConferences.get();
             totalPartiallyFailedConferences
                 += jvbStats.totalPartiallyFailedConferences.get();
@@ -684,7 +685,8 @@ public class VideobridgeStatistics
             unlockedSetStat(TOTAL_UDP_CONNECTIONS, totalUdpConnections);
             unlockedSetStat(TOTAL_TCP_CONNECTIONS, totalTcpConnections);
             unlockedSetStat(TOTAL_CONFERENCE_SECONDS, totalConferenceSeconds);
-            unlockedSetStat(TOTAL_PARTICIPANT_SECONDS, totalParticipantSeconds);
+            unlockedSetStat(TOTAL_LOSS_CONTROLLED_PARTICIPANT_SECONDS,
+                totalLossControlledParticipantSeconds);
             unlockedSetStat(TOTAL_LOSS_LIMITED_PARTICIPANT_SECONDS,
                     totalLossLimitedParticipantSeconds);
             unlockedSetStat(TOTAL_LOSS_DEGRADED_PARTICIPANT_SECONDS,


### PR DESCRIPTION
This PR adds three new stats:
- total participant-seconds
- total loss-limited participant-seconds (which is the total number of
  seconds that the bandwidth is limited due to loss.
- total loss-degraded participant seconds (which is the total number of
  seconds that the bandwidth is degraded due to loss.

Depends on https://github.com/jitsi/libjitsi/pull/426