### PR TITLE
Handle notify after ready

### DIFF
--- a/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
+++ b/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
@@ -418,8 +418,14 @@ class EndpointMessageTransport
             }
             else
             {
+                String reason = "";
+                if (sctpConnection == null) {
+                    reason = " because sctp is not connected.";
+                } else if (!sctpConnection.isReady()) {
+                    reason = " because sctp is not ready.";
+                }
                 logger.warn(
-                    "SCTP connection with " + endpointId + " not ready yet.");
+                    "SCTP session with " + endpointId + " unavailable" + reason);
             }
         }
 

--- a/src/main/java/org/jitsi/videobridge/SctpConnection.java
+++ b/src/main/java/org/jitsi/videobridge/SctpConnection.java
@@ -1054,18 +1054,20 @@ public class SctpConnection
                             {
                                 if (sctpSocket.accept())
                                 {
+                                    boolean wasReady = isReady();
+
                                     acceptedIncomingConnection = true;
+
                                     logger.info("SCTP socket accepted for "
                                             + "endpoint "
                                             + getEndpoint().getID());
+                                    if (isReady() && !wasReady) {
+                                        notifySctpConnectionReady();
+                                    }
                                     break;
                                 }
                                 Thread.sleep(100);
                                 sctpSocket = SctpConnection.this.sctpSocket;
-                            }
-                            if (isReady())
-                            {
-                                notifySctpConnectionReady();
                             }
                         }
                         catch (Exception e)

--- a/src/test/java/org/jitsi/videobridge/SctpConnectionTest.java
+++ b/src/test/java/org/jitsi/videobridge/SctpConnectionTest.java
@@ -10,28 +10,32 @@ import org.junit.runner.*;
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.impl.*;
 import org.jxmpp.stringprep.*;
+import org.powermock.core.classloader.annotations.*;
 import org.powermock.modules.junit4.*;
 
 import static org.junit.Assert.*;
+import static org.powermock.api.easymock.PowerMock.*;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(SctpConnection.class)
 public class SctpConnectionTest
 {
     /**
      * Tested <tt>SctpConnection</tt> instance.
      */
-    private static SctpConnection sctpConnection;
+    private SctpConnection sctpConnection;
 
     /**
      * Test fixtures.
      */
 
-    private static OSGiHandler osgiHandler = new OSGiHandler();
+    private OSGiHandler osgiHandler = new OSGiHandler();
 
     /**
      * Initializes OSGi
      */
-    @BeforeClass
-    public static void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
         osgiHandler.start();
@@ -77,8 +81,8 @@ public class SctpConnectionTest
     /**
      * Shutdown OSGi
      */
-    @AfterClass
-    public static void tearDown()
+    @After
+    public void tearDown()
         throws InterruptedException
     {
         osgiHandler.stop();
@@ -147,6 +151,9 @@ public class SctpConnectionTest
         SctpSocket sctpSocket = null;
         byte[] data = getCommunicationUpPacket();
         SctpNotification notification = SctpNotification.parse(data);
+
+        // createPartialMock(SctpNotification.class, "notifySctpConnectionReady");
+        // expectPrivate(sctpConnection, "notifySctpConnectionReady");
 
         sctpConnection.onSctpNotification(sctpSocket, notification);
     }

--- a/src/test/java/org/jitsi/videobridge/SctpConnectionTest.java
+++ b/src/test/java/org/jitsi/videobridge/SctpConnectionTest.java
@@ -1,0 +1,46 @@
+package org.jitsi.videobridge;
+
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+public class SctpConnectionTest
+{
+    /**
+     * Tested <tt>SctpConnection</tt> instance.
+     */
+    private static SctpConnection sctpConnection;
+
+    private static OSGiHandler osgiHandler = new OSGiHandler();
+
+    /**
+     * Initializes OSGi
+     */
+    @BeforeClass
+    public static void setUp()
+        throws InterruptedException
+    {
+        osgiHandler.start();
+        sctpConnection = osgiHandler.getService(SctpConnection.class);
+    }
+
+    /**
+     * Shutdown OSGi
+     */
+    @AfterClass
+    public static void tearDown()
+        throws InterruptedException
+    {
+        osgiHandler.stop();
+    }
+
+    /**
+     * Tests that connection-ready notifications are sent after a new
+     * connection is accepted
+     */
+    @Test
+    public void testConnectionReadyNotifications()
+    {
+        assertTrue(false);
+    }
+}

--- a/src/test/java/org/jitsi/videobridge/SctpConnectionTest.java
+++ b/src/test/java/org/jitsi/videobridge/SctpConnectionTest.java
@@ -1,6 +1,16 @@
 package org.jitsi.videobridge;
 
+import java.nio.*;
+import java.util.*;
+import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
+import org.jivesoftware.smack.packet.*;
+import org.jitsi.sctp4j.*;
 import org.junit.*;
+import org.junit.runner.*;
+import org.jxmpp.jid.*;
+import org.jxmpp.jid.impl.*;
+import org.jxmpp.stringprep.*;
+import org.powermock.modules.junit4.*;
 
 import static org.junit.Assert.*;
 
@@ -11,6 +21,10 @@ public class SctpConnectionTest
      */
     private static SctpConnection sctpConnection;
 
+    /**
+     * Test fixtures.
+     */
+
     private static OSGiHandler osgiHandler = new OSGiHandler();
 
     /**
@@ -18,10 +32,46 @@ public class SctpConnectionTest
      */
     @BeforeClass
     public static void setUp()
-        throws InterruptedException
+        throws Exception
     {
         osgiHandler.start();
-        sctpConnection = osgiHandler.getService(SctpConnection.class);
+        Videobridge bridge = osgiHandler.getService(Videobridge.class);
+
+        // Create the conference
+        Jid focusJid = JidCreate.from("focusJid");
+        ColibriConferenceIQ confIq
+            = ColibriUtilities.createConferenceIq(focusJid);
+        IQ respIq = bridge.handleColibriConferenceIQ(confIq);
+        assertTrue(respIq instanceof ColibriConferenceIQ);
+        ColibriConferenceIQ respConfIq = (ColibriConferenceIQ) respIq;
+
+        // Find content and channel to run our SCTP connection alongside
+        Content content = null;
+        Channel channel = null;
+        Conference conference = bridge.getConference(respConfIq.getID(), null);
+        for (Content ct : conference.getContents()) {
+            if (ct == null) {
+                continue;
+            }
+            for (Channel cl : ct.getChannels()) {
+                if (cl == null) {
+                    continue;
+                }
+                content = ct;
+                channel = cl;
+                break;
+            }
+        }
+        if (content == null || channel == null) {
+            throw new Exception("Couldn't find candidate content or channel");
+        }
+
+        // Construct a SCTP connection
+        String id = "sctp";
+        String cb = "test";
+        AbstractEndpoint endpoint = new Endpoint("endp", conference);
+        sctpConnection =
+            new SctpConnection(id, content, endpoint, 10000, cb, true);
     }
 
     /**
@@ -35,12 +85,69 @@ public class SctpConnectionTest
     }
 
     /**
+     * Fixture providing an SCTP_COMM_UP association change packet
+     */
+    private byte[] getCommunicationUpPacket()
+    {
+        // Data-structures from jitsi/libjitsi.git
+        // commit: 70d104004a9bc9de79c22b73237e87a83570a2fb
+        // path: /src/org/jitsi/sctp4j/SctpNotification.java
+        int sz =
+            (Short.SIZE * 2) +
+            Integer.SIZE +
+            (Short.SIZE * 4) +
+            Integer.SIZE;
+
+        return ByteBuffer.
+            allocate(sz).
+            order(ByteOrder.LITTLE_ENDIAN).
+            putShort((short) SctpNotification.SCTP_ASSOC_CHANGE).
+            putShort((short) 0).
+            putInt(sz).
+            putShort((short) SctpNotification.AssociationChange.SCTP_COMM_UP).
+            putShort((short) 0).
+            putShort((short) 0).
+            putShort((short) 0).
+            putInt(0).
+            array();
+    }
+
+    /**
+     * Ensure that parsing the COMM_UP packet succeeds.
+     *
+     * TODO(jayaddison): Upstream this into libjitsi; it's here as a
+     * convenience due to the need for the fixture elsewhere in this file.
+     */
+    @Test
+    public void testSctpPacketParsing()
+    {
+        byte[] data = getCommunicationUpPacket();
+        SctpNotification notification = SctpNotification.parse(data);
+        assertEquals(
+            SctpNotification.SCTP_ASSOC_CHANGE,
+            notification.sn_type
+        );
+
+        SctpNotification.AssociationChange association =
+            (SctpNotification.AssociationChange) notification;
+        assertEquals(
+            SctpNotification.AssociationChange.SCTP_COMM_UP,
+            association.state
+        );
+    }
+
+    /**
      * Tests that connection-ready notifications are sent after a new
      * connection is accepted
      */
     @Test
     public void testConnectionReadyNotifications()
+        throws Exception
     {
-        assertTrue(false);
+        SctpSocket sctpSocket = null;
+        byte[] data = getCommunicationUpPacket();
+        SctpNotification notification = SctpNotification.parse(data);
+
+        sctpConnection.onSctpNotification(sctpSocket, notification);
     }
 }

--- a/src/test/java/org/jitsi/videobridge/VideoBridgeTestSuite.java
+++ b/src/test/java/org/jitsi/videobridge/VideoBridgeTestSuite.java
@@ -29,6 +29,7 @@ import org.junit.runners.*;
     {
         FocusControlTest.class,
         RawUdpConferenceTest.class,
+        SctpConnectionTest.class,
         EndpointMessageBuilderTest.class,
         MediaStreamTrackFactoryTest.class,
         BridgeShutdownTest.class, // This one must be the last one


### PR DESCRIPTION
While digging into connectivity issues as part of https://github.com/jitsi/jitsi-meet/issues/3738 , I discovered a bug (and potential fix) in the way that connectivity-readiness is notified out to other participants/channels during a conference.

In short, are [two](https://github.com/jitsi/jitsi-videobridge/blob/4b3fd77cac7cc3d45b9bd8ce4217f531092bb5e7/src/main/java/org/jitsi/videobridge/SctpConnection.java#L750-L754)[paths](https://github.com/jitsi/jitsi-videobridge/blob/56d941ae8634a2f2d781f00a7d1a259ee7d1d9d6/src/main/java/org/jitsi/videobridge/SctpConnection.java#L1068) which both need to be called in order for a connection to become 'ready'.

However, only one of these locations currently performs the before & after check to see if the connection state has changed from unready to ready.  This _should_ be innocent and just result in more `notifySctpConnectionReady` calls than necessary, but there appear to be side-effects from that call which result in the connection looping.  https://github.com/jitsi/jitsi-videobridge/commit/7492b47a9eeee495b3c1bf1db780134a4682bebd can be merged to see the effect of that by enhancing the debug logs a little.

Not yet certain this is the correct or full fix - I think something further down the chain from `notifySctpConnectionReady` also needs to be handled here, but this helped me to make a bit of progress.

NB: Tests aren't yet working due to an obscure dual-classloaders issue, and commits are out-of-order from some rebasing.

```
JVB 2018-12-27 09:07:39.204 WARNING: [682] org.jitsi.videobridge.EndpointMessageTransport.log() SCTP connection with Bunny not ready yet.
JVB 2018-12-27 09:07:39.205 WARNING: [682] org.jitsi.videobridge.EndpointMessageTransport.log() No available transport channel, can't send a message
JVB 2018-12-27 09:07:39.211 WARNING: [682] org.jitsi.videobridge.EndpointMessageTransport.log() SCTP connection with Bunny not ready yet.
JVB 2018-12-27 09:07:39.211 WARNING: [682] org.jitsi.videobridge.EndpointMessageTransport.log() No available transport channel, can't send a message
JVB 2018-12-27 09:07:41.208 WARNING: [682] org.jitsi.videobridge.EndpointMessageTransport.log() SCTP connection with Bunny not ready yet.
JVB 2018-12-27 09:07:41.208 WARNING: [682] org.jitsi.videobridge.EndpointMessageTransport.log() No available transport channel, can't send a message
```