### PR TITLE
Add support for VP8 simulcast stream with no temporal scalability

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
@@ -264,32 +264,17 @@ public class AdaptiveTrackProjection
 
         if (Constants.VP8.equalsIgnoreCase(format.getEncoding()))
         {
-            // Context switch between VP8 simulcast and VP8 non-simulcast (sort
-            // of pretend that they're different codecs).
-            //
-            // HACK: When simulcast is activated, we also get temporal
-            // scalability, conversely if temporal scalability is disabled
-            // then simulcast is disabled.
-
-            byte[] buf = rtpPacket.getBuffer();
-            int payloadOffset = rtpPacket.getPayloadOffset(),
-                payloadLen = rtpPacket.getPayloadLength();
-
-            boolean hasTemporalLayerIndex = DePacketizer.VP8PayloadDescriptor
-                .getTemporalLayerIndex(buf, payloadOffset, payloadLen) > -1;
-
-            if (hasTemporalLayerIndex
-                && !(context instanceof VP8AdaptiveTrackProjectionContext))
+            // We use VP8 simulcast context for any kind of VP8 stream as
+            // currently we don't have any mean of distinguishing single VP8
+            // stream from simulcast VP8 stream from here.
+            // VP8 simulcast stream may or may not have temporal scalability
+            // enabled depending on the encoder configuration.
+            // TODO: use GenericAdaptiveTrackProjectionContext for single VP8
+            // stream
+            if (!(context instanceof VP8AdaptiveTrackProjectionContext))
             {
                 // context switch
                 context = new VP8AdaptiveTrackProjectionContext(format, getRtpState());
-                contextPayloadType = payloadType;
-            }
-            else if (!hasTemporalLayerIndex
-                && !(context instanceof GenericAdaptiveTrackProjectionContext))
-            {
-                // context switch
-                context = new GenericAdaptiveTrackProjectionContext(format, getRtpState());
                 contextPayloadType = payloadType;
             }
 

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameProjection.java
@@ -396,10 +396,15 @@ public class VP8FrameProjection
         int payloadOff = pkt.getPayloadOffset()
             , payloadLen = pkt.getPayloadLength();
 
-        if (!DePacketizer.VP8PayloadDescriptor.setTL0PICIDX(
-            buf, payloadOff, payloadLen, tl0PICIDX))
-        {
-            logger.warn("Failed to set the TL0PICIDX of a VP8 packet.");
+        boolean hasTemporalLayerIndex = DePacketizer.VP8PayloadDescriptor
+            .getTemporalLayerIndex(buf, payloadOff, payloadLen) > -1;
+
+        if (hasTemporalLayerIndex) {
+            if (!DePacketizer.VP8PayloadDescriptor.setTL0PICIDX(
+                    buf, payloadOff, payloadLen, tl0PICIDX))
+            {
+                logger.warn("Failed to set the TL0PICIDX of a VP8 packet.");
+            }
         }
 
         if (!DePacketizer.VP8PayloadDescriptor.setExtendedPictureId(


### PR DESCRIPTION
This commit brings back support for VP8 simulcast streams with no temporal scalability. JVB used to support it with ENABLE_SVC flag disabled. It was broken by recent simulcast re-architecture preventing any simulcast layer switching for streams with no temporal scalability.
VP8 simulcast with no temporal scalability may be produced by HW encoders with no SVC features (majority of Android devices).
Ideally there shouldn't be need for this flag at all and we should base the logic entirely on the payload.

As a side effect it was necessary to remove use of GenericAdaptiveTrackProjectionContext for VP8 stream with no temporal scalability. I think that single streams may be served by VP8AdaptiveTrackProjectionContext anyway. 