### PR TITLE
Unthrottle bitrate allocation updates when the bandwidth increases

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -159,7 +159,7 @@ public class BitrateController
      * The default value of the bandwidth change threshold above which we react
      * with a new bandwidth allocation.
      */
-    private static final int BWE_CHANGE_THRESHOLD_PCT_DEFAULT = 15;
+    private static final int BWE_CHANGE_THRESHOLD_PCT_DEFAULT = -15;
 
     /**
      * The ConfigurationService to get config values from.
@@ -363,8 +363,8 @@ public class BitrateController
         {
             return true;
         }
-        return Math.abs(previousBwe - currentBwe)
-            >= previousBwe * BWE_CHANGE_THRESHOLD_PCT / 100;
+        return previousBwe - currentBwe
+            < previousBwe * BWE_CHANGE_THRESHOLD_PCT / 100;
     }
 
     /**
@@ -605,13 +605,14 @@ public class BitrateController
             // do not update the bitrate allocation. The goal is to limit
             // the resolution changes due to bandwidth estimation changes,
             // as often resolution changes can negatively impact user
-            // experience.
+            // experience, at the risk of clogging the receiver pipe.
         }
         else
         {
             if (logger.isDebugEnabled())
             {
-                logger.debug(destinationEndpoint.getID() + " bandwidth has changed, updating");
+                logger.debug(destinationEndpoint.getID() +
+                        " bandwidth has changed, updating");
             }
 
             lastBwe = newBandwidthBps;

--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -356,7 +356,7 @@ public class BitrateController
      * @return true if the bandwidth has changed above the configured threshold,
      * false otherwise.
      */
-    private static boolean isLargerThanBweThreshold(
+    private static boolean changeIsLargerThanThreshold(
         long previousBwe, long currentBwe)
     {
         if (previousBwe == -1 || currentBwe == -1)
@@ -613,7 +613,7 @@ public class BitrateController
                 .addField("bwe_bps", newBandwidthBps));
         }
 
-        if (!isLargerThanBweThreshold(lastBwe, newBandwidthBps))
+        if (!changeIsLargerThanThreshold(lastBwe, newBandwidthBps))
         {
             logger.debug("New bandwidth (" + newBandwidthBps
                 + ") is not significantly " +


### PR DESCRIPTION
Right now we require a 15% (configurable) change in the bwe in order to
update the bitrate allocation. This is an ugly hack to prevent too many
resolution/UI changes in case the bridge produces too low bandwdith
estimate, at the risk of clogging the receiver's pipe.

The code prevented not only downscaling, but also upscaling, which is
problematic: Suppose that the target bitrate is 2.5Mbps, and that the
last bitrate allocation was performed with a 2.4Mbps bandwidth esitmate.
The bridge keeps probing and, suppose that, eventually the bandwidth
estimate reaches 2.6Mbps, which is plenty to accomodate the target
bitrat; but the minimum bandwidth estimate that would trigger a new
bitrate allocation is 2.4Mbps + 2.4Mbps * 15% = 2.76Mbps.