### PR TITLE
Add a grace period before a conference is expired.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -1048,7 +1048,9 @@ public class Conference
     @Override
     public boolean shouldExpire()
     {
-        return getEndpointCount() == 0;
+        // Allow a conference to have no endpoints in the first 20 seconds.
+        return getEndpointCount() == 0
+                && (System.currentTimeMillis() - creationTime > 20000);
     }
 
     /**


### PR DESCRIPTION
Without the grace period the conference might be expired prematurely. We
observed the following exception:

```
JVB 2019-08-05 12:30:39.031 INFO: [47] org.jitsi.videobridge.VideobridgeExpireThread.log() Running expire()
JVB 2019-08-05 12:30:39.031 INFO: [48] org.jitsi.videobridge.Videobridge.log() create_conf,[id=4821bc9b84c7418d gid=null name=null] logging=false
JVB 2019-08-05 12:30:39.031 INFO: [47] org.jitsi.videobridge.VideobridgeExpireThread.log() Conference 4821bc9b84c7418d should expire, expiring it
JVB 2019-08-05 12:30:39.032 SEVERE: [48] org.jitsi.videobridge.health.Health.log() Health check failed in 1ms:
java.lang.NullPointerException
    at org.jitsi.videobridge.ConferenceSpeechActivity.endpointsChanged(ConferenceSpeechActivity.java:392)
    at org.jitsi.videobridge.Conference.endpointsChanged(Conference.java:646)
    at org.jitsi.videobridge.Conference.getEndpoint(Conference.java:635)
    at org.jitsi.videobridge.Conference.getOrCreateLocalEndpoint(Conference.java:783)
    at org.jitsi.videobridge.health.Health.check(Health.java:116)
    at org.jitsi.videobridge.health.Health.doCheck(Health.java:204)
    at org.jitsi.videobridge.health.Health.doRun(Health.java:341)
```