### PR TITLE
Fixed Colibri description of data channels.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -192,11 +192,21 @@ public class ConferenceShim
 
             for (ChannelShim channelShim : contentShim.getChannelShims())
             {
-                ColibriConferenceIQ.Channel channelIQ
-                    = new ColibriConferenceIQ.Channel();
+                if (channelShim instanceof SctpConnectionShim)
+                {
+                    ColibriConferenceIQ.SctpConnection sctpConnectionIQ
+                        = new ColibriConferenceIQ.SctpConnection();
+                    channelShim.describe(sctpConnectionIQ);
+                    contentIQ.addSctpConnection(sctpConnectionIQ);
+                }
+                else
+                {
+                    ColibriConferenceIQ.Channel channelIQ
+                        = new ColibriConferenceIQ.Channel();
 
-                channelShim.describe(channelIQ);
-                contentIQ.addChannel(channelIQ);
+                    channelShim.describe(channelIQ);
+                    contentIQ.addChannel(channelIQ);
+                }
             }
         }
         // Do we also want endpoint-s anc channel-bundle-id-s?


### PR DESCRIPTION
Fixed probably wrong `Colibri` generation for data channels (at least `JVB 1.0` put data channel into sctp connection in IQ).