### PR TITLE
fix: Do not accept packets until ICE and DTLS connect.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/DtlsTransport.java
+++ b/src/main/java/org/jitsi/videobridge/DtlsTransport.java
@@ -89,7 +89,7 @@ public class DtlsTransport extends IceTransport
     private final Node incomingPipelineRoot;
     private final Node outgoingDtlsPipelineRoot;
     private final Node outgoingSrtpPipelineRoot;
-    protected boolean dtlsHandshakeComplete = false;
+    private boolean dtlsHandshakeComplete = false;
 
     /**
      * Initializes a new {@link DtlsTransport} instance for a specific endpoint.
@@ -210,12 +210,16 @@ public class DtlsTransport extends IceTransport
         super.startConnectivityEstablishment(transportPacketExtension);
     }
 
+    /**
+     * Returns {@code true} if this {@link DtlsTransport} is connected. It is
+     * considered connected if the underlying ICE connection has been
+     * established and the DTLS session has been established.
+     * @return
+     */
     @Override
     public boolean isConnected()
     {
-        // TODO: do we consider this TM connected when ICE completes, or when
-        // ICE and DTLS both complete?
-        return super.isConnected();
+        return super.isConnected() && dtlsHandshakeComplete;
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -407,11 +407,33 @@ public class Endpoint
     }
 
     /**
+     * Checks if this endpoint's transport manager is connected.
+     * @return
+     */
+    private boolean isTransportConnected()
+    {
+        try
+        {
+            return getTransportManager().isConnected();
+        }
+        catch (IOException ioe)
+        {
+            logger.warn("Could not get transport manager: ", ioe);
+            return false;
+        }
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
     public boolean wants(PacketInfo packetInfo)
     {
+        if (!isTransportConnected())
+        {
+            return false;
+        }
+
         Packet packet = Objects.requireNonNull(packetInfo.getPacket(), "packet");
 
         if (packet instanceof RtpPacket)

--- a/src/main/java/org/jitsi/videobridge/IceTransport.java
+++ b/src/main/java/org/jitsi/videobridge/IceTransport.java
@@ -398,7 +398,8 @@ public class IceTransport
     }
 
     /**
-     * {@inheritDoc}
+     * Returns {@code true} if this {@link IceTransport} has connected. It is
+     * considered connected once the ICE connection is extablished.
      */
     public boolean isConnected()
     {


### PR DESCRIPTION
ICE/DTLS may take a long time (>1s) and if we keep caching packets
coming from other endpoint in the conference we:
1. Might fill the SRTP cache
2. Will cause a spike in bitrate once we connect (while videos are probably
not decodable because yet because there's no keyframe)
3. Might cause problems with the timing of the audio playback