### PR TITLE
Fixes moving endpoints between bridges with Octo

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -775,6 +775,18 @@ public class Conference
     public Endpoint getOrCreateLocalEndpoint(String id)
     {
         AbstractEndpoint endpoint = getEndpoint(id, /* create */ true);
+        if (endpoint instanceof OctoEndpoint)
+        {
+            // It is possible that an Endpoint was migrated from another bridge
+            // in the conference to this one, and the sources lists (which
+            // implicitly signal the Octo endpoints in the conference) haven't
+            // been updated yet. We'll force the Octo endpoint to expire and
+            // we'll continue with the creation of a new local Endpoint for the
+            // participant.
+            endpoint.expire();
+            endpoint = getEndpoint(id, /* create */ true);
+        }
+
         if (!(endpoint instanceof Endpoint))
         {
             throw new IllegalStateException("Endpoint with id " + id +

--- a/src/main/java/org/jitsi/videobridge/octo/OctoEndpoint.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoEndpoint.java
@@ -38,14 +38,21 @@ public class OctoEndpoint
     private final Set<Long> receiveSsrcs = new HashSet<>();
 
     /**
+     * The {@link OctoEndpoints} instance for the conference.
+     */
+    private final OctoEndpoints octoEndpoints;
+
+    /**
      * Initializes a new {@link OctoEndpoint} with a specific ID in a specific
      * conference.
      * @param conference the conference.
      * @param id the ID of the endpoint.
      */
-    OctoEndpoint(Conference conference, String id)
+    OctoEndpoint(Conference conference, String id, OctoEndpoints octoEndpoints)
     {
         super(conference, id);
+
+        this.octoEndpoints = octoEndpoints;
     }
 
     /**
@@ -115,6 +122,21 @@ public class OctoEndpoint
     public void addReceiveSsrc(long ssrc)
     {
         receiveSsrcs.add(ssrc);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void expire()
+    {
+        if (super.isExpired())
+        {
+            return;
+        }
+
+        octoEndpoints.endpointExpired(this);
+        super.expire();
     }
 
 }

--- a/src/main/java/org/jitsi/videobridge/octo/OctoEndpoints.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoEndpoints.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.octo;
 
+import org.jetbrains.annotations.*;
 import org.jitsi.utils.logging.*;
 import org.jitsi.videobridge.*;
 import org.json.simple.*;
@@ -113,9 +114,18 @@ import java.util.stream.*;
          });
 
 
-         octoEndpointIds = Collections.unmodifiableSet(endpointIds);
+         octoEndpointIds = new HashSet<>(endpointIds);
 
          return !toCreate.isEmpty() || !toExpire.isEmpty();
+     }
+
+     /**
+      * Notifies this instance that one of its {@link OctoEndpoint}s expired.
+      * @param endpoint
+      */
+     void endpointExpired(@NotNull OctoEndpoint endpoint)
+     {
+        octoEndpointIds.remove(endpoint.getID());
      }
 
      /**
@@ -126,7 +136,7 @@ import java.util.stream.*;
       */
      private OctoEndpoint addEndpoint(String id)
      {
-         OctoEndpoint endpoint = new OctoEndpoint(conference, id);
+         OctoEndpoint endpoint = new OctoEndpoint(conference, id, this);
 
          conference.addEndpoint(endpoint);
 


### PR DESCRIPTION
Expires OctoEndpoints if a request for a new local endpoint with the
same ID is received.