### PR TITLE
DO NOT MERGE use StripedExecutorService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.igniterealtime</groupId>
       <artifactId>tinder</artifactId>
-      <version>1.3.0</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.igniterealtime.smack</groupId>
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jicoco</artifactId>
-      <version>1.1-20180821.201527-7</version>
+      <version>1.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Uses StripedExecutorService to fix the order in which the packets are
processed by the XMPP component. Packets related to one conference must
be processed in the order they were received. That is achieved by
producing a stripe for a conference ID extracted from a Colibri packet.
See docs of the ComponentImpl.getStripeForPacket method for more info.
See also: https://www.javaspecialists.eu/archive/Issue206.html