### PR TITLE
fix: Fixes the order in which TCP/443 is bound.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/osgi/JvbBundleConfig.java
+++ b/src/main/java/org/jitsi/videobridge/osgi/JvbBundleConfig.java
@@ -80,9 +80,6 @@ public class JvbBundleConfig
             "org/jitsi/videobridge/eventadmin/callstats/Activator"
         },
         {
-            "org/jitsi/videobridge/VideobridgeBundleActivator"
-        },
-        {
             "org/jitsi/videobridge/version/VersionActivator"
         },
         {
@@ -101,6 +98,9 @@ public class JvbBundleConfig
             // of the Videobridge and (2) it pulls, does not push.
             "org/jitsi/videobridge/stats/StatsManagerBundleActivator",
             "org/jitsi/videobridge/EndpointConnectionStatus"
+        },
+        {
+            "org/jitsi/videobridge/VideobridgeBundleActivator"
         },
         {
             "org/jitsi/videobridge/xmpp/ClientConnectionImpl"


### PR DESCRIPTION
Loads the REST bundle before the Videobridge bundle, because Jetty needs
to bind on port 443 before ice4j's TCP harvester does. When Videobridge
loads it starts its health checks, which results in the TCP harvester
binding.