### PR TITLE
Fixes scrambled video from non-simulcast streams.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
@@ -262,8 +262,7 @@ public class AdaptiveTrackProjection
     private static AdaptiveTrackProjectionContext makeContext(
         @NotNull MediaStreamTrackDesc track, @NotNull MediaFormat format)
     {
-        if (Constants.VP8.equalsIgnoreCase(format.getEncoding())
-            && track.getRTPEncodings().length > 1)
+        if (Constants.VP8.equalsIgnoreCase(format.getEncoding()))
         {
             long ssrc = track.getRTPEncodings()[0].getPrimarySSRC();
             return new VP8AdaptiveTrackProjectionContext(ssrc);

--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjectionContext.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjectionContext.java
@@ -17,6 +17,7 @@ package org.jitsi.videobridge.cc;
 
 import org.jitsi.impl.neomedia.rtp.*;
 import org.jitsi.service.neomedia.*;
+import org.jitsi.service.neomedia.format.*;
 
 /**
  * Implementations of this interface are responsible for projecting a specific
@@ -81,4 +82,16 @@ public interface AdaptiveTrackProjectionContext
      * case it needs to be dropped.
      */
     boolean rewriteRtcp(RawPacket rtcpPacket);
+
+    /**
+     * @return the RTP state that describes the max sequence number, max
+     * timestamp and other RTP-level details.
+     */
+    RtpState getRtpState();
+
+    /**
+     * @return the {@link MediaFormat} of the RTP packets that this context
+     * processes.
+     */
+    MediaFormat getFormat();
 }

--- a/src/main/java/org/jitsi/videobridge/cc/GenericAdaptiveTrackProjectionContext.java
+++ b/src/main/java/org/jitsi/videobridge/cc/GenericAdaptiveTrackProjectionContext.java
@@ -62,6 +62,8 @@ class GenericAdaptiveTrackProjectionContext
     private static final Logger logger
         = Logger.getLogger(GenericAdaptiveTrackProjectionContext.class);
 
+    private final long ssrc;
+
     /**
      * Raised when a track has been resumed (after being suspended).
      */
@@ -76,6 +78,24 @@ class GenericAdaptiveTrackProjectionContext
      * The maximum sequence number that we have sent.
      */
     private int maxDestinationSequenceNumber;
+
+    /**
+     * The delta to apply to the timestamps of the RTP packets of the source
+     * track.
+     */
+    private long timestampDelta;
+
+    /**
+     * A boolean that indicates whether or not the timestap delta has been
+     * initialized. This is only necessary upon adaptive track projection
+     * context switches.
+     */
+    private boolean timestampDeltaInitialized = false;
+
+    /**
+     * The maximum timestamp that we have sent.
+     */
+    private long maxDestinationTimestamp;
 
     /**
      * The delta to apply to the sequence numbers of the RTP packets of the
@@ -93,22 +113,29 @@ class GenericAdaptiveTrackProjectionContext
      * Keeps track of the number of transmitted bytes. This is used in RTCP SR
      * rewriting.
      */
-    private long transmittedBytes = 0;
+    private long transmittedBytes;
 
     /**
      * Keeps track of the number of transmitted packets. This is used in RTCP SR
      * rewriting.
      */
-    private long transmittedPackets = 0;
+    private long transmittedPackets;
 
     /**
      * Ctor.
      *
      * @param format the media format to expect
+     * @param rtpState the RTP state (i.e. seqnum, timestamp to start with, etc).
      */
-    GenericAdaptiveTrackProjectionContext(MediaFormat format)
+    GenericAdaptiveTrackProjectionContext(
+        @NotNull MediaFormat format, @NotNull RtpState rtpState)
     {
         this.format = format;
+        this.ssrc = rtpState.ssrc;
+        this.transmittedBytes = rtpState.transmittedBytes;
+        this.transmittedPackets = rtpState.transmittedPackets;
+        this.maxDestinationSequenceNumber = rtpState.maxSequenceNumber;
+        this.maxDestinationTimestamp = rtpState.maxTimestamp;
     }
 
     /**
@@ -177,13 +204,26 @@ class GenericAdaptiveTrackProjectionContext
 
         if (accept)
         {
+            if (!timestampDeltaInitialized)
+            {
+                initializeTimestampDelta(rtpPacket.getTimestamp());
+            }
             int destinationSequenceNumber
                 = computeDestinationSequenceNumber(sourceSequenceNumber);
+
+            long destinationTimestamp
+                = computeDestinationTimestamp(rtpPacket.getTimestamp());
 
             if (RTPUtils.isOlderSequenceNumberThan(
                 maxDestinationSequenceNumber, destinationSequenceNumber))
             {
                 maxDestinationSequenceNumber = destinationSequenceNumber;
+            }
+
+            if (RTPUtils.isNewerTimestampThan(
+                destinationSequenceNumber, maxDestinationTimestamp))
+            {
+                maxDestinationTimestamp = destinationTimestamp;
             }
 
             if (logger.isDebugEnabled())
@@ -204,6 +244,21 @@ class GenericAdaptiveTrackProjectionContext
         }
 
         return accept;
+    }
+
+    private void initializeTimestampDelta(long sourceTimestamp)
+    {
+        if (RTPUtils.isNewerTimestampThan(
+            maxDestinationSequenceNumber, sourceTimestamp))
+        {
+            long destinationTimestamp =
+                (maxDestinationTimestamp + 3000) & RawPacket.TIMESTAMP_MASK;
+
+            timestampDelta
+                = RTPUtils.rtpTimestampDiff(destinationTimestamp, sourceTimestamp);
+        }
+
+        timestampDeltaInitialized = true;
     }
 
     private static boolean isKeyframe(
@@ -268,6 +323,15 @@ class GenericAdaptiveTrackProjectionContext
             rtpPacket.setSequenceNumber(destinationSequenceNumber);
         }
 
+        long sourceTimestamp = rtpPacket.getSequenceNumber();
+        long destinationTimestamp
+            = computeDestinationTimestamp(sourceTimestamp);
+
+        if (sourceTimestamp != destinationTimestamp)
+        {
+            rtpPacket.setTimestamp(destinationTimestamp);
+        }
+
         if (logger.isDebugEnabled())
         {
             logger.debug("rewrite ssrc=" + rtpPacket.getSSRCAsLong()
@@ -287,8 +351,16 @@ class GenericAdaptiveTrackProjectionContext
 
     private int computeDestinationSequenceNumber(int sourceSequenceNumber)
     {
-        return (sourceSequenceNumber + sequenceNumberDelta)
-            & RawPacket.SEQUENCE_NUMBER_MASK;
+        return sequenceNumberDelta != 0
+            ? (sourceSequenceNumber + sequenceNumberDelta)
+            & RawPacket.SEQUENCE_NUMBER_MASK : sourceSequenceNumber;
+    }
+
+    private long computeDestinationTimestamp(long sourceTimestamp)
+    {
+        return timestampDelta != 0
+            ? (sourceTimestamp + timestampDelta) & RawPacket.TIMESTAMP_MASK
+            : sourceTimestamp;
     }
 
     /**
@@ -315,5 +387,22 @@ class GenericAdaptiveTrackProjectionContext
         }
 
         return true;
+    }
+
+    @Override
+    public RtpState getRtpState()
+    {
+        synchronized (transmittedSyncRoot)
+        {
+            return new RtpState(
+                transmittedBytes, transmittedPackets,
+                ssrc, maxDestinationSequenceNumber, maxDestinationTimestamp);
+        }
+    }
+
+    @Override
+    public MediaFormat getFormat()
+    {
+        return format;
     }
 }

--- a/src/main/java/org/jitsi/videobridge/cc/RtpState.java
+++ b/src/main/java/org/jitsi/videobridge/cc/RtpState.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright @ 2019 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.cc;
+
+/**
+ * This class represents the RTP state and is used in adaptive track context
+ * switches (see {@link AdaptiveTrackProjection}).
+ *
+ * @author George Politis
+ */
+public class RtpState
+{
+    /**
+     * The SSRC of the RTP stream that this information pertains to.
+     */
+    public final long ssrc;
+
+    /**
+     * The highest sent RTP timestamp.
+     */
+    public final long maxTimestamp;
+
+    /**
+     * The highest sent sequence number.
+     */
+    public final int maxSequenceNumber;
+
+    /**
+     * The number of transmitted bytes so far.
+     */
+    public final long transmittedBytes;
+
+    /**
+     * The number of transmitted packets so far.
+     */
+    public final long transmittedPackets;
+
+    /**
+     *
+     * @param transmittedBytes the number of transmitted bytes so far.
+     * @param transmittedPackets the number of transmitted packets so far.
+     * @param ssrc the SSRC of the RTP stream that this information pertains to.
+     * @param maxSequenceNumber the highest sent sequence number.
+     * @param maxTimestamp the highest sent RTP timestamp.
+     */
+    public RtpState(long transmittedBytes, long transmittedPackets,
+                    long ssrc, int maxSequenceNumber, long maxTimestamp)
+    {
+        this.ssrc = ssrc;
+        this.transmittedBytes = transmittedBytes;
+        this.transmittedPackets = transmittedPackets;
+        this.maxSequenceNumber = maxSequenceNumber;
+        this.maxTimestamp = maxTimestamp;
+    }
+}

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameProjection.java
@@ -95,10 +95,15 @@ public class VP8FrameProjection
      * Ctor.
      *
      * @param ssrc the SSRC of the destination VP8 picture.
+     * @param timestamp The RTP timestamp of the projected frame that this
+     * instance refers to (RFC3550).
+     * @param startingSequenceNumber The starting RTP sequence number of the
+     * projected frame that this instance refers to (RFC3550).
      */
-    VP8FrameProjection(long ssrc)
+    VP8FrameProjection(long ssrc, int startingSequenceNumber, long timestamp)
     {
-        this(null, ssrc, 0, 0, 0, 0, 0);
+        this(null /* vp8Frame */, ssrc, timestamp, startingSequenceNumber,
+            0 /* extendedPictureId */, 0 /* tl0PICIDX */, 0 /* createdMs */);
     }
 
     /**
@@ -162,7 +167,7 @@ public class VP8FrameProjection
             // without having sent a keyframe first.
             if (nextVP8Frame.isKeyframe())
             {
-                isLast = false;
+                close();
                 return new VP8FrameProjection(nextVP8Frame, ssrc, timestamp,
                     startingSequenceNumber, extendedPictureId, tl0PICIDX,
                     nowMs);
@@ -183,14 +188,11 @@ public class VP8FrameProjection
             // We synchronize on the VP8 frame because the max sequence number
             // can be updated from other threads and the isLast field can be
             // read by other threads.
-            synchronized (vp8Frame)
-            {
-                isLast = false;
-                return new VP8FrameProjection(
-                    nextVP8Frame, ssrc, nextTimestamp(nextVP8Frame, nowMs),
-                    nextStartingSequenceNumber(), nextExtendedPictureId(),
-                    nextTL0PICIDX(nextVP8Frame), nowMs);
-            }
+            close();
+            return new VP8FrameProjection(
+                nextVP8Frame, ssrc, nextTimestamp(nextVP8Frame, nowMs),
+                nextStartingSequenceNumber(), nextExtendedPictureId(),
+                nextTL0PICIDX(nextVP8Frame), nowMs);
         }
     }
 
@@ -252,14 +254,34 @@ public class VP8FrameProjection
      */
     private int nextStartingSequenceNumber()
     {
-        int vp8FrameLength = RTPUtils.getSequenceNumberDelta(
-            vp8Frame.getMaxSequenceNumber(),
-            vp8Frame.getStartingSequenceNumber());
+        return (maxSequenceNumber() + 1) & RawPacket.SEQUENCE_NUMBER_MASK;
+    }
 
-        int nextStartingSequenceNumber
-            = startingSequenceNumber + vp8FrameLength + 1;
+    /**
+     * Small utility method that computes and returns the max sequence number of
+     * this frame.
+     *
+     * @return the max sequence number of this frame.
+     */
+    int maxSequenceNumber()
+    {
+        // assert !isLast; otherwise the maxSequenceNumber is not guaranteed to
+        // not change. So, prior to calling this method the caller needs to have
+        // called the close method.
+        if (vp8Frame != null)
+        {
+            int vp8FrameLength = RTPUtils.getSequenceNumberDelta(
+                vp8Frame.getMaxSequenceNumber(),
+                vp8Frame.getStartingSequenceNumber());
 
-        return nextStartingSequenceNumber & RawPacket.SEQUENCE_NUMBER_MASK;
+            int maxSequenceNumber = startingSequenceNumber + vp8FrameLength;
+            return maxSequenceNumber & RawPacket.SEQUENCE_NUMBER_MASK;
+        }
+        else
+        {
+            return (startingSequenceNumber - 1)
+                & RawPacket.SEQUENCE_NUMBER_MASK;
+        }
     }
 
     /**
@@ -483,11 +505,20 @@ public class VP8FrameProjection
     }
 
     /**
-     * @return true if this is the "last" accepted {@link VP8Frame} instance,
-     * false otherwise.
+     * Prevents the max sequence number of this frame to grow any further.
      */
-    boolean isLast()
+    public void close()
     {
-        return isLast;
+        if (vp8Frame != null)
+        {
+            synchronized (vp8Frame)
+            {
+                isLast = false;
+            }
+        }
+        else
+        {
+            isLast = false;
+        }
     }
 }


### PR DESCRIPTION
This PR fixes scrambled video from non-simulcast streams by implementing adaptive track projection context switches and treating the change from simulcast -> non-simulcast stream as a codec switch.