### PR TITLE
Use WebRTC data channels opened by the client

### DIFF
--- a/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
+++ b/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
@@ -85,7 +85,7 @@ class EndpointMessageTransport
      * The {@link WebRtcDataStream} currently used by this
      * {@link EndpointMessageTransport} instance for writing.
      */
-    private WebRtcDataStream webrtcDataStream;
+    private WebRtcDataStream writableWebRtcDataStream;
 
     /**
      * The listener which will be added to {@link SctpConnection}s associated
@@ -143,9 +143,9 @@ class EndpointMessageTransport
 
         if (_defaultStream != null)
         {
-            WebRtcDataStream oldDataStream = this.webrtcDataStream;
+            WebRtcDataStream oldDataStream = this.writableWebRtcDataStream;
 
-            this.webrtcDataStream = _defaultStream;
+            this.writableWebRtcDataStream = _defaultStream;
 
             _defaultStream.setDataCallback(EndpointMessageTransport.this);
 
@@ -435,7 +435,7 @@ class EndpointMessageTransport
         {
             if (sctpConnection != null && sctpConnection.isReady())
             {
-                dst = webrtcDataStream;
+                dst = writableWebRtcDataStream;
 
                 if (dst == null)
                 {
@@ -605,10 +605,10 @@ class EndpointMessageTransport
                 // in the new SCTP connection (because the call to
                 // hookUpDefaultWebRtcDataChannel didn't select any) and where
                 // the current one belongs to the old SCTP connection.
-                if (webrtcDataStream != null
-                    && webrtcDataStream.getSctpConnection() == oldValue)
+                if (writableWebRtcDataStream != null
+                    && writableWebRtcDataStream.getSctpConnection() == oldValue)
                 {
-                    webrtcDataStream = null;
+                    writableWebRtcDataStream = null;
                 }
 
                 oldValue.removeChannelListener(webRtcDataStreamListener);

--- a/src/main/java/org/jitsi/videobridge/SctpConnection.java
+++ b/src/main/java/org/jitsi/videobridge/SctpConnection.java
@@ -436,7 +436,6 @@ public class SctpConnection
      */
     @Override
     protected void maybeStartStream()
-        throws IOException
     {
         // connector
         final StreamConnector connector = getStreamConnector();
@@ -450,36 +449,29 @@ public class SctpConnection
                 return;
 
             threadPool.execute(
-                    new Runnable()
+                () -> {
+                    try
                     {
-                        @Override
-                        public void run()
+                        Sctp.init();
+
+                        runOnDtlsTransport(connector);
+                    }
+                    catch (IOException e)
+                    {
+                        logger.error(e, e);
+                    }
+                    finally
+                    {
+                        try
                         {
-                            try
-                            {
-                                Sctp.init();
-        
-                                runOnDtlsTransport(connector);
-                            }
-                            catch (IOException e)
-                            {
-                                logger.error(e, e);
-                            }
-                            finally
-                            {
-                                try
-                                {
-                                    Sctp.finish();
-                                }
-                                catch (IOException e)
-                                {
-                                    logger.error(
-                                            "Failed to shutdown SCTP stack",
-                                            e);
-                                }
-                            }
+                            Sctp.finish();
                         }
-                    });
+                        catch (IOException e)
+                        {
+                            logger.error("Failed to shutdown SCTP stack", e);
+                        }
+                    }
+                });
 
             started = true;
         }

--- a/src/main/java/org/jitsi/videobridge/SctpConnection.java
+++ b/src/main/java/org/jitsi/videobridge/SctpConnection.java
@@ -662,7 +662,12 @@ public class SctpConnection
             WebRtcDataStream.DataCallback oldCallback = null;
             if (channels.containsKey(sid))
             {
-                logger.log(Level.WARNING, Logger.Category.STATISTICS,
+                // FIXME According to the RFC the DTLS initiator should be using
+                // even and the responder odd SID numbers, so such conflict
+                // should never happen. If it happens then the JVB should
+                // shutdown (reset) the SCTP stream identified by
+                // the conflicting SID.
+                logger.log(Level.SEVERE, Logger.Category.STATISTICS,
                            "sctp_channel_exists," + getLoggingId()
                            + " sid=" + sid);
                 oldCallback = channels.get(sid).getDataCallback();

--- a/src/main/java/org/jitsi/videobridge/SctpConnection.java
+++ b/src/main/java/org/jitsi/videobridge/SctpConnection.java
@@ -677,7 +677,7 @@ public class SctpConnection
             }
 
             WebRtcDataStream newChannel
-                = new WebRtcDataStream(sctpSocket, sid, label, true);
+                = new WebRtcDataStream(this, sctpSocket, sid, label, true);
             channels.put(sid, newChannel);
 
             if (oldCallback != null)
@@ -886,7 +886,7 @@ public class SctpConnection
             throw new IOException("Failed to open new chanel on sid: " + sid);
 
         WebRtcDataStream channel
-            = new WebRtcDataStream(sctpSocket, sid, label, false);
+            = new WebRtcDataStream(this, sctpSocket, sid, label, false);
 
         channels.put(sid, channel);
 

--- a/src/main/java/org/jitsi/videobridge/SctpConnection.java
+++ b/src/main/java/org/jitsi/videobridge/SctpConnection.java
@@ -439,7 +439,7 @@ public class SctpConnection
                             s -> isInitiator()
                                 ? s.getSid() % 2 == 1
                                 : s.getSid() % 2 == 0)
-                        .reduce((s1, s2) -> s1.getSid() > s2.getSid() ? s1 : s2)
+                        .max(Comparator.comparingInt(WebRtcDataStream::getSid))
                         .orElse(null);
 
                 if (highestClientSid != null)
@@ -450,7 +450,7 @@ public class SctpConnection
                 // Return the highest SID (probably will be the JVB's one)
                 return channels.values()
                     .stream()
-                    .reduce((s1, s2) -> s1.getSid() > s2.getSid() ? s1 : s2)
+                    .max(Comparator.comparingInt(WebRtcDataStream::getSid))
                     .orElse(null);
             }
 

--- a/src/main/java/org/jitsi/videobridge/WebRtcDataStream.java
+++ b/src/main/java/org/jitsi/videobridge/WebRtcDataStream.java
@@ -34,6 +34,11 @@ public class WebRtcDataStream
         = Logger.getLogger(WebRtcDataStream.class);
 
     /**
+     * The parent {@link SctpConnection} instance.
+     */
+    private final SctpConnection sctpConnection;
+
+    /**
      * <tt>SctpSocket</tt> used for sending SCTP data.
      */
     private final SctpSocket socket;
@@ -61,15 +66,18 @@ public class WebRtcDataStream
     /**
      * Initializes new instance of <tt>WebRtcDataStream</tt> with specified
      * parameters.
+     * @param connection the parent {@link SctpConnection} instance.
      * @param socket the SCTP socket used for transport.
      * @param sid SCTP stream id to be used by this channel.
      * @param label name of the channel.
      * @param acknowledged indicates if this channel has been already
      *                     acknowledged by remote peer.
      */
-    WebRtcDataStream(SctpSocket socket, int sid, String label,
+    WebRtcDataStream(SctpConnection connection,
+                     SctpSocket socket, int sid, String label,
                      boolean acknowledged)
     {
+        this.sctpConnection = connection;
         this.socket = socket;
         this.sid = sid;
         this.label = label;
@@ -83,6 +91,15 @@ public class WebRtcDataStream
     public String getLabel()
     {
         return label;
+    }
+
+    /**
+     * Returns the parent {@link SctpConnection} which owns this instance.
+     * @return {@link SctpConnection}
+     */
+    public SctpConnection getSctpConnection()
+    {
+        return sctpConnection;
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/WebRtcDataStream.java
+++ b/src/main/java/org/jitsi/videobridge/WebRtcDataStream.java
@@ -136,7 +136,19 @@ public class WebRtcDataStream
     public void onStringMsg(String stringMsg)
     {
         if(dataCallback != null)
+        {
             dataCallback.onStringData(this, stringMsg);
+        }
+        else
+        {
+            // NOTE consider adding analytics for the missed out data to detect
+            // bugs ?
+            logger.error(
+                String.format(
+                    "Unprocessed data on %s (SID=%d) - no callback registered",
+                    sctpConnection.getLoggingId(),
+                    sid));
+        }
     }
 
     /**
@@ -177,7 +189,19 @@ public class WebRtcDataStream
     public void onBinaryMsg(byte[] binMsg)
     {
         if(dataCallback != null)
+        {
             dataCallback.onBinaryData(this, binMsg);
+        }
+        else
+        {
+            // NOTE consider adding analytics for the missed out data to detect
+            // bugs ?
+            logger.error(
+                String.format(
+                    "Unprocessed data on %s (SID=%d) - no callback registered",
+                    sctpConnection.getLoggingId(),
+                    sid));
+        }
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/WebRtcDataStreamListener.java
+++ b/src/main/java/org/jitsi/videobridge/WebRtcDataStreamListener.java
@@ -17,7 +17,7 @@ package org.jitsi.videobridge;
 
 /**
  * Interface used to notify about WebRTC data channels opened by
- * remote peer.
+ * {@link SctpConnection}.
  *
  * @author Pawel Domas
  * @author Lyubomir Marinov
@@ -27,6 +27,8 @@ public interface WebRtcDataStreamListener
     /**
      * Fired when new WebRTC data channel is opened.
      *
+     * NOTE It's important that the listener will not do any blocking operations
+     *
      * @param source the <tt>SctpConnection</tt> which is the source of the
      * event
      * @param channel the <tt>WebRtcDataStream</tt> that represents opened
@@ -35,18 +37,6 @@ public interface WebRtcDataStreamListener
     default void onChannelOpened(
             SctpConnection source,
             WebRtcDataStream channel)
-    {
-    }
-
-    /**
-     * Indicates that a <tt>SctpConnection</tt> has established SCTP connection.
-     * After that it can be used to either open WebRTC data channel or listen
-     * for channels opened by remote peer.
-     *
-     * @param source the <tt>SctpConnection</tt> which is the source of the
-     * event i.e. which has established an SCTP connection
-     */
-    default void onSctpConnectionReady(SctpConnection source)
     {
     }
 }


### PR DESCRIPTION
Starting in Chrome M69 it will no longer release WebRTC Data Channels when the "data" content is [rejected] on ICE restart. I suspect it's this [commit in WebRTC] which waits for the channels to be gracefully closed (but haven't bisected that to confirm). Because the conference is moved to new bridge it will never happen. So the stack correctly resets the SCTP transport layer, but keeps the SID = 0 used by the bridge and does not allow it to open it's data channel on SID = 0 again.

As a workaround (because it's to late to file a bug and have a fix in the stable) I was thinking about moving opening of the data channel to the client, so that it know which next SID is free. This also makes the JVB a bit more elastic for other clients, because should accommodate both cases where JVB opens channel or the client.

SID is a SCTP stream identifier which values range goes from 0 - 1024 in WebRTC (up to 65k allowed by SCTP). Each WebRTC data channel has a SID assigned and the rule there is that the DTLS initiator uses even SID number and the client odd ones to avoid conflicts.

[rejected]: https://github.com/jitsi/lib-jitsi-meet/blob/master/modules/xmpp/JingleSessionPC.js#L989
[commit in WebRTC]: https://webrtc.googlesource.com/src.git/+/cdd05f0cc1edd36ca5c61ab7154beab63fc3bbe7