### PR TITLE
bring back overall stats

### DIFF
--- a/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
+++ b/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
@@ -28,6 +28,7 @@ import org.jitsi.videobridge.rest.debug.*;
 import org.jitsi.videobridge.rest.about.health.*;
 import org.jitsi.videobridge.rest.mucclient.*;
 import org.jitsi.videobridge.rest.shutdown.*;
+import org.jitsi.videobridge.rest.stats.*;
 import org.jitsi.videobridge.util.*;
 import org.osgi.framework.*;
 
@@ -125,6 +126,11 @@ public class RESTBundleActivator
             MucClientApp mucClientHandler = new MucClientApp(clientConnectionProvider);
             ServletHolder mucClientServletHolder = new ServletHolder(new ServletContainer(mucClientHandler));
             colibriContextHandler.addServlet(mucClientServletHolder, "/muc-client/*");
+
+            StatsManagerProvider statsManagerProvider = new StatsManagerProvider(bundleContext);
+            StatsApp statHandler = new StatsApp(statsManagerProvider);
+            ServletHolder statsServletHolder = new ServletHolder(new ServletContainer(statHandler));
+            colibriContextHandler.addServlet(statsServletHolder, "/stats/*");
 
             if (getCfgBoolean(ENABLE_REST_SHUTDOWN_PNAME, false))
             {

--- a/src/main/java/org/jitsi/videobridge/rest/stats/Stats.java
+++ b/src/main/java/org/jitsi/videobridge/rest/stats/Stats.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.rest.stats;
+
+import org.jitsi.videobridge.rest.*;
+import org.jitsi.videobridge.stats.*;
+import org.jitsi.videobridge.util.*;
+import org.json.simple.*;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
+
+@Path("/")
+public class Stats
+{
+    protected final StatsManagerProvider statsManagerProvider;
+
+    public Stats(StatsManagerProvider statsManagerProvider)
+    {
+        this.statsManagerProvider = statsManagerProvider;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public String getStats()
+    {
+        StatsManager statsManager = statsManagerProvider.get();
+
+        JSONArray jsonStats = new JSONArray();
+
+        for (Statistics stat : statsManager.getStatistics())
+        {
+            jsonStats.add(JSONSerializer.serializeStatistics(stat));
+        }
+
+        return jsonStats.toJSONString();
+    }
+}

--- a/src/main/java/org/jitsi/videobridge/rest/stats/StatsApp.java
+++ b/src/main/java/org/jitsi/videobridge/rest/stats/StatsApp.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.rest.stats;
+
+import org.glassfish.jersey.server.*;
+import org.jitsi.videobridge.util.*;
+
+public class StatsApp extends ResourceConfig
+{
+    public StatsApp(StatsManagerProvider statsManagerProvider)
+    {
+        register(new Stats(statsManagerProvider));
+    }
+}

--- a/src/main/java/org/jitsi/videobridge/util/StatsManagerProvider.java
+++ b/src/main/java/org/jitsi/videobridge/util/StatsManagerProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.util;
+
+import org.jitsi.videobridge.stats.*;
+import org.osgi.framework.*;
+
+public class StatsManagerProvider extends OsgiServiceProvider<StatsManager>
+{
+    public StatsManagerProvider(BundleContext bundleContext)
+    {
+        super(bundleContext, StatsManager.class);
+    }
+}


### PR DESCRIPTION
missed these overall bridge stats (used mainly when pushing to datadog)