### PR TITLE
Port BitrateController

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -463,7 +463,7 @@ public class Endpoint
             // different order) so we can't just reassign a transformed packet back into its
             // proper packetinfo.  need to change those classes to work with the new packet
             // types
-            org.jitsi.service.neomedia.RawPacket[] res = bitrateController.getRTPTransformer().transform(packets);
+            org.jitsi.service.neomedia.RawPacket[] res = bitrateController.transformRtp(packets);
             for (org.jitsi.service.neomedia.RawPacket legacyRawPacket : res)
             {
                 if (legacyRawPacket == null)

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -458,16 +458,13 @@ public class Endpoint
             // different order) so we can't just reassign a transformed packet back into its
             // proper packetinfo.  need to change those classes to work with the new packet
             // types
-            org.jitsi.service.neomedia.RawPacket[] res = bitrateController.transformRtp(packetInfo);
-            for (org.jitsi.service.neomedia.RawPacket legacyRawPacket : res)
+            VideoRtpPacket[] res = bitrateController.transformRtp(packetInfo);
+            for (VideoRtpPacket videoRtpPacket : res)
             {
-                if (legacyRawPacket == null)
+                if (videoRtpPacket == null)
                 {
                     continue;
                 }
-                UnparsedPacket rawPacket = RawPacketExtensionsKt.fromLegacyRawPacket(legacyRawPacket);
-                //TODO(brian): we can clean this up once the transformer is moved over
-                VideoRtpPacket videoRtpPacket = rawPacket.toOtherType(VideoRtpPacket::new);
                 transceiver.sendRtp(new PacketInfo(videoRtpPacket));
             }
         }

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -450,20 +450,15 @@ public class Endpoint
     @Override
     public void sendRtp(PacketInfo packetInfo, String sourceEpId)
     {
-        //TODO(brian): need to declare this here (not as a member, due to the fact that will be
-        // called from multiple threads).  in the future hopefully we can get rid of the need for
-        // this array
-        org.jitsi.service.neomedia.RawPacket[] packets = new org.jitsi.service.neomedia.RawPacket[1];
         Packet packet = packetInfo.getPacket();
         if (packet instanceof VideoRtpPacket)
         {
-            packets[0] = RawPacketExtensionsKt.toLegacyRawPacket(packet);
             //TODO(brian): we lose all information in packetinfo here, unfortunately, because
             // the bitratecontroller can return more than/less than what was passed in (and in
             // different order) so we can't just reassign a transformed packet back into its
             // proper packetinfo.  need to change those classes to work with the new packet
             // types
-            org.jitsi.service.neomedia.RawPacket[] res = bitrateController.transformRtp(packets);
+            org.jitsi.service.neomedia.RawPacket[] res = bitrateController.transformRtp(RawPacketExtensionsKt.toLegacyRawPacket(packet));
             for (org.jitsi.service.neomedia.RawPacket legacyRawPacket : res)
             {
                 if (legacyRawPacket == null)
@@ -472,9 +467,6 @@ public class Endpoint
                 }
                 UnparsedPacket rawPacket = RawPacketExtensionsKt.fromLegacyRawPacket(legacyRawPacket);
                 //TODO(brian): we can clean this up once the transformer is moved over
-//                ByteBuffer rawPacketBuf = ByteBuffer.wrap(pkt.getBuffer(), pkt.getOffset(), pkt.getBuffer().length);
-//                rawPacketBuf.limit(pkt.getLength());
-//                VideoRtpPacket videoRtpPacket = RtpPacket.Companion.fromBuffer(rawPacketBuf).toOtherRtpPacketType(VideoRtpPacket::new);
                 VideoRtpPacket videoRtpPacket = rawPacket.toOtherType(VideoRtpPacket::new);
                 transceiver.sendRtp(new PacketInfo(videoRtpPacket));
             }

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -458,7 +458,7 @@ public class Endpoint
             // different order) so we can't just reassign a transformed packet back into its
             // proper packetinfo.  need to change those classes to work with the new packet
             // types
-            org.jitsi.service.neomedia.RawPacket[] res = bitrateController.transformRtp(RawPacketExtensionsKt.toLegacyRawPacket(packet));
+            org.jitsi.service.neomedia.RawPacket[] res = bitrateController.transformRtp(packetInfo);
             for (org.jitsi.service.neomedia.RawPacket legacyRawPacket : res)
             {
                 if (legacyRawPacket == null)

--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
@@ -366,7 +366,7 @@ public class AdaptiveTrackProjection
      * @return any piggy-backed packets to include with the packet.
      * XXX unused?
      */
-    RawPacket[] rewriteRtp(@NotNull RawPacket rtpPacket)
+    RawPacket[] rewriteRtp(@NotNull VideoRtpPacket rtpPacket)
         throws RewriteException
     {
         AdaptiveTrackProjectionContext contextCopy = context;
@@ -375,7 +375,7 @@ public class AdaptiveTrackProjection
             return EMPTY_PACKET_ARR;
         }
 
-        return contextCopy.rewriteRtp(rtpPacket, packetCache);
+        return contextCopy.rewriteRtp(RawPacketExtensionsKt.toLegacyRawPacket(rtpPacket), packetCache);
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
@@ -62,7 +62,7 @@ public class AdaptiveTrackProjection
      * An empty {@link RawPacket} array that is used as a return value when no
      * packets need to be piggy-backed.
      */
-    public static final RawPacket[]
+    public static final VideoRtpPacket[]
         EMPTY_PACKET_ARR = AdaptiveTrackProjectionContext.EMPTY_PACKET_ARR;
 
     /**
@@ -200,9 +200,7 @@ public class AdaptiveTrackProjection
         }
         VideoRtpPacket videoRtpPacket = (VideoRtpPacket) rtpPacket;
 
-        RawPacket legacyRawPacket
-                = RawPacketExtensionsKt.toLegacyRawPacket(rtpPacket);
-        AdaptiveTrackProjectionContext contextCopy = getContext(legacyRawPacket);
+        AdaptiveTrackProjectionContext contextCopy = getContext(videoRtpPacket);
         if (contextCopy == null)
         {
             return false;
@@ -224,7 +222,7 @@ public class AdaptiveTrackProjection
 
         int targetIndexCopy = targetIndex;
         boolean accept = contextCopy.accept(
-            legacyRawPacket, videoRtpPacket.getQualityIndex(), targetIndexCopy);
+            videoRtpPacket, videoRtpPacket.getQualityIndex(), targetIndexCopy);
 
         // We check if the context needs a keyframe regardless of whether or not
         // the packet was accepted.
@@ -271,7 +269,7 @@ public class AdaptiveTrackProjection
      * the payload type of the RTP packet that is specified as a parameter.
      */
     private synchronized
-    AdaptiveTrackProjectionContext getContext(@NotNull RawPacket rtpPacket)
+    AdaptiveTrackProjectionContext getContext(@NotNull VideoRtpPacket rtpPacket)
     {
         PayloadType payloadTypeObject;
         int payloadType = rtpPacket.getPayloadType();
@@ -366,7 +364,7 @@ public class AdaptiveTrackProjection
      * @return any piggy-backed packets to include with the packet.
      * XXX unused?
      */
-    RawPacket[] rewriteRtp(@NotNull VideoRtpPacket rtpPacket)
+    VideoRtpPacket[] rewriteRtp(@NotNull VideoRtpPacket rtpPacket)
         throws RewriteException
     {
         AdaptiveTrackProjectionContext contextCopy = context;
@@ -375,7 +373,7 @@ public class AdaptiveTrackProjection
             return EMPTY_PACKET_ARR;
         }
 
-        return contextCopy.rewriteRtp(RawPacketExtensionsKt.toLegacyRawPacket(rtpPacket), packetCache);
+        return contextCopy.rewriteRtp(rtpPacket, packetCache);
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjectionContext.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjectionContext.java
@@ -16,6 +16,7 @@
 package org.jitsi.videobridge.cc;
 
 import org.jitsi.nlj.format.*;
+import org.jitsi.nlj.rtp.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi_modified.impl.neomedia.rtp.*;
 import org.jitsi.service.neomedia.format.*;
@@ -40,7 +41,7 @@ public interface AdaptiveTrackProjectionContext
      * An empty {@link RawPacket} array that is used as a return value when no
      * packets need to be piggy-backed.
      */
-    RawPacket[] EMPTY_PACKET_ARR = new RawPacket[0];
+    VideoRtpPacket[] EMPTY_PACKET_ARR = new VideoRtpPacket[0];
 
     /**
      * Determines whether an RTP packet should be accepted or not.
@@ -50,7 +51,7 @@ public interface AdaptiveTrackProjectionContext
      * @param targetIndex the target quality index
      * @return true if the packet should be accepted, false otherwise.
      */
-    boolean accept(RawPacket rtpPacket, int incomingIndex, int targetIndex);
+    boolean accept(VideoRtpPacket rtpPacket, int incomingIndex, int targetIndex);
 
     /**
      * @return true if this stream context needs a keyframe in order to either
@@ -72,8 +73,8 @@ public interface AdaptiveTrackProjectionContext
      * @throws RewriteException the underlying code has failed to rewrite the
      * RTP packet that is specified as an argument.
      */
-    RawPacket[]
-    rewriteRtp(RawPacket rtpPacket, RtpPacketCache incomingRawPacketCache)
+    VideoRtpPacket[]
+    rewriteRtp(VideoRtpPacket rtpPacket, RtpPacketCache incomingRawPacketCache)
         throws RewriteException;
 
     /**

--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -1133,9 +1133,8 @@ public class BitrateController
         });
     }
 
-    public RawPacket[] transformRtp(@NotNull PacketInfo packetInfo)
+    public VideoRtpPacket[] transformRtp(@NotNull PacketInfo packetInfo)
     {
-        RawPacket pkt = RawPacketExtensionsKt.toLegacyRawPacket(packetInfo.getPacket());
         VideoRtpPacket videoPacket = (VideoRtpPacket)packetInfo.getPacket();
         if (firstMediaMs == -1)
         {
@@ -1153,17 +1152,17 @@ public class BitrateController
 
         try
         {
-            RawPacket[] extras = adaptiveTrackProjection.rewriteRtp(videoPacket);
+            VideoRtpPacket[] extras = adaptiveTrackProjection.rewriteRtp(videoPacket);
             if (extras.length > 0)
             {
-                RawPacket[] allPackets = new RawPacket[extras.length + 1];
-                allPackets[0] = pkt;
+                VideoRtpPacket[] allPackets = new VideoRtpPacket[extras.length + 1];
+                allPackets[0] = videoPacket;
                 System.arraycopy(extras, 0, allPackets, 1, extras.length);
                 return allPackets;
             }
             else
             {
-                return new RawPacket[] {pkt};
+                return new VideoRtpPacket[] {videoPacket};
             }
         }
         catch (RewriteException e)

--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -1136,12 +1136,13 @@ public class BitrateController
     public RawPacket[] transformRtp(@NotNull PacketInfo packetInfo)
     {
         RawPacket pkt = RawPacketExtensionsKt.toLegacyRawPacket(packetInfo.getPacket());
+        VideoRtpPacket videoPacket = (VideoRtpPacket)packetInfo.getPacket();
         if (firstMediaMs == -1)
         {
             firstMediaMs = System.currentTimeMillis();
         }
 
-        long ssrc = pkt.getSSRCAsLong();
+        Long ssrc = videoPacket.getSsrc();
         AdaptiveTrackProjection adaptiveTrackProjection
                 = adaptiveTrackProjectionMap.get(ssrc);
 
@@ -1152,7 +1153,7 @@ public class BitrateController
 
         try
         {
-            RawPacket[] extras = adaptiveTrackProjection.rewriteRtp(pkt);
+            RawPacket[] extras = adaptiveTrackProjection.rewriteRtp(videoPacket);
             if (extras.length > 0)
             {
                 RawPacket[] allPackets = new RawPacket[extras.length + 1];
@@ -1164,7 +1165,6 @@ public class BitrateController
             {
                 return new RawPacket[] {pkt};
             }
-
         }
         catch (RewriteException e)
         {

--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -89,7 +89,6 @@ import java.util.function.*;
  */
 @SuppressWarnings("JavadocReference")
 public class BitrateController
-    implements TransformEngine
 {
     /**
      * The property name that holds the bandwidth estimation threshold.
@@ -239,22 +238,6 @@ public class BitrateController
         adaptiveTrackProjectionMap = new ConcurrentHashMap<>();
 
     /**
-     * The {@link PacketTransformer} that handles incoming/outgoing RTP
-     * packets for this {@link BitrateController} instance. Internally,
-     * it delegates this responsibility to the appropriate media stream track
-     * bitrate controller ({@link AdaptiveTrackProjection}, etc).
-     */
-    private final PacketTransformer rtpTransformer = new RTPTransformer();
-
-    /**
-     * The {@link PacketTransformer} that handles incoming/outgoing RTCP
-     * packets for this {@link BitrateController} instance. Internally,
-     * it delegates this responsibility to the appropriate media stream track
-     * bitrate controller ({@link AdaptiveTrackProjection}, etc).
-     */
-    private final PacketTransformer rtcpTransformer = new RTCPTransformer();
-
-    /**
      * The {@link List} of endpoints that are currently being forwarded,
      * represented by their IDs. Required for backwards compatibility with
      * existing LastN code.
@@ -387,24 +370,6 @@ public class BitrateController
         }
         return Math.abs(previousBwe - currentBwe)
             >= previousBwe * BWE_CHANGE_THRESHOLD_PCT / 100;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public PacketTransformer getRTPTransformer()
-    {
-        return rtpTransformer;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public PacketTransformer getRTCPTransformer()
-    {
-        return rtcpTransformer;
     }
 
     /**
@@ -1164,6 +1129,70 @@ public class BitrateController
         });
     }
 
+    public RawPacket[] transformRtp(RawPacket[] pkts)
+    {
+        if (ArrayUtils.isNullOrEmpty(pkts))
+        {
+            return pkts;
+        }
+
+        if (firstMediaMs == -1)
+        {
+            firstMediaMs = System.currentTimeMillis();
+        }
+
+        RawPacket[] extras = null;
+        for (int i = 0; i < pkts.length; i++)
+        {
+            if (!RTPPacketPredicate.INSTANCE.test(pkts[i]))
+            {
+                continue;
+            }
+
+            long ssrc = pkts[i].getSSRCAsLong();
+
+            AdaptiveTrackProjection adaptiveTrackProjection
+                    = adaptiveTrackProjectionMap.get(ssrc);
+
+            if (adaptiveTrackProjection == null)
+            {
+                pkts[i] = null;
+                continue;
+            }
+
+            RawPacket[] ret;
+            try
+            {
+                ret = adaptiveTrackProjection.rewriteRtp(pkts[i]);
+            }
+            catch (RewriteException ex)
+            {
+                pkts[i] = null;
+                continue;
+            }
+
+            if (ArrayUtils.isNullOrEmpty(ret))
+            {
+                continue;
+            }
+
+            int extrasLen
+                    = ArrayUtils.isNullOrEmpty(extras) ? 0 : extras.length;
+            RawPacket[] newExtras = new RawPacket[extrasLen + ret.length];
+            System.arraycopy(ret, 0, newExtras, extrasLen, ret.length);
+
+            if (extrasLen > 0)
+            {
+                System.arraycopy(extras, 0, newExtras, 0, extrasLen);
+            }
+
+            extras = newExtras;
+        }
+
+        return ArrayUtils.concat(pkts, extras);
+    }
+
+
     /**
      * A snapshot of the bitrate for a given {@link RTPEncodingDesc}.
      */
@@ -1451,145 +1480,6 @@ public class BitrateController
             // quality.
             return ratedIndices.length != 0
                 ? ratedIndices[ratedIndices.length - 1].encoding.getIndex() : -1;
-        }
-    }
-
-    /**
-     * The {@link PacketTransformer} that handles incoming/outgoing RTP
-     * packets for this {@link BitrateController} instance. Internally,
-     * it delegates this responsibility to the appropriate media stream track
-     * bitrate controller ({@link AdaptiveTrackProjection}, etc).
-     */
-    private class RTPTransformer
-        implements PacketTransformer
-    {
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public void close()
-        {
-            // no-op
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public RawPacket[] reverseTransform(RawPacket[] pkts)
-        {
-            return pkts;
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public RawPacket[] transform(RawPacket[] pkts)
-        {
-            if (ArrayUtils.isNullOrEmpty(pkts))
-            {
-                return pkts;
-            }
-
-            if (firstMediaMs == -1)
-            {
-                firstMediaMs = System.currentTimeMillis();
-            }
-
-            RawPacket[] extras = null;
-            for (int i = 0; i < pkts.length; i++)
-            {
-                if (!RTPPacketPredicate.INSTANCE.test(pkts[i]))
-                {
-                    continue;
-                }
-
-                long ssrc = pkts[i].getSSRCAsLong();
-
-                AdaptiveTrackProjection adaptiveTrackProjection
-                    = adaptiveTrackProjectionMap.get(ssrc);
-
-                if (adaptiveTrackProjection == null)
-                {
-                    pkts[i] = null;
-                    continue;
-                }
-
-                RawPacket[] ret;
-                try
-                {
-                    ret = adaptiveTrackProjection.rewriteRtp(pkts[i]);
-                }
-                catch (RewriteException ex)
-                {
-                    pkts[i] = null;
-                    continue;
-                }
-
-                if (ArrayUtils.isNullOrEmpty(ret))
-                {
-                    continue;
-                }
-
-                int extrasLen
-                    = ArrayUtils.isNullOrEmpty(extras) ? 0 : extras.length;
-                RawPacket[] newExtras = new RawPacket[extrasLen + ret.length];
-                System.arraycopy(ret, 0, newExtras, extrasLen, ret.length);
-
-                if (extrasLen > 0)
-                {
-                    System.arraycopy(extras, 0, newExtras, 0, extrasLen);
-                }
-
-                extras = newExtras;
-            }
-
-            return ArrayUtils.concat(pkts, extras);
-        }
-    }
-
-    /**
-     * The {@link PacketTransformer} that handles incoming/outgoing RTCP
-     * packets for this {@link BitrateController} instance. Internally,
-     * it delegates this responsibility to the appropriate media stream track
-     * bitrate controller ({@link AdaptiveTrackProjection}, etc).
-     */
-    private class RTCPTransformer
-        extends SinglePacketTransformerAdapter
-    {
-        /**
-         * Ctor.
-         */
-        RTCPTransformer()
-        {
-            super(RTCPPacketPredicate.INSTANCE);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public RawPacket transform(RawPacket pkt)
-        {
-            long ssrc = pkt.getRTCPSSRC();
-            if (ssrc < 0)
-            {
-                return pkt;
-            }
-
-            AdaptiveTrackProjection adaptiveTrackProjection
-                = adaptiveTrackProjectionMap.get(ssrc);
-
-            if (adaptiveTrackProjection != null)
-            {
-                if (!adaptiveTrackProjection.rewriteRtcp(pkt))
-                {
-                    return null;
-                }
-            }
-
-            return pkt;
         }
     }
 }

--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -18,8 +18,10 @@ package org.jitsi.videobridge.cc;
 import org.jetbrains.annotations.*;
 import org.jitsi.impl.neomedia.*;
 import org.jitsi.impl.neomedia.transform.*;
+import org.jitsi.nlj.*;
 import org.jitsi.nlj.format.*;
 import org.jitsi.nlj.rtp.*;
+import org.jitsi.nlj.util.*;
 import org.jitsi.rtp.rtp.*;
 import org.jitsi.service.configuration.*;
 import org.jitsi.service.libjitsi.*;
@@ -1131,8 +1133,9 @@ public class BitrateController
         });
     }
 
-    public RawPacket[] transformRtp(@NotNull RawPacket pkt)
+    public RawPacket[] transformRtp(@NotNull PacketInfo packetInfo)
     {
+        RawPacket pkt = RawPacketExtensionsKt.toLegacyRawPacket(packetInfo.getPacket());
         if (firstMediaMs == -1)
         {
             firstMediaMs = System.currentTimeMillis();

--- a/src/main/java/org/jitsi/videobridge/cc/GenericAdaptiveTrackProjectionContext.java
+++ b/src/main/java/org/jitsi/videobridge/cc/GenericAdaptiveTrackProjectionContext.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.*;
 import org.jitsi.impl.neomedia.rtcp.*;
 import org.jitsi.impl.neomedia.rtp.RTPEncodingDesc;
 import org.jitsi.nlj.format.*;
+import org.jitsi.nlj.rtp.*;
 import org.jitsi.rtp.rtcp.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.util.*;
@@ -58,7 +59,7 @@ class GenericAdaptiveTrackProjectionContext
      * Checks if the given packet with the given format is part of a key frame.
      */
     private static boolean isKeyframe(
-            @NotNull RawPacket rtpPacket, @NotNull PayloadType payloadType)
+            @NotNull VideoRtpPacket rtpPacket, @NotNull PayloadType payloadType)
     {
         byte[] buf = rtpPacket.getBuffer();
         int payloadOff = rtpPacket.getPayloadOffset(),
@@ -186,7 +187,7 @@ class GenericAdaptiveTrackProjectionContext
      */
     @Override
     public synchronized boolean
-    accept(@NotNull RawPacket rtpPacket, int incomingIndex, int targetIndex)
+    accept(@NotNull VideoRtpPacket rtpPacket, int incomingIndex, int targetIndex)
     {
         if (targetIndex == RTPEncodingDesc.SUSPENDED_INDEX)
         {
@@ -216,7 +217,7 @@ class GenericAdaptiveTrackProjectionContext
 
                 if (logger.isDebugEnabled())
                 {
-                    logger.debug("delta ssrc=" + rtpPacket.getSSRCAsLong()
+                    logger.debug("delta ssrc=" + rtpPacket.getSsrc()
                         + ",src_sequence=" + sourceSequenceNumber
                         + ",dst_sequence=" + destinationSequenceNumber
                         + ",max_sequence=" + maxDestinationSequenceNumber
@@ -259,7 +260,7 @@ class GenericAdaptiveTrackProjectionContext
 
             if (logger.isDebugEnabled())
             {
-                logger.debug("accept ssrc=" + rtpPacket.getSSRCAsLong()
+                logger.debug("accept ssrc=" + rtpPacket.getSsrc()
                 + ",src_sequence=" + sourceSequenceNumber
                 + ",dst_sequence=" + destinationSequenceNumber
                 + ",max_sequence=" + maxDestinationSequenceNumber);
@@ -269,7 +270,7 @@ class GenericAdaptiveTrackProjectionContext
         {
             if (logger.isDebugEnabled())
             {
-                logger.debug("reject ssrc=" + rtpPacket.getSSRCAsLong()
+                logger.debug("reject ssrc=" + rtpPacket.getSsrc()
                     + ",src_sequence=" + sourceSequenceNumber);
             }
         }
@@ -318,8 +319,8 @@ class GenericAdaptiveTrackProjectionContext
      * @return {@link #EMPTY_PACKET_ARR}
      */
     @Override
-    public RawPacket[] rewriteRtp(
-        @NotNull RawPacket rtpPacket, RtpPacketCache incomingRawPacketCache)
+    public VideoRtpPacket[] rewriteRtp(
+        @NotNull VideoRtpPacket rtpPacket, RtpPacketCache incomingRawPacketCache)
     {
         int sourceSequenceNumber = rtpPacket.getSequenceNumber();
         int destinationSequenceNumber
@@ -341,7 +342,7 @@ class GenericAdaptiveTrackProjectionContext
 
         if (logger.isDebugEnabled())
         {
-            logger.debug("rewrite ssrc=" + rtpPacket.getSSRCAsLong()
+            logger.debug("rewrite ssrc=" + rtpPacket.getSsrc()
                 + ",src_sequence=" + sourceSequenceNumber
                 + ",dst_sequence=" + destinationSequenceNumber
                 + ",max_sequence=" + maxDestinationSequenceNumber);

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8Frame.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8Frame.java
@@ -17,6 +17,7 @@ package org.jitsi.videobridge.cc.vp8;
 
 import org.jetbrains.annotations.*;
 import org.jitsi.impl.neomedia.codec.video.vp8.*;
+import org.jitsi.nlj.rtp.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.util.*;
 
@@ -116,10 +117,10 @@ class VP8Frame
      * that was seen before the arrival of the first packet of this frame. This
      * is useful for piggybacking any mis-ordered packets.
      */
-    VP8Frame(@NotNull RawPacket firstPacketOfFrame,
+    VP8Frame(@NotNull VideoRtpPacket firstPacketOfFrame,
              int maxSequenceNumberSeenBeforeFirstPacket)
     {
-        this.ssrc = firstPacketOfFrame.getSSRCAsLong();
+        this.ssrc = firstPacketOfFrame.getSsrc();
         this.timestamp = firstPacketOfFrame.getTimestamp();
         this.startingSequenceNumber = firstPacketOfFrame.getSequenceNumber();
         this.maxSequenceNumberSeenBeforeFirstPacket
@@ -270,9 +271,9 @@ class VP8Frame
      * is part of the VP8 picture that is represented by this
      * {@link VP8Frame} instance, false otherwise.
      */
-    private boolean matchesSSRC(@NotNull RawPacket pkt)
+    private boolean matchesSSRC(@NotNull VideoRtpPacket pkt)
     {
-        return ssrc == pkt.getSSRCAsLong();
+        return ssrc == pkt.getSsrc();
     }
 
     /**
@@ -282,7 +283,7 @@ class VP8Frame
      * @return true if the specified RTP packet is part of an older frame, false
      * otherwise.
      */
-    boolean matchesOlderFrame(@NotNull RawPacket pkt)
+    boolean matchesOlderFrame(@NotNull VideoRtpPacket pkt)
     {
         if (!matchesSSRC(pkt))
         {
@@ -301,7 +302,7 @@ class VP8Frame
      * @return true if the specified RTP packet is part of this frame, false
      * otherwise.
      */
-    boolean matchesFrame(@NotNull RawPacket pkt)
+    boolean matchesFrame(@NotNull VideoRtpPacket pkt)
     {
         return matchesSSRC(pkt) && timestamp == pkt.getTimestamp();
     }

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8QualityFilter.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8QualityFilter.java
@@ -17,6 +17,7 @@ package org.jitsi.videobridge.cc.vp8;
 
 import org.jetbrains.annotations.*;
 import org.jitsi.impl.neomedia.codec.video.vp8.*;
+import org.jitsi.nlj.rtp.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.util.*;
 
@@ -67,7 +68,7 @@ class VP8QualityFilter
      * The spatial/quality layer id that this instance tries to achieve. Upon
      * receipt of a packet, we check whether externalSpatialLayerIdTarget
      * (that's specified as an argument to the
-     * {@link #acceptFrame(RawPacket, int, long)} method) is set to something
+     * {@link #acceptFrame(VideoRtpPacket, int, long)} method) is set to something
      * different, in which case we set {@link #needsKeyframe} equal to true and
      * update.
      */
@@ -106,7 +107,7 @@ class VP8QualityFilter
      * @return true to accept the VP8 frame, otherwise false.
      */
     synchronized boolean acceptFrame(
-        @NotNull RawPacket firstPacketOfFrame,
+        @NotNull VideoRtpPacket firstPacketOfFrame,
         int incomingIndex,
         int externalTargetIndex, long nowMs)
     {
@@ -157,7 +158,7 @@ class VP8QualityFilter
         int spatialLayerId = getSpatialLayerId(incomingIndex);
         if (DePacketizer.isKeyFrame(buf, payloadOff, payloadLen))
         {
-            logger.debug(hashCode() + " Quality filter got keyframe for stream " + firstPacketOfFrame.getSSRCAsLong());
+            logger.debug(hashCode() + " Quality filter got keyframe for stream " + firstPacketOfFrame.getSsrc());
             return acceptKeyframe(spatialLayerId, nowMs);
         }
         else if (currentSpatialLayerId > SUSPENDED_LAYER_ID)
@@ -222,7 +223,7 @@ class VP8QualityFilter
      * method for specific details).
      */
     private synchronized boolean isPossibleToSwitch(
-        @NotNull RawPacket firstPacketOfFrame, int spatialLayerId)
+        @NotNull VideoRtpPacket firstPacketOfFrame, int spatialLayerId)
     {
         if (spatialLayerId == -1)
         {


### PR DESCRIPTION
I did not get as far as I wanted to with this (we still do not preserve the PacketInfo instance, meaning we lose the receivedTime/timeline), but it is a step in the right direction (we avoid packet conversion) and I think the next step will be a pretty big change.

I think we can actually change this flow a bit to work such that, rather than caching all packets, it holds only those that it may want in incomplete frames and can then release them.  So instead of copying and caching all packets of which we may only use some, we can just hold some pending packets until we discover we do (or don't) need them.  This is along the lines of the 'jitter buffer scheme' idea I had for this class before.  We'll probably need to talk with george about that change, but we can discuss it more tomorrow.