### PR TITLE
Adjust shim's member visibility.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
@@ -383,7 +383,7 @@ public class ChannelShim
     /**
      * @return This {@link ChannelShim}'s endpoint.
      */
-    public Endpoint getEndpoint()
+    Endpoint getEndpoint()
     {
         return endpoint;
     }
@@ -391,7 +391,7 @@ public class ChannelShim
     /**
      * @return the ID of this channel.
      */
-    public String getId()
+    String getId()
     {
         return id;
     }

--- a/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
@@ -114,7 +114,7 @@ public class ChannelShim
     /**
      * The source groups that were signaled for this channel.
      */
-    Collection<SourceGroupPacketExtension> sourceGroups;
+    private Collection<SourceGroupPacketExtension> sourceGroups;
 
     /**
      * The expire value for this channel.
@@ -383,7 +383,7 @@ public class ChannelShim
     /**
      * @return This {@link ChannelShim}'s endpoint.
      */
-    Endpoint getEndpoint()
+    public Endpoint getEndpoint()
     {
         return endpoint;
     }
@@ -391,7 +391,7 @@ public class ChannelShim
     /**
      * @return the ID of this channel.
      */
-    String getId()
+    public String getId()
     {
         return id;
     }

--- a/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
@@ -198,7 +198,7 @@ public class ContentShim
     /**
      * Returns a copy of this content's list of channels.
      */
-    public List<ChannelShim> getChannelShims()
+    List<ChannelShim> getChannelShims()
     {
         synchronized (channels)
         {

--- a/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
@@ -73,7 +73,7 @@ public class ContentShim
      * initial offer, assuming it's up to the other side not to conflict with us
      * and therefore it won't need to be changed.
      */
-    final long localSsrc = Videobridge.RANDOM.nextLong() & 0xffff_ffffL;
+    private final long localSsrc = Videobridge.RANDOM.nextLong() & 0xffff_ffffL;
 
     /**
      * Initializes a new {@link ContentShim} instance.
@@ -198,7 +198,7 @@ public class ContentShim
     /**
      * Returns a copy of this content's list of channels.
      */
-    List<ChannelShim> getChannelShims()
+    public List<ChannelShim> getChannelShims()
     {
         synchronized (channels)
         {


### PR DESCRIPTION
I'm migrating to `JVB 2.0` and I think default visibility of changed members was introduced non-intentionally.
If default visibility was design decision please let me know.