### PR TITLE
Added endpoint expire event.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -74,7 +74,7 @@ public class Conference
      * (we iterate over it for each RTP packet) and the Octo endpoints are not
      * needed.
      */
-    private List<Endpoint> endpointsCache = Collections.EMPTY_LIST;
+    private List<Endpoint> endpointsCache = Collections.emptyList();
 
     /**
      * The {@link EventAdmin} instance (to be) used by this {@code Conference}

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -939,8 +939,20 @@ public class Conference
      */
     void endpointExpired(AbstractEndpoint endpoint)
     {
-        if (endpoints.remove(endpoint.getID()) != null)
+        final AbstractEndpoint removedEndpoint;
+        synchronized (endpoints)
         {
+            removedEndpoint = endpoints.remove(endpoint.getID());
+        }
+
+        if (removedEndpoint != null)
+        {
+            final EventAdmin eventAdmin = getEventAdmin();
+            if (eventAdmin != null)
+            {
+                eventAdmin.sendEvent(
+                    EventFactory.endpointExpired(removedEndpoint));
+            }
             updateEndpointsCache();
             endpointsChanged();
         }

--- a/src/main/java/org/jitsi/videobridge/EventFactory.java
+++ b/src/main/java/org/jitsi/videobridge/EventFactory.java
@@ -49,6 +49,12 @@ public class EventFactory
         = "org/jitsi/videobridge/Endpoint/CREATED";
 
     /**
+     * The name of the topic of a "endpoint expired" event.
+     */
+    public static final String ENDPOINT_EXPIRED_TOPIC
+        = "org/jitsi/videobridge/Endpoint/EXPIRED";
+
+    /**
      * The name of the topic of a "message transport ready" event triggered on
      * an endpoint instance when it's message transport connection is ready for
      * sending/receiving data.
@@ -109,6 +115,18 @@ public class EventFactory
     public static Event endpointCreated(AbstractEndpoint endpoint)
     {
         return new Event(ENDPOINT_CREATED_TOPIC, makeProperties(endpoint));
+    }
+
+    /**
+     * Creates a new "endpoint expired" <tt>Event</tt>, which indicates that
+     * a COLIBRI endpoint was expired.
+     * @param endpoint the just expired endpoint.
+     *
+     * @return the <tt>Event</tt> which was created.
+     */
+    public static Event endpointExpired(AbstractEndpoint endpoint)
+    {
+        return new Event(ENDPOINT_EXPIRED_TOPIC, makeProperties(endpoint));
     }
 
     /**


### PR DESCRIPTION
In `JVB 1.0` there was an `CHANNEL_EXPIRED_TOPIC`. 
I've used it to find out when endpoint is expired, by handler like this:
```
final void onChannelExpired(Object eventSource, String eventTopic, Event event) {
    Channel channel = (Channel) eventSource;
    if (channel.getEndpoint().isExpired()) {
        // endpoint expiration handling here
    }
}
```
The `CHANNEL_EXPIRED_TOPIC` event was removed from `JVB 2.0` as there is no more the notion of `CHANNEL` in `JVB 2.0` (shim layer is not counted).

AFAIK, `Endpont` is now the primary entity in a conference, so it make sense to have dedicated event for endpoint expiration.