### PR TITLE
feat: Adds an XMPP client connection interface.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jicoco</artifactId>
-      <version>1.1-20180327.183532-3</version>
+      <version>1.1-20180710.162527-5</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <assembly.skipAssembly>true</assembly.skipAssembly>
     <exec.mainClass>org.jitsi.videobridge.Main</exec.mainClass>
     <jitsi-desktop.version>2.13.f0a8003</jitsi-desktop.version>
-    <smack.version>4.2.1</smack.version>
+    <smack.version>4.2.2-b1c107f</smack.version>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/org/jitsi/videobridge/AudioChannel.java
+++ b/src/main/java/org/jitsi/videobridge/AudioChannel.java
@@ -61,14 +61,12 @@ public class AudioChannel
      * or {@link RawUdpTransportPacketExtension#NAMESPACE}.
      * @param initiator the value to use for the initiator field, or
      * <tt>null</tt> to use the default value.
-     * @throws Exception if an error occurs while initializing the new instance
      */
     public AudioChannel(Content content,
                         String id,
                         String channelBundleId,
                         String transportNamespace,
                         Boolean initiator)
-        throws Exception
     {
         super(content, id, channelBundleId, transportNamespace, initiator);
     }

--- a/src/main/java/org/jitsi/videobridge/Channel.java
+++ b/src/main/java/org/jitsi/videobridge/Channel.java
@@ -214,7 +214,6 @@ public abstract class Channel
      * {@link RawUdpTransportPacketExtension#NAMESPACE}.
      * @param initiator the value to use for the initiator field, or
      * <tt>null</tt> to use the default value.
-     * @throws Exception if an error occurs while initializing the new instance
      */
     public Channel(
             Content content,
@@ -222,7 +221,6 @@ public abstract class Channel
             String channelBundleId,
             String transportNamespace,
             Boolean initiator)
-        throws Exception
     {
         Objects.requireNonNull(content, "content");
         org.jivesoftware.smack.util.StringUtils.requireNotNullOrEmpty(id, "id");

--- a/src/main/java/org/jitsi/videobridge/Content.java
+++ b/src/main/java/org/jitsi/videobridge/Content.java
@@ -283,14 +283,15 @@ public class Content
      * @param rtpLevelRelayType
      * @return the created <tt>RtpChannel</tt> instance.
      * @param octo whether to create a regular channel or an Octo channel.
-     * @throws Exception
+     * @throws IOException if the new {@link RtpChannel} instance failed to
+     * initialize.
      */
     public RtpChannel createRtpChannel(String channelBundleId,
                                        String transportNamespace,
                                        Boolean initiator,
                                        RTPLevelRelayType rtpLevelRelayType,
                                        boolean octo)
-        throws Exception
+        throws IOException
     {
         RtpChannel channel;
 
@@ -384,16 +385,15 @@ public class Content
      * @param initiator the value to use for the initiator field, or
      * <tt>null</tt> to use the default value.
      * @return new <tt>SctpConnection</tt> with given <tt>Endpoint</tt>
-     * @throws Exception if an error occurs while initializing the new instance
-     * @throws IllegalArgumentException if <tt>SctpConnection</tt> exists
-     * already for given <tt>Endpoint</tt>.
+     * @throws IOException if the new {@link SctpConnection} instance fails to
+     * initialize.
      */
     public SctpConnection createSctpConnection(
             AbstractEndpoint endpoint,
             int sctpPort,
             String channelBundleId,
             Boolean initiator)
-        throws Exception
+        throws IOException
     {
         SctpConnection sctpConnection;
 

--- a/src/main/java/org/jitsi/videobridge/RtpChannel.java
+++ b/src/main/java/org/jitsi/videobridge/RtpChannel.java
@@ -262,7 +262,6 @@ public class RtpChannel
      * {@link RawUdpTransportPacketExtension#NAMESPACE}.
      * @param initiator the value to use for the initiator field, or
      * <tt>null</tt> to use the default value.
-     * @throws Exception if an error occurs while initializing the new instance
      */
     public RtpChannel(
             Content content,
@@ -270,7 +269,6 @@ public class RtpChannel
             String channelBundleId,
             String transportNamespace,
             Boolean initiator)
-        throws Exception
     {
         super(content, id, channelBundleId, transportNamespace, initiator);
 
@@ -284,7 +282,7 @@ public class RtpChannel
          * synchronization source identifier (SSRC), which Jitsi Videobridge
          * pre-announces.
          */
-        initialLocalSSRC = Videobridge.RANDOM.nextLong() & 0xffffffffL;
+        initialLocalSSRC = Videobridge.RANDOM.nextLong() & 0xffff_ffffL;
 
         Conference conference = content.getConference();
         conference.addPropertyChangeListener(propertyChangeListener);

--- a/src/main/java/org/jitsi/videobridge/SctpConnection.java
+++ b/src/main/java/org/jitsi/videobridge/SctpConnection.java
@@ -234,7 +234,6 @@ public class SctpConnection
      * @param channelBundleId the ID of the channel-bundle this
      * <tt>SctpConnection</tt> is to be a part of (or <tt>null</tt> if no it is
      * not to be a part of a channel-bundle).
-     * @throws Exception if an error occurs while initializing the new instance
      */
     public SctpConnection(
             String id,
@@ -243,7 +242,6 @@ public class SctpConnection
             int remoteSctpPort,
             String channelBundleId,
             Boolean initiator)
-        throws Exception
     {
         super(content,
               id,

--- a/src/main/java/org/jitsi/videobridge/VideoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/VideoChannel.java
@@ -236,14 +236,12 @@ public class VideoChannel
      * or {@link RawUdpTransportPacketExtension#NAMESPACE}.
      * @param initiator the value to use for the initiator field, or
      * <tt>null</tt> to use the default value.
-     * @throws Exception if an error occurs while initializing the new instance
      */
     VideoChannel(Content content,
                  String id,
                  String channelBundleId,
                  String transportNamespace,
                  Boolean initiator)
-        throws Exception
     {
         super(content, id, channelBundleId, transportNamespace, initiator);
 

--- a/src/main/java/org/jitsi/videobridge/octo/OctoChannel.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoChannel.java
@@ -107,10 +107,8 @@ public class OctoChannel
      * list of <tt>Channel</tt>s listed in <tt>content</tt> while the new
      * instance
      * is listed there as well.
-     * @throws Exception if an error occurs while initializing the new instance
      */
     public OctoChannel(Content content, String id)
-        throws Exception
     {
         super(
                 content, id, null /*channelBundleId*/,

--- a/src/main/java/org/jitsi/videobridge/osgi/JvbBundleConfig.java
+++ b/src/main/java/org/jitsi/videobridge/osgi/JvbBundleConfig.java
@@ -103,6 +103,9 @@ public class JvbBundleConfig
             "org/jitsi/videobridge/EndpointConnectionStatus"
         },
         {
+            "org/jitsi/videobridge/xmpp/ClientConnectionImpl"
+        },
+        {
             "org/jitsi/videobridge/octo/OctoRelayService"
         }
     };

--- a/src/main/java/org/jitsi/videobridge/stats/MucStatsTransport.java
+++ b/src/main/java/org/jitsi/videobridge/stats/MucStatsTransport.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright @ 2018 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.stats;
+
+import net.java.sip.communicator.util.*;
+
+import org.jitsi.videobridge.xmpp.*;
+
+/**
+ * Implements a {@link StatsTransport} which publishes via Presence in an XMPP
+ * MUC.
+ *
+ * @author Boris Grozev
+ */
+public class MucStatsTransport
+    extends StatsTransport
+{
+    /**
+     * The <tt>Logger</tt> used by the <tt>MucStatsTransport</tt> class and
+     * its instances to print debug information.
+     */
+    private static final Logger logger
+        = Logger.getLogger(MucStatsTransport.class);
+
+    /**
+     * Gets the {@link ClientConnectionImpl} to be used to publish
+     * statistics.
+     * @return the {@link ClientConnectionImpl} or {@code null}.
+     */
+    private ClientConnectionImpl getUserConnectionBundleActivator()
+    {
+        return ServiceUtils.getService(
+            getBundleContext(), ClientConnectionImpl.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void publishStatistics(Statistics stats)
+    {
+        ClientConnectionImpl clientConnectionImpl
+            = getUserConnectionBundleActivator();
+        if (clientConnectionImpl != null)
+        {
+            if (logger.isDebugEnabled())
+            {
+                logger.debug("Publishing statistics through MUC: " + stats);
+            }
+
+            clientConnectionImpl
+                .setPresenceExtension(Statistics.toXmppExtensionElement(stats));
+        }
+        else
+        {
+            logger.warn(
+                "Can not publish via presence, no ClientConnectionImpl.");
+        }
+    }
+}
+

--- a/src/main/java/org/jitsi/videobridge/stats/PubSubStatsTransport.java
+++ b/src/main/java/org/jitsi/videobridge/stats/PubSubStatsTransport.java
@@ -64,15 +64,7 @@ public class PubSubStatsTransport
      * in which this <tt>StatsTransport</tt> is started in order to track when
      * <tt>ComponentImpl</tt>s are registered and unregistering.
      */
-    private final ServiceListener serviceListener
-        = new ServiceListener()
-        {
-            @Override
-            public void serviceChanged(ServiceEvent ev)
-            {
-                PubSubStatsTransport.this.serviceChanged(ev);
-            }
-        };
+    private final ServiceListener serviceListener = this::serviceChanged;
 
     /**
      * The name of the service.

--- a/src/main/java/org/jitsi/videobridge/stats/StatsManager.java
+++ b/src/main/java/org/jitsi/videobridge/stats/StatsManager.java
@@ -94,7 +94,7 @@ public class StatsManager
      * <tt>StatsManager</tt> is to periodically send the <tt>Statistics</tt>
      * added to it.
      * <p>
-     * Warning: {@code StatsTransport}s added to this {@code StatsMamanager}
+     * Warning: {@code StatsTransport}s added to this {@code StatsManager}
      * after {@link #start(BundleContext)} has been invoked will not be called.
      * </p>
      *

--- a/src/main/java/org/jitsi/videobridge/stats/StatsManagerBundleActivator.java
+++ b/src/main/java/org/jitsi/videobridge/stats/StatsManagerBundleActivator.java
@@ -101,6 +101,11 @@ public class StatsManagerBundleActivator
     private static final String STAT_TRANSPORT_PUBSUB = "pubsub";
 
     /**
+     * The value used to enable the MUC statistics transport.
+     */
+    private static final String STAT_TRANSPORT_MUC = "muc";
+
+    /**
      * The name of the property which specifies the interval in milliseconds for
      * sending statistics about the Videobridge.
      */
@@ -188,6 +193,11 @@ public class StatsManagerBundleActivator
                         "No configuration properties for PubSub service"
                             + " and/or node found.");
             }
+        }
+        else if (STAT_TRANSPORT_MUC.equalsIgnoreCase(transport))
+        {
+            logger.info("Using a MUC stats transport");
+            t = new MucStatsTransport();
         }
         else
         {

--- a/src/main/java/org/jitsi/videobridge/stats/StatsManagerBundleActivator.java
+++ b/src/main/java/org/jitsi/videobridge/stats/StatsManagerBundleActivator.java
@@ -151,7 +151,7 @@ public class StatsManagerBundleActivator
     private void addTransport(
             StatsManager statsMgr,
             ConfigurationService cfg,
-            long interval,
+            int interval,
             String transport)
     {
         StatsTransport t = null;
@@ -189,11 +189,10 @@ public class StatsManagerBundleActivator
                             + " and/or node found.");
             }
         }
-        else if (transport != null && transport.length() != 0)
+        else
         {
             logger.error(
-                    "Unknown/unsupported statistics transport: "
-                        + transport);
+                    "Unknown/unsupported statistics transport: " + transport);
         }
 
         if (t != null)
@@ -204,7 +203,7 @@ public class StatsManagerBundleActivator
                 = ConfigUtils.getInt(
                         cfg,
                         STATISTICS_INTERVAL_PNAME + "." + transport,
-                        (int) interval);
+                        interval);
 
             // The interval/period of the Statistics better be the same as the
             // interval/period of the StatsTransport.
@@ -234,7 +233,7 @@ public class StatsManagerBundleActivator
     private void addTransports(
             StatsManager statsMgr,
             ConfigurationService cfg,
-            long interval)
+            int interval)
     {
         String transports
             = ConfigUtils.getString(

--- a/src/main/java/org/jitsi/videobridge/xmpp/ClientConnectionImpl.java
+++ b/src/main/java/org/jitsi/videobridge/xmpp/ClientConnectionImpl.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright @ 2018 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.xmpp;
+
+import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
+import net.java.sip.communicator.impl.protocol.jabber.extensions.health.*;
+import net.java.sip.communicator.util.*;
+import org.jitsi.osgi.*;
+import org.jitsi.service.configuration.*;
+import org.jitsi.xmpp.mucclient.*;
+import org.jivesoftware.smack.packet.*;
+import org.osgi.framework.*;
+
+import java.util.*;
+import java.util.function.*;
+
+/**
+ * Provides jitsi-videobridge functions through an XMPP client connection.
+ *
+ * @author Boris Grozev
+ */
+public class ClientConnectionImpl
+    implements BundleActivator, Function<IQ, IQ>
+{
+    /**
+     * The {@link Logger} used by the {@link ClientConnectionImpl}
+     * class and its instances for logging output.
+     */
+    private static final org.jitsi.util.Logger logger
+        =  org.jitsi.util.Logger.getLogger(ClientConnectionImpl.class);
+
+    /**
+     * The prefix of the property names used to configure this bundle.
+     */
+    private static final String PREFIX = "org.jitsi.videobridge.xmpp.user.";
+
+    /**
+     * The {@link MucClientManager} which manages the XMPP user connections
+     * and the MUCs.
+     */
+    private MucClientManager mucClientManager;
+
+    /**
+     * The {@link XmppCommon} instance which implements handling of Smack IQs
+     * for this {@link ClientConnectionImpl}.
+     */
+    private final XmppCommon common = new XmppCommon();
+
+    /**
+     * Starts this bundle.
+     */
+    @Override
+    public void start(BundleContext bundleContext)
+    {
+        ConfigurationService config
+            = ServiceUtils.getService(
+                bundleContext, ConfigurationService.class);
+        if (config == null)
+        {
+            logger.info("Not using XMPP user login; no config service.");
+            return;
+        }
+
+        // Register this instance as an OSGi service.
+        Collection<ClientConnectionImpl> userLoginBundles
+            = ServiceUtils2.getServices(
+                bundleContext, ClientConnectionImpl.class);
+
+        if (!userLoginBundles.contains(this))
+        {
+            common.start(bundleContext);
+
+            mucClientManager = new MucClientManager(XmppCommon.FEATURES);
+
+            // These are the IQs that we are interested in.
+            mucClientManager.registerIQ(new HealthCheckIQ());
+            mucClientManager.registerIQ(new ColibriConferenceIQ());
+            mucClientManager.registerIQ(
+                new org.jivesoftware.smackx.iqversion.packet.Version());
+            mucClientManager.registerIQ(ShutdownIQ.createForceShutdownIQ());
+            mucClientManager.registerIQ(
+                ShutdownIQ.createGracefulShutdownIQ());
+            mucClientManager.setIQListener(this);
+
+            mucClientManager.addMucClients(config, PREFIX);
+
+            bundleContext.registerService(
+                ClientConnectionImpl.class, this, null);
+        }
+        else
+        {
+            logger.error("Already started");
+        }
+    }
+
+    /**
+     * Processes an {@link IQ} received by one of the {@link MucClient}s of
+     * {@link #mucClientManager}.
+     *
+     * @param iq the IQ to process.
+     * @return the IQ to send as a response, or {@code null}.
+     */
+    @Override
+    public IQ apply(IQ iq)
+    {
+        return common.handleIQ(iq);
+    }
+
+    /**
+     * Stops this bundle.
+     */
+    @Override
+    public void stop(BundleContext bundleContext)
+        throws Exception
+    {
+        try
+        {
+            // Unregister this instance as an OSGi service.
+            Collection<ServiceReference<ComponentImpl>> serviceReferences
+                = bundleContext.getServiceReferences(ComponentImpl.class, null);
+
+            if (serviceReferences != null)
+            {
+                for (ServiceReference<ComponentImpl> serviceReference
+                    : serviceReferences)
+                {
+                    Object service = bundleContext.getService(serviceReference);
+
+                    if (service == this)
+                        bundleContext.ungetService(serviceReference);
+                }
+            }
+        }
+        finally
+        {
+            common.stop(bundleContext);
+        }
+    }
+
+    /**
+     * Adds an {@link ExtensionElement} to our presence, and removes any other
+     * extensions with the same element name and namespace, if any exists.
+     * @param extension the extension to add.
+     */
+    public void setPresenceExtension(ExtensionElement extension)
+    {
+        mucClientManager.setPresenceExtension(extension);
+    }
+}

--- a/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java
+++ b/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java
@@ -17,9 +17,7 @@ package org.jitsi.videobridge.xmpp;
 
 import java.util.*;
 
-import net.java.sip.communicator.impl.protocol.jabber.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
-import net.java.sip.communicator.impl.protocol.jabber.extensions.health.*;
 import net.java.sip.communicator.util.*;
 
 import org.jitsi.meet.*;
@@ -27,7 +25,6 @@ import org.jitsi.osgi.*;
 import org.jitsi.service.configuration.*;
 import org.jitsi.xmpp.component.*;
 import org.jitsi.xmpp.util.*;
-import org.jivesoftware.smackx.iqversion.packet.Version;
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.impl.*;
 import org.osgi.framework.*;
@@ -121,19 +118,7 @@ public class ComponentImpl
     @Override
     protected String[] discoInfoFeatureNamespaces()
     {
-        return
-            new String[]
-                    {
-                        ColibriConferenceIQ.NAMESPACE,
-                        HealthCheckIQ.NAMESPACE,
-                        ProtocolProviderServiceJabberImpl
-                            .URN_XMPP_JINGLE_DTLS_SRTP,
-                        ProtocolProviderServiceJabberImpl
-                            .URN_XMPP_JINGLE_ICE_UDP_1,
-                        ProtocolProviderServiceJabberImpl
-                            .URN_XMPP_JINGLE_RAW_UDP_0,
-                        Version.NAMESPACE
-                    };
+        return XmppCommon.FEATURES.clone();
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java
+++ b/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java
@@ -25,11 +25,8 @@ import net.java.sip.communicator.util.*;
 import org.jitsi.meet.*;
 import org.jitsi.osgi.*;
 import org.jitsi.service.configuration.*;
-import org.jitsi.service.version.*;
-import org.jitsi.videobridge.*;
 import org.jitsi.xmpp.component.*;
 import org.jitsi.xmpp.util.*;
-import org.jivesoftware.smack.packet.*;
 import org.jivesoftware.smackx.iqversion.packet.Version;
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.impl.*;
@@ -45,6 +42,7 @@ import org.xmpp.packet.Packet;
  *
  * @author Lyubomir Marinov
  * @author Pawel Domas
+ * @author Boris Grozev
  */
 public class ComponentImpl
     extends ComponentBase
@@ -87,10 +85,10 @@ public class ComponentImpl
     }
 
     /**
-     * The <tt>BundleContext</tt> in which this instance has been started as an
-     * OSGi bundle.
+     * The {@link XmppCommon} instance which implements handling of Smack IQs
+     * for this {@link ComponentImpl}.
      */
-    private BundleContext bundleContext;
+    private final XmppCommon common = new XmppCommon();
 
     /**
      * Initializes a new <tt>ComponentImpl</tt> instance.
@@ -104,11 +102,12 @@ public class ComponentImpl
      * @param secret the password used by the component to authenticate with
      *               XMPP server.
      */
-    public ComponentImpl(String          host,
-                         int             port,
-                         String        domain,
-                         String     subDomain,
-                         String        secret)
+    public ComponentImpl(
+        String host,
+        int port,
+        String domain,
+        String subDomain,
+        String secret)
     {
         super(host, port, domain, subDomain, secret);
     }
@@ -150,18 +149,6 @@ public class ComponentImpl
     }
 
     /**
-     * Gets the OSGi <tt>BundleContext</tt> in which this Jabber component is
-     * executing.
-     *
-     * @return the OSGi <tt>BundleContext</tt> in which this Jabber component is
-     * executing
-     */
-    public BundleContext getBundleContext()
-    {
-        return bundleContext;
-    }
-
-    /**
      * Gets the description of this <tt>Component</tt>.
      *
      * @return the description of this <tt>Component</tt>
@@ -186,54 +173,11 @@ public class ComponentImpl
     }
 
     /**
-     * Returns the {@link Videobridge} instance that is managing conferences
-     * for this component. Returns <tt>null</tt> if no instance is running.
-     *
-     * @return the videobridge instance, <tt>null</tt> when none is running.
-     */
-    public Videobridge getVideobridge()
-    {
-        BundleContext bundleContext = getBundleContext();
-        Videobridge videobridge;
-
-        if (bundleContext == null)
-        {
-            videobridge = null;
-        }
-        else
-        {
-            videobridge
-                = ServiceUtils2.getService(bundleContext, Videobridge.class);
-        }
-        return videobridge;
-    }
-
-    /**
-     * Returns the <tt>VersionService</tt> used by this
-     * <tt>Videobridge</tt>.
-     *
-     * @return the <tt>VersionService</tt> used by this
-     * <tt>Videobridge</tt>.
-     */
-    public VersionService getVersionService()
-    {
-        BundleContext bundleContext = getBundleContext();
-
-        if (bundleContext != null)
-        {
-            return ServiceUtils2.getService(bundleContext,
-                VersionService.class);
-        }
-
-        return null;
-    }
-
-    /**
      * Handles an <tt>org.xmpp.packet.IQ</tt> stanza of type <tt>get</tt> or
      * <tt>set</tt> which represents a request. Converts the specified
      * <tt>org.xmpp.packet.IQ</tt> to an
      * <tt>org.jivesoftware.smack.packet.IQ</tt> stanza, handles the Smack
-     * stanza via a call to {@link #handleIQ(org.jivesoftware.smack.packet.IQ)},
+     * stanza via a call to {@link XmppCommon#handleIQ},
      * converts the result Smack stanza to an <tt>org.xmpp.packet.iQ</tt> which
      * is returned as the response to the request.
      *
@@ -277,7 +221,8 @@ public class ComponentImpl
                 }
             }
 
-            org.jivesoftware.smack.packet.IQ resultSmackIQ = handleIQ(smackIQ);
+            org.jivesoftware.smack.packet.IQ resultSmackIQ
+                = common.handleIQ(smackIQ);
             IQ resultIQ;
 
             if (resultSmackIQ == null)
@@ -305,49 +250,6 @@ public class ComponentImpl
 
             throw e;
         }
-    }
-
-    /**
-     * Handles an <tt>org.jivesoftware.smack.packet.IQ</tt> stanza of type
-     * <tt>get</tt> or <tt>set</tt> which represents a request.
-     *
-     * @param iq the <tt>org.jivesoftware.smack.packet.IQ</tt> stanza of type
-     * <tt>get</tt> or <tt>set</tt> which represents the request to handle
-     * @return an <tt>org.jivesoftware.smack.packet.IQ</tt> stanza which
-     * represents the response to the specified request or <tt>null</tt> to
-     * reply with <tt>feature-not-implemented</tt>
-     * @throws Exception to reply with <tt>internal-server-error</tt> to the
-     * specified request
-     */
-    private org.jivesoftware.smack.packet.IQ handleIQ(
-            org.jivesoftware.smack.packet.IQ iq)
-        throws Exception
-    {
-        org.jivesoftware.smack.packet.IQ responseIQ = null;
-
-        if (iq != null)
-        {
-            org.jivesoftware.smack.packet.IQ.Type type = iq.getType();
-
-            if (org.jivesoftware.smack.packet.IQ.Type.get.equals(type)
-                    || org.jivesoftware.smack.packet.IQ.Type.set.equals(type))
-            {
-                responseIQ = handleIQRequest(iq);
-                if (responseIQ != null)
-                {
-                    responseIQ.setFrom(iq.getTo());
-                    responseIQ.setStanzaId(iq.getStanzaId());
-                    responseIQ.setTo(iq.getFrom());
-                }
-            }
-            else if (org.jivesoftware.smack.packet.IQ.Type.error.equals(type)
-                    || org.jivesoftware.smack.packet.IQ.Type.result.equals(
-                            type))
-            {
-                handleIQResponse(iq);
-            }
-        }
-        return responseIQ;
     }
 
     @Override
@@ -389,115 +291,6 @@ public class ComponentImpl
         return (resultIQ == null) ? super.handleIQGetImpl(iq) : resultIQ;
     }
 
-    private org.jivesoftware.smack.packet.IQ handleIQRequest(
-            org.jivesoftware.smack.packet.IQ request)
-        throws Exception
-    {
-        // Requests can be categorized in pieces of Videobridge functionality
-        // based on the org.jivesoftware.smack.packet.IQ runtime type (of their
-        // child element) and forwarded to specialized Videobridge methods for
-        // convenience.
-        if (request instanceof org.jivesoftware.smackx.iqversion.packet.Version)
-        {
-            return
-                handleVersionIQ(
-                        (org.jivesoftware.smackx.iqversion.packet.Version)
-                                request);
-        }
-
-        Videobridge videobridge = getVideobridge();
-        if (videobridge == null)
-        {
-            return IQUtils.createError(
-                    request,
-                    XMPPError.Condition.internal_server_error,
-                    "No Videobridge service is running");
-        }
-
-        org.jivesoftware.smack.packet.IQ response;
-
-        if (request instanceof ColibriConferenceIQ)
-        {
-            response
-                = videobridge.handleColibriConferenceIQ(
-                        (ColibriConferenceIQ) request);
-        }
-        else if (request instanceof HealthCheckIQ)
-        {
-            response = videobridge.handleHealthCheckIQ((HealthCheckIQ) request);
-        }
-        else if (request instanceof ShutdownIQ)
-        {
-            response = videobridge.handleShutdownIQ((ShutdownIQ) request);
-        }
-        else
-        {
-            response = null;
-        }
-        return response;
-    }
-
-    /**
-     * Handles a <tt>Version</tt> stanza which represents a request.
-     *
-     * @param versionRequest the <tt>Version</tt> stanza represents
-     * the request to handle
-     * @return an <tt>org.jivesoftware.smack.packet.IQ</tt> stanza which
-     * represents the response to the specified request.
-     */
-    private org.jivesoftware.smack.packet.IQ handleVersionIQ(
-            org.jivesoftware.smackx.iqversion.packet.Version versionRequest)
-    {
-        VersionService versionService = getVersionService();
-        if (versionService == null)
-        {
-            return org.jivesoftware.smack.packet.IQ.createErrorResponse(
-                versionRequest,
-                XMPPError.getBuilder(XMPPError.Condition.service_unavailable));
-        }
-
-        org.jitsi.service.version.Version
-            currentVersion = versionService.getCurrentVersion();
-
-        if (currentVersion == null)
-        {
-            return org.jivesoftware.smack.packet.IQ.createErrorResponse(
-                versionRequest,
-                XMPPError.getBuilder(XMPPError.Condition.internal_server_error));
-        }
-
-        // send packet
-        org.jivesoftware.smackx.iqversion.packet.Version versionResult =
-            new org.jivesoftware.smackx.iqversion.packet.Version(
-                    currentVersion.getApplicationName(),
-                    currentVersion.toString(),
-                    System.getProperty("os.name")
-            );
-
-        // to, from and packetId are set by the caller.
-        // versionResult.setTo(versionRequest.getFrom());
-        // versionResult.setFrom(versionRequest.getTo());
-        // versionResult.setPacketID(versionRequest.getPacketID());
-        versionResult.setType(org.jivesoftware.smack.packet.IQ.Type.result);
-
-        return versionResult;
-    }
-
-    private void handleIQResponse(org.jivesoftware.smack.packet.IQ response)
-        throws Exception
-    {
-        /*
-         * Requests can be categorized in pieces of Videobridge functionality
-         * based on the org.jivesoftware.smack.packet.IQ runtime type (of their
-         * child element) and forwarded to specialized Videobridge methods for
-         * convenience. However, responses cannot be categorized because they
-         * care the id of their respective requests only.
-         */
-        Videobridge videobridge = getVideobridge();
-
-        if (videobridge != null)
-            videobridge.handleIQResponse(response);
-    }
 
     @Override
     protected void handleIQResultImpl(IQ iq)
@@ -631,13 +424,15 @@ public class ComponentImpl
     public void start(BundleContext bundleContext)
         throws Exception
     {
-        this.bundleContext = bundleContext;
+        common.start(bundleContext);
 
         // Register this instance as an OSGi service.
         Collection<ComponentImpl> components = getComponents(bundleContext);
 
         if (!components.contains(this))
+        {
             bundleContext.registerService(ComponentImpl.class, this, null);
+        }
 
         // Schedule ping task
         // note: the task if stopped automatically on component shutdown
@@ -648,7 +443,9 @@ public class ComponentImpl
         loadConfig(config, "org.jitsi.videobridge");
 
         if (!isPingTaskStarted())
+        {
             startPingTask();
+        }
     }
 
     /**
@@ -680,13 +477,15 @@ public class ComponentImpl
                     Object service = bundleContext.getService(serviceReference);
 
                     if (service == this)
+                    {
                         bundleContext.ungetService(serviceReference);
+                    }
                 }
             }
         }
         finally
         {
-            this.bundleContext = null;
+            common.stop(bundleContext);
         }
     }
 }

--- a/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java
+++ b/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java
@@ -45,6 +45,10 @@ public class ComponentImpl
     extends ComponentBase
     implements BundleActivator
 {
+    /**
+     * The {@link Logger} used by the {@link ComponentImpl} class and its
+     * instances for logging output.
+     */
     private static final org.jitsi.util.Logger logger
             =  org.jitsi.util.Logger.getLogger(ComponentImpl.class);
 

--- a/src/main/java/org/jitsi/videobridge/xmpp/XmppCommon.java
+++ b/src/main/java/org/jitsi/videobridge/xmpp/XmppCommon.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.xmpp;
 
+import net.java.sip.communicator.impl.protocol.jabber.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.health.*;
 import org.jitsi.osgi.*;
@@ -34,6 +35,18 @@ import org.osgi.framework.*;
  */
 class XmppCommon
 {
+
+    static final String[] FEATURES
+        = new String[]
+        {
+            ColibriConferenceIQ.NAMESPACE,
+            HealthCheckIQ.NAMESPACE,
+            ProtocolProviderServiceJabberImpl.URN_XMPP_JINGLE_DTLS_SRTP,
+            ProtocolProviderServiceJabberImpl.URN_XMPP_JINGLE_ICE_UDP_1,
+            ProtocolProviderServiceJabberImpl.URN_XMPP_JINGLE_RAW_UDP_0,
+            Version.NAMESPACE
+    };
+
     /**
      * The <tt>BundleContext</tt> in which this instance has been started as an
      * OSGi bundle.

--- a/src/main/java/org/jitsi/videobridge/xmpp/XmppCommon.java
+++ b/src/main/java/org/jitsi/videobridge/xmpp/XmppCommon.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright @ 2018 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.xmpp;
+
+import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
+import net.java.sip.communicator.impl.protocol.jabber.extensions.health.*;
+import org.jitsi.osgi.*;
+import org.jitsi.service.version.*;
+import org.jitsi.videobridge.*;
+import org.jitsi.xmpp.util.*;
+import org.jivesoftware.smack.packet.*;
+import org.jivesoftware.smackx.iqversion.packet.Version;
+import org.osgi.framework.*;
+
+/**
+ * Implements logic for handling incoming IQs represented as Smack {@link IQ}
+ * instances. The logic is meant to be reused between {@link ComponentImpl}
+ * and other implementations (e.g. one based on an XMPP user connection).
+ *
+ * @author Boris Grozev
+ */
+class XmppCommon
+{
+    /**
+     * The <tt>BundleContext</tt> in which this instance has been started as an
+     * OSGi bundle.
+     */
+    private BundleContext bundleContext;
+
+    /**
+     * Gets the OSGi <tt>BundleContext</tt> in which this Jabber component is
+     * executing.
+     *
+     * @return the OSGi <tt>BundleContext</tt> in which this Jabber component is
+     * executing
+     */
+    BundleContext getBundleContext()
+    {
+        return bundleContext;
+    }
+
+    void start(BundleContext bundleContext)
+    {
+        this.bundleContext = bundleContext;
+    }
+
+    void stop(BundleContext bundleContext)
+    {
+        this.bundleContext = null;
+    }
+
+    /**
+     * Returns the {@link Videobridge} instance that is managing conferences
+     * for this component. Returns <tt>null</tt> if no instance is running.
+     *
+     * @return the videobridge instance, <tt>null</tt> when none is running.
+     */
+    private Videobridge getVideobridge()
+    {
+        BundleContext bundleContext = getBundleContext();
+        return bundleContext != null
+            ? ServiceUtils2.getService(bundleContext, Videobridge.class)
+            : null;
+    }
+
+    /**
+     * Returns the <tt>VersionService</tt> used by this
+     * <tt>Videobridge</tt>.
+     *
+     * @return the <tt>VersionService</tt> used by this
+     * <tt>Videobridge</tt>.
+     */
+    private VersionService getVersionService()
+    {
+        BundleContext bundleContext = getBundleContext();
+        return bundleContext != null
+            ? ServiceUtils2.getService(bundleContext, VersionService.class)
+            : null;
+    }
+
+    /**
+     * Handles an <tt>org.jivesoftware.smack.packet.IQ</tt> stanza of type
+     * <tt>get</tt> or <tt>set</tt> which represents a request.
+     *
+     * @param iq the <tt>org.jivesoftware.smack.packet.IQ</tt> stanza of type
+     * <tt>get</tt> or <tt>set</tt> which represents the request to handle
+     * @return an <tt>org.jivesoftware.smack.packet.IQ</tt> stanza which
+     * represents the response to the specified request or <tt>null</tt> to
+     * reply with <tt>feature-not-implemented</tt>
+     * @throws Exception to reply with <tt>internal-server-error</tt> to the
+     * specified request
+     */
+    IQ handleIQ(IQ iq)
+        throws Exception
+    {
+        IQ responseIQ = null;
+
+        if (iq != null)
+        {
+            IQ.Type type = iq.getType();
+
+            if (IQ.Type.get.equals(type) || IQ.Type.set.equals(type))
+            {
+                responseIQ = handleIQRequest(iq);
+                if (responseIQ != null)
+                {
+                    responseIQ.setFrom(iq.getTo());
+                    responseIQ.setStanzaId(iq.getStanzaId());
+                    responseIQ.setTo(iq.getFrom());
+                }
+            }
+            else if (IQ.Type.error.equals(type) || IQ.Type.result.equals(type))
+            {
+                handleIQResponse(iq);
+            }
+        }
+        return responseIQ;
+    }
+
+    private IQ handleIQRequest(IQ request)
+        throws Exception
+    {
+        // Requests can be categorized in pieces of Videobridge functionality
+        // based on the org.jivesoftware.smack.packet.IQ runtime type (of their
+        // child element) and forwarded to specialized Videobridge methods for
+        // convenience.
+        if (request instanceof Version)
+        {
+            return handleVersionIQ((Version) request);
+        }
+
+        Videobridge videobridge = getVideobridge();
+        if (videobridge == null)
+        {
+            return IQUtils.createError(
+                request,
+                XMPPError.Condition.internal_server_error,
+                "No Videobridge service is running");
+        }
+
+        IQ response;
+
+        if (request instanceof ColibriConferenceIQ)
+        {
+            response
+                = videobridge.handleColibriConferenceIQ(
+                    (ColibriConferenceIQ) request);
+        }
+        else if (request instanceof HealthCheckIQ)
+        {
+            response = videobridge.handleHealthCheckIQ((HealthCheckIQ) request);
+        }
+        else if (request instanceof ShutdownIQ)
+        {
+            response = videobridge.handleShutdownIQ((ShutdownIQ) request);
+        }
+        else
+        {
+            response = null;
+        }
+        return response;
+    }
+
+    /**
+     * Handles a <tt>Version</tt> stanza which represents a request.
+     *
+     * @param versionRequest the <tt>Version</tt> stanza represents
+     * the request to handle
+     * @return an <tt>org.jivesoftware.smack.packet.IQ</tt> stanza which
+     * represents the response to the specified request.
+     */
+    private IQ handleVersionIQ(Version versionRequest)
+    {
+        VersionService versionService = getVersionService();
+        if (versionService == null)
+        {
+            return IQ.createErrorResponse(
+                versionRequest,
+                XMPPError.getBuilder(XMPPError.Condition.service_unavailable));
+        }
+
+        org.jitsi.service.version.Version
+            currentVersion = versionService.getCurrentVersion();
+
+        if (currentVersion == null)
+        {
+            return IQ.createErrorResponse(
+                versionRequest,
+                XMPPError.getBuilder(XMPPError.Condition.internal_server_error));
+        }
+
+        // send packet
+        Version versionResult =
+            new Version(
+                currentVersion.getApplicationName(),
+                currentVersion.toString(),
+                System.getProperty("os.name"));
+
+        // to, from and packetId are set by the caller.
+        // versionResult.setTo(versionRequest.getFrom());
+        // versionResult.setFrom(versionRequest.getTo());
+        // versionResult.setPacketID(versionRequest.getPacketID());
+        versionResult.setType(IQ.Type.result);
+
+        return versionResult;
+    }
+
+    private void handleIQResponse(IQ response)
+        throws Exception
+    {
+        Videobridge videobridge = getVideobridge();
+
+        if (videobridge != null)
+        {
+            videobridge.handleIQResponse(response);
+        }
+    }
+}

--- a/src/main/java/org/jitsi/videobridge/xmpp/XmppCommon.java
+++ b/src/main/java/org/jitsi/videobridge/xmpp/XmppCommon.java
@@ -28,8 +28,9 @@ import org.osgi.framework.*;
 
 /**
  * Implements logic for handling incoming IQs represented as Smack {@link IQ}
- * instances. The logic is meant to be reused between {@link ComponentImpl}
- * and other implementations (e.g. one based on an XMPP user connection).
+ * instances. This is used in both {@link ComponentImpl} (which receives IQs
+ * from an XMPP component connection) and {@link ClientConnectionImpl} (which
+ * receives IQs from an XMPP client connection).
  *
  * @author Boris Grozev
  */

--- a/src/main/java/org/jitsi/videobridge/xmpp/XmppCommon.java
+++ b/src/main/java/org/jitsi/videobridge/xmpp/XmppCommon.java
@@ -113,11 +113,8 @@ class XmppCommon
      * @return an <tt>org.jivesoftware.smack.packet.IQ</tt> stanza which
      * represents the response to the specified request or <tt>null</tt> to
      * reply with <tt>feature-not-implemented</tt>
-     * @throws Exception to reply with <tt>internal-server-error</tt> to the
-     * specified request
      */
     IQ handleIQ(IQ iq)
-        throws Exception
     {
         IQ responseIQ = null;
 
@@ -144,7 +141,6 @@ class XmppCommon
     }
 
     private IQ handleIQRequest(IQ request)
-        throws Exception
     {
         // Requests can be categorized in pieces of Videobridge functionality
         // based on the org.jivesoftware.smack.packet.IQ runtime type (of their
@@ -232,7 +228,6 @@ class XmppCommon
     }
 
     private void handleIQResponse(IQ response)
-        throws Exception
     {
         Videobridge videobridge = getVideobridge();
 


### PR DESCRIPTION
Publishes statistics as presence in a MUC (a-la jibri).

Supports COLIBRI, health checks and the rest of the functionality
exposed through the XMPP component through an XMPP client connection.