### PR TITLE
Debug logging of packet mishandling round 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-utils</artifactId>
-      <version>1.0-20190401.122850-7</version>
+      <version>1.0-20190723.110846-12</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>libjitsi</artifactId>
-      <version>1.0-20190718.110720-388</version>
+      <version>1.0-20190724.114721-390</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/SctpConnection.java
+++ b/src/main/java/org/jitsi/videobridge/SctpConnection.java
@@ -34,7 +34,7 @@ import org.jitsi.service.libjitsi.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.service.packetlogging.*;
 import org.jitsi.util.*;
-import org.jitsi.utils.*;
+import org.jitsi.utils.queue.*;
 import org.jitsi.utils.concurrent.ExecutorUtils;
 import org.jitsi.utils.logging.Logger; // Disambiguation.
 

--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
@@ -28,6 +28,7 @@ import org.jitsi.utils.logging.*;
 import org.jitsi.videobridge.cc.vp8.*;
 
 import java.lang.ref.*;
+import java.util.*;
 
 /**
  * Filters the packets coming from a specific {@link MediaStreamTrackDesc}
@@ -192,18 +193,23 @@ public class AdaptiveTrackProjection
             MediaStreamTrackDesc sourceTrack = getSource();
             if (sourceTrack != null)
             {
+                MediaStreamTrackReceiver mediaStreamTrackReceiver
+                    = sourceTrack.getMediaStreamTrackReceiver();
+
                 logger.warn(
-                    "Dropping an RTP packet, because the SSRC has not " +
-                        "been signaled " +
-                        sourceTrack
-                            .getMediaStreamTrackReceiver()
-                            .getStream().packetToString(rtpPacket));
+                    "Dropping an RTP packet, because egress was unable " +
+                        "to find an encoding for raw packet " +
+                        mediaStreamTrackReceiver
+                            .getStream().packetToString(rtpPacket)
+                        + ". Ingress is aware of these tracks: "
+                        + Arrays.toString(
+                            mediaStreamTrackReceiver.getMediaStreamTracks()));
             }
             else
             {
                 logger.warn(
-                    "Dropping an RTP packet. Source track is null and the SSRC " +
-                        "has not been signaled " + rtpPacket);
+                    "Dropping an RTP packet, because egress was unable " +
+                        "to find an encoding for raw packet " + rtpPacket);
             }
 
             return false;

--- a/src/main/java/org/jitsi/videobridge/cc/BandwidthProbing.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BandwidthProbing.java
@@ -205,7 +205,7 @@ public class BandwidthProbing
             DiagnosticContext diagnosticContext
                 = videoStreamImpl.getDiagnosticContext();
             timeSeriesLogger.trace(diagnosticContext
-                    .makeTimeSeriesPoint("out_padding")
+                    .makeTimeSeriesPoint("sent_padding")
                     .addField("padding_bps", paddingBps)
                     .addField("total_ideal_bps", totalIdealBps)
                     .addField("total_target_bps", totalTargetBps)

--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -418,6 +418,14 @@ public class BitrateController
      */
     public void update(long bweBps)
     {
+        if (timeSeriesLogger.isTraceEnabled())
+        {
+            VideoMediaStreamImpl destStream
+                = (VideoMediaStreamImpl) dest.getStream();
+            timeSeriesLogger.trace(destStream.getDiagnosticContext()
+                    .makeTimeSeriesPoint("new_bwe")
+                    .addField("bwe_bps", bweBps));
+        }
         update(null, bweBps);
     }
 
@@ -579,7 +587,7 @@ public class BitrateController
                                 trackBitrateAllocation.oversending)
                             .addField("preferred_idx",
                                 trackBitrateAllocation.ratedPreferredIdx)
-                            .addField("endpoint_id",
+                            .addField("remote_endpoint_id",
                                 trackBitrateAllocation.endpointID)
                             .addField("ideal_bps", trackIdealBps));
                     }
@@ -620,10 +628,10 @@ public class BitrateController
             DiagnosticContext diagnosticContext
                 = destStream.getDiagnosticContext();
             timeSeriesLogger.trace(diagnosticContext
-                    .makeTimeSeriesPoint("video_quality", nowMs)
+                    .makeTimeSeriesPoint("did_update", nowMs)
                     .addField("total_target_idx", totalTargetIdx)
                     .addField("total_ideal_idx", totalIdealIdx)
-                    .addField("available_bps", bweBps)
+                    .addField("bwe_bps", bweBps)
                     .addField("total_target_bps", totalTargetBps)
                     .addField("total_ideal_bps", totalIdealBps));
         }


### PR DESCRIPTION
Related PR https://github.com/jitsi/libjitsi/pull/483

This PR addresses an issue caused by https://github.com/jitsi/jitsi-videobridge/pull/870 where the bridge logs fill-up the disk because it prints multiple lines for every packet that it processes.