### PR TITLE
Fill proper DTLS setup value when transport is described.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/DtlsTransport.java
+++ b/src/main/java/org/jitsi/videobridge/DtlsTransport.java
@@ -248,7 +248,11 @@ public class DtlsTransport extends IceTransport
 
         final DtlsRole role = dtlsStack.getRole();
         final String setupRole;
-        if (role instanceof DtlsServer)
+        if (role == null)
+        {
+            setupRole = "actpass";
+        }
+        else if (role instanceof DtlsServer)
         {
             setupRole = "passive";
         }
@@ -258,7 +262,7 @@ public class DtlsTransport extends IceTransport
         }
         else
         {
-            setupRole = "actpass";
+            throw new IllegalStateException("Can not describe role " + role);
         }
         fingerprintPE.setSetup(setupRole);
     }

--- a/src/main/java/org/jitsi/videobridge/DtlsTransport.java
+++ b/src/main/java/org/jitsi/videobridge/DtlsTransport.java
@@ -250,6 +250,7 @@ public class DtlsTransport extends IceTransport
         final String setupRole;
         if (role == null)
         {
+            // We've not chosen a role yet, so we can be either
             setupRole = "actpass";
         }
         else if (role instanceof DtlsServer)

--- a/src/main/java/org/jitsi/videobridge/DtlsTransport.java
+++ b/src/main/java/org/jitsi/videobridge/DtlsTransport.java
@@ -246,8 +246,21 @@ public class DtlsTransport extends IceTransport
         fingerprintPE.setFingerprint(dtlsStack.getLocalFingerprint());
         fingerprintPE.setHash(dtlsStack.getLocalFingerprintHashFunction());
 
-        // TODO: don't we only support ACTIVE right now?
-        fingerprintPE.setSetup("ACTPASS");
+        final DtlsRole role = dtlsStack.getRole();
+        final String setupRole;
+        if (role instanceof DtlsServer)
+        {
+            setupRole = "passive";
+        }
+        else if (role instanceof DtlsClient)
+        {
+            setupRole = "active";
+        }
+        else
+        {
+            setupRole = "actpass";
+        }
+        fingerprintPE.setSetup(setupRole);
     }
 
     /**


### PR DESCRIPTION
The `setup` field was properly described in `JVB 1.0`, but not in `JVB 2.0`:
https://github.com/jitsi/jitsi-videobridge/blob/838e190c4dcf0ca5b94a4065780a59a82792a744/src/main/java/org/jitsi/videobridge/IceUdpTransportManager.java#L1321-L1327

According to [this document](https://xmpp.org/extensions/xep-0320.html) role spelling must be lower case:
```
<xs:attribute name='setup' use='required'/>
    <xs:simpleType>
        <xs:restriction base='xs:NCName'>
        <xs:enumeration value='active'/>
        <xs:enumeration value='passive'/>
        <xs:enumeration value='actpass'/>
        <xs:enumeration value='holdconn'/>
        <xs:annotation>
            <xs:documentation>
            the 'holdconn' value is not used and included only for completeness.
            </xs:documentation>
        </xs:annotation>
        </xs:restriction>
    </xs:simpleType>
</xs:attribute>
```