### PR TITLE
Fill in SSRCs field in channel IQ.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
@@ -241,6 +241,26 @@ public class ChannelShim
                 bridgeSource.setSSRC(localSsrc);
                 iq.addSource(bridgeSource);
             }
+
+            if (sources != null && !sources.isEmpty())
+            {
+                int[] ssrcs = new int[sources.size()];
+                int i = 0;
+                for (SourcePacketExtension source : sources)
+                {
+                    long ssrc = source.getSSRC();
+                    if (ssrc != -1)
+                    {
+                        ssrcs[i] = (int) source.getSSRC();
+                        i++;
+                    }
+                }
+                if (i < ssrcs.length)
+                {
+                    ssrcs = Arrays.copyOf(ssrcs, i);
+                }
+                iq.setSSRCs(ssrcs);
+            }
         }
     }
 


### PR DESCRIPTION
In `JVB 1.0` `conference.describeDeep` produce channel's description with `SSRC` information. 
Example:
```
<channel endpoint="#1" expire="15" id="e352c15176eab2c0" channel-bundle-id="#1" rtp-level-relay-type="translator">
...
    <source xmlns="urn:xmpp:jingle:apps:rtp:ssma:0" ssrc="2481496264" />
    <ssrc>4228755975</ssrc>
...
</channel>
```
In `JVB 2.0` `<ssrc>` attribute is missing.
I don't know if it's intentional or not. Since it might be accidental missing information here is PR which adds it back.