### PR TITLE
Implements adaptive track context switching with some other fixes.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
@@ -17,6 +17,7 @@ package org.jitsi.videobridge.cc;
 
 import org.jetbrains.annotations.*;
 import org.jitsi.impl.neomedia.*;
+import org.jitsi.impl.neomedia.codec.video.vp8.*;
 import org.jitsi.impl.neomedia.rtp.*;
 import org.jitsi.impl.neomedia.rtp.translator.*;
 import org.jitsi.impl.neomedia.transform.*;
@@ -177,8 +178,7 @@ public class AdaptiveTrackProjection
      */
     public boolean accept(@NotNull RawPacket rtpPacket)
     {
-        AdaptiveTrackProjectionContext
-            contextCopy = getContext(RawPacket.getPayloadType(rtpPacket));
+        AdaptiveTrackProjectionContext contextCopy = getContext(rtpPacket);
 
         // XXX We want to let the context know that the stream has been
         // suspended so that it can raise the needsKeyframe flag and also allow
@@ -214,31 +214,78 @@ public class AdaptiveTrackProjection
 
     /**
      * Gets or creates the adaptive track projection context that corresponds to
-     * the payload type that is specified as a parameter. If the payload type
-     * is different from {@link #contextPayloadType}, then a new adaptive track
-     * projection context is created that is appropriate for the new payload
-     * type.
+     * the payload type of the RTP packet that is specified as a parameter. If
+     * the payload type is different from {@link #contextPayloadType}, then a
+     * new adaptive track projection context is created that is appropriate for
+     * the new payload type.
      *
      * Note that, at the time of this writing, there's no practical need for a
      * synchronized keyword because there's only one thread (the translator
      * thread) accessing this method at a time.
      *
-     * @param payloadType the payload type of the adaptive track projection to
-     * get or create.
+     * @param rtpPacket the RTP packet of the adaptive track projection context
+     * to get or create.
      * @return the adaptive track projection context that corresponds to
-     * the payload type that is specified as a parameter.
+     * the payload type of the RTP packet that is specified as a parameter.
      */
     private synchronized
-    AdaptiveTrackProjectionContext getContext(int payloadType)
+    AdaptiveTrackProjectionContext getContext(@NotNull RawPacket rtpPacket)
     {
+        MediaFormat format;
+        int payloadType = rtpPacket.getPayloadType();
         if (context == null || contextPayloadType != payloadType)
         {
+            // This is either the first RTP packet or the codec changed
+            // mid-flight, i.e. VP8 -> H264 (even tho that would be suspicious
+            // as we don't have a use case for that atm).
             MediaStreamTrackDesc source = getSource();
-            MediaFormat format = source
-                .getMediaStreamTrackReceiver()
-                .getStream().getDynamicRTPPayloadTypes().get((byte) payloadType);
+            format = source
+                .getMediaStreamTrackReceiver().getStream()
+                .getDynamicRTPPayloadTypes().get((byte) payloadType);
+        }
+        else
+        {
+            // No need to call the expensive getDynamicRTPPayloadTypes.
+            format = context.getFormat();
+        }
 
-            context = makeContext(source, format);
+        if (Constants.VP8.equalsIgnoreCase(format.getEncoding()))
+        {
+            // Context switch between VP8 simulcast and VP8 non-simulcast (sort
+            // of pretend that they're different codecs).
+            //
+            // HACK: When simulcast is activated, we also get temporal
+            // scalability, conversely if temporal scalability is disabled
+            // then simulcast is disabled.
+
+            byte[] buf = rtpPacket.getBuffer();
+            int payloadOffset = rtpPacket.getPayloadOffset(),
+                payloadLen = rtpPacket.getPayloadLength();
+
+            boolean hasTemporalLayerIndex = DePacketizer.VP8PayloadDescriptor
+                .getTemporalLayerIndex(buf, payloadOffset, payloadLen) > -1;
+
+            if (hasTemporalLayerIndex
+                && !(context instanceof VP8AdaptiveTrackProjectionContext))
+            {
+                // context switch
+                context = new VP8AdaptiveTrackProjectionContext(format, getRtpState());
+                contextPayloadType = payloadType;
+            }
+            else if (!hasTemporalLayerIndex
+                && !(context instanceof GenericAdaptiveTrackProjectionContext))
+            {
+                // context switch
+                context = new GenericAdaptiveTrackProjectionContext(format, getRtpState());
+                contextPayloadType = payloadType;
+            }
+
+            // no context switch
+            return context;
+        }
+        else if (context == null || contextPayloadType != payloadType)
+        {
+            context = new GenericAdaptiveTrackProjectionContext(format, getRtpState());
             contextPayloadType = payloadType;
             return context;
         }
@@ -248,29 +295,22 @@ public class AdaptiveTrackProjection
         }
     }
 
-    /**
-     * Utility/factory method that creates the appropriate adaptive track
-     * projection context based on the media format that is specified as a
-     * parameter. Note that a media format is the same thing as a payload type
-     * (there's a one-to-one mapping between payload type and media format).
-     *
-     * @param track the ssrc of the track projection.
-     * @param format the media format.
-     * @return an adaptive track projection context that corresponds to the
-     * media format that is specified as a parameter.
-     */
-    private static AdaptiveTrackProjectionContext makeContext(
-        @NotNull MediaStreamTrackDesc track, @NotNull MediaFormat format)
+    private RtpState getRtpState()
     {
-        if (Constants.VP8.equalsIgnoreCase(format.getEncoding())
-            && track.getRTPEncodings().length > 1)
+        if (context == null)
         {
+            MediaStreamTrackDesc track = getSource();
             long ssrc = track.getRTPEncodings()[0].getPrimarySSRC();
-            return new VP8AdaptiveTrackProjectionContext(ssrc);
+            return new RtpState(
+                0 /* transmittedBytes */,
+                0 /* transmittedPackets */,
+                ssrc,
+                1 /* maxSequenceNumber */,
+                1 /* maxTimestamp */) ;
         }
         else
         {
-            return new GenericAdaptiveTrackProjectionContext(format);
+            return context.getRtpState();
         }
     }
 

--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjectionContext.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjectionContext.java
@@ -17,6 +17,7 @@ package org.jitsi.videobridge.cc;
 
 import org.jitsi.impl.neomedia.rtp.*;
 import org.jitsi.service.neomedia.*;
+import org.jitsi.service.neomedia.format.*;
 
 /**
  * Implementations of this interface are responsible for projecting a specific
@@ -81,4 +82,16 @@ public interface AdaptiveTrackProjectionContext
      * case it needs to be dropped.
      */
     boolean rewriteRtcp(RawPacket rtcpPacket);
+
+    /**
+     * @return the RTP state that describes the max sequence number, max
+     * timestamp and other RTP-level details.
+     */
+    RtpState getRtpState();
+
+    /**
+     * @return the {@link MediaFormat} of the RTP packets that this context
+     * processes.
+     */
+    MediaFormat getFormat();
 }

--- a/src/main/java/org/jitsi/videobridge/cc/RtpState.java
+++ b/src/main/java/org/jitsi/videobridge/cc/RtpState.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright @ 2019 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.cc;
+
+/**
+ * This class represents the RTP state and is used in adaptive track context
+ * switches (see {@link AdaptiveTrackProjection}).
+ *
+ * @author George Politis
+ */
+public class RtpState
+{
+    /**
+     * The SSRC of the RTP stream that this information pertains to.
+     */
+    public final long ssrc;
+
+    /**
+     * The highest sent RTP timestamp.
+     */
+    public final long maxTimestamp;
+
+    /**
+     * The highest sent sequence number.
+     */
+    public final int maxSequenceNumber;
+
+    /**
+     * The number of transmitted bytes so far.
+     */
+    public final long transmittedBytes;
+
+    /**
+     * The number of transmitted packets so far.
+     */
+    public final long transmittedPackets;
+
+    /**
+     *
+     * @param transmittedBytes the number of transmitted bytes so far.
+     * @param transmittedPackets the number of transmitted packets so far.
+     * @param ssrc the SSRC of the RTP stream that this information pertains to.
+     * @param maxSequenceNumber the highest sent sequence number.
+     * @param maxTimestamp the highest sent RTP timestamp.
+     */
+    public RtpState(long transmittedBytes, long transmittedPackets,
+                    long ssrc, int maxSequenceNumber, long maxTimestamp)
+    {
+        this.ssrc = ssrc;
+        this.transmittedBytes = transmittedBytes;
+        this.transmittedPackets = transmittedPackets;
+        this.maxSequenceNumber = maxSequenceNumber;
+        this.maxTimestamp = maxTimestamp;
+    }
+}

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameProjection.java
@@ -353,7 +353,7 @@ public class VP8FrameProjection
             // packet of a frame, the first packet of another frame may have
             // already been accepted, which means there's no longer space to
             // piggyback anything.
-            if (accept(lastPacket))
+            if (lastPacket != null && accept(lastPacket))
             {
                 piggyBackedPackets.add(lastPacket);
             }

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameProjection.java
@@ -95,10 +95,15 @@ public class VP8FrameProjection
      * Ctor.
      *
      * @param ssrc the SSRC of the destination VP8 picture.
+     * @param timestamp The RTP timestamp of the projected frame that this
+     * instance refers to (RFC3550).
+     * @param startingSequenceNumber The starting RTP sequence number of the
+     * projected frame that this instance refers to (RFC3550).
      */
-    VP8FrameProjection(long ssrc)
+    VP8FrameProjection(long ssrc, int startingSequenceNumber, long timestamp)
     {
-        this(null, ssrc, 0, 0, 0, 0, 0);
+        this(null /* vp8Frame */, ssrc, timestamp, startingSequenceNumber,
+            0 /* extendedPictureId */, 0 /* tl0PICIDX */, 0 /* createdMs */);
     }
 
     /**
@@ -162,7 +167,7 @@ public class VP8FrameProjection
             // without having sent a keyframe first.
             if (nextVP8Frame.isKeyframe())
             {
-                isLast = false;
+                close();
                 return new VP8FrameProjection(nextVP8Frame, ssrc, timestamp,
                     startingSequenceNumber, extendedPictureId, tl0PICIDX,
                     nowMs);
@@ -183,14 +188,11 @@ public class VP8FrameProjection
             // We synchronize on the VP8 frame because the max sequence number
             // can be updated from other threads and the isLast field can be
             // read by other threads.
-            synchronized (vp8Frame)
-            {
-                isLast = false;
-                return new VP8FrameProjection(
-                    nextVP8Frame, ssrc, nextTimestamp(nextVP8Frame, nowMs),
-                    nextStartingSequenceNumber(), nextExtendedPictureId(),
-                    nextTL0PICIDX(nextVP8Frame), nowMs);
-            }
+            close();
+            return new VP8FrameProjection(
+                nextVP8Frame, ssrc, nextTimestamp(nextVP8Frame, nowMs),
+                nextStartingSequenceNumber(), nextExtendedPictureId(),
+                nextTL0PICIDX(nextVP8Frame), nowMs);
         }
     }
 
@@ -252,14 +254,34 @@ public class VP8FrameProjection
      */
     private int nextStartingSequenceNumber()
     {
-        int vp8FrameLength = RTPUtils.getSequenceNumberDelta(
-            vp8Frame.getMaxSequenceNumber(),
-            vp8Frame.getStartingSequenceNumber());
+        return (maxSequenceNumber() + 1) & RawPacket.SEQUENCE_NUMBER_MASK;
+    }
 
-        int nextStartingSequenceNumber
-            = startingSequenceNumber + vp8FrameLength + 1;
+    /**
+     * Small utility method that computes and returns the max sequence number of
+     * this frame.
+     *
+     * @return the max sequence number of this frame.
+     */
+    int maxSequenceNumber()
+    {
+        // assert !isLast; otherwise the maxSequenceNumber is not guaranteed to
+        // not change. So, prior to calling this method the caller needs to have
+        // called the close method.
+        if (vp8Frame != null)
+        {
+            int vp8FrameLength = RTPUtils.getSequenceNumberDelta(
+                vp8Frame.getMaxSequenceNumber(),
+                vp8Frame.getStartingSequenceNumber());
 
-        return nextStartingSequenceNumber & RawPacket.SEQUENCE_NUMBER_MASK;
+            int maxSequenceNumber = startingSequenceNumber + vp8FrameLength;
+            return maxSequenceNumber & RawPacket.SEQUENCE_NUMBER_MASK;
+        }
+        else
+        {
+            return (startingSequenceNumber - 1)
+                & RawPacket.SEQUENCE_NUMBER_MASK;
+        }
     }
 
     /**
@@ -483,11 +505,20 @@ public class VP8FrameProjection
     }
 
     /**
-     * @return true if this is the "last" accepted {@link VP8Frame} instance,
-     * false otherwise.
+     * Prevents the max sequence number of this frame to grow any further.
      */
-    boolean isLast()
+    public void close()
     {
-        return isLast;
+        if (vp8Frame != null)
+        {
+            synchronized (vp8Frame)
+            {
+                isLast = false;
+            }
+        }
+        else
+        {
+            isLast = false;
+        }
     }
 }

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameProjection.java
@@ -366,8 +366,7 @@ public class VP8FrameProjection
                 rewriteRtpInternal(pktOut);
             }
 
-            return piggyBackedPackets.toArray(
-                new RawPacket[piggyBackedPackets.size()]);
+            return piggyBackedPackets.toArray(new RawPacket[0]);
         }
         else
         {

--- a/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java
+++ b/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java
@@ -195,11 +195,6 @@ public class ComponentImpl
     {
         try
         {
-            if (logger.isDebugEnabled())
-            {
-                logger.debug("RECV: " + iq.toXML());
-            }
-
             org.jivesoftware.smack.packet.IQ smackIQ = IQUtils.convert(iq);
             // Failed to convert to Smack IQ ?
             if (smackIQ == null)
@@ -233,11 +228,6 @@ public class ComponentImpl
             else
             {
                 resultIQ = IQUtils.convert(resultSmackIQ);
-
-                if (logger.isDebugEnabled())
-                {
-                    logger.debug("SENT: " + resultIQ.toXML());
-                }
             }
 
             return resultIQ;

--- a/src/main/java/org/jitsi/videobridge/xmpp/XmppCommon.java
+++ b/src/main/java/org/jitsi/videobridge/xmpp/XmppCommon.java
@@ -18,6 +18,7 @@ package org.jitsi.videobridge.xmpp;
 import net.java.sip.communicator.impl.protocol.jabber.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.colibri.*;
 import net.java.sip.communicator.impl.protocol.jabber.extensions.health.*;
+import net.java.sip.communicator.util.*;
 import org.jitsi.osgi.*;
 import org.jitsi.service.version.*;
 import org.jitsi.videobridge.*;
@@ -36,6 +37,12 @@ import org.osgi.framework.*;
  */
 class XmppCommon
 {
+    /**
+     * The {@link Logger} used by the {@link XmppCommon} class and its
+     * instances for logging output.
+     */
+    private static final org.jitsi.util.Logger logger
+        =  org.jitsi.util.Logger.getLogger(XmppCommon.class);
 
     static final String[] FEATURES
         = new String[]
@@ -105,6 +112,22 @@ class XmppCommon
             : null;
     }
 
+    IQ handleIQ(IQ requestIQ)
+    {
+        if (logger.isDebugEnabled() && requestIQ != null)
+        {
+            logger.debug("RECV: " + requestIQ.toXML());
+        }
+
+        IQ replyIQ = handleIQInternal(requestIQ);
+
+        if (logger.isDebugEnabled() && replyIQ != null)
+        {
+            logger.debug("SENT: " + replyIQ.toXML());
+        }
+
+        return replyIQ;
+    }
     /**
      * Handles an <tt>org.jivesoftware.smack.packet.IQ</tt> stanza of type
      * <tt>get</tt> or <tt>set</tt> which represents a request.
@@ -115,7 +138,7 @@ class XmppCommon
      * represents the response to the specified request or <tt>null</tt> to
      * reply with <tt>feature-not-implemented</tt>
      */
-    IQ handleIQ(IQ iq)
+    private IQ handleIQInternal(IQ iq)
     {
         IQ responseIQ = null;
 


### PR DESCRIPTION
In theory the media engine can switch from sending simulcast -> non-simulcast on the fly and without additional signaling (either intentionally, or unintentionally due to a bug for example). The JS code can also activate/de-activate simulcast on the fly without signaling that back to the bridge (that would definitely be due to a bug). We recently observed for some scrambling video issues with the latest bridge and suspected that a bug in the JS code was causing the media engine to switch from doing simulcast -> not simulcast without signaling that to the bridge. This PR implements adaptive track projection context switches and treats the change from simulcast -> non-simulcast stream as a codec switch. Further analysis showed that there this wasn't an issue in the client and that there's no such simulcast -> non-simulcast switch, but it's good to be able to cope with such switches on the fly, so I'm opening a PR for that functionality.

Also this PR includes fixes for a few minor issues and it also brings back logging of the COLIBRI messages received/sent by the bridge. 