### PR TITLE
Ability to set ICE role during DtlsTransport creation.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -309,7 +309,6 @@ public abstract class AbstractEndpoint extends PropertyChangeNotifier
      * @param channelBundle the channel bundle element to describe in.
      */
     public void describe(ColibriConferenceIQ.ChannelBundle channelBundle)
-            throws IOException
     {
     }
 

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -964,19 +964,19 @@ public class Conference
                 "conference = " + endpoint.getConference());
         }
 
-        final AbstractEndpoint overwrittenEndpoint;
+        final AbstractEndpoint replacedEndpoint;
         synchronized (endpoints)
         {
-            overwrittenEndpoint = endpoints.put(endpoint.getID(), endpoint);
+            replacedEndpoint = endpoints.put(endpoint.getID(), endpoint);
             updateEndpointsCache();
         }
 
         endpointsChanged();
 
-        if (overwrittenEndpoint != null)
+        if (replacedEndpoint != null)
         {
             logger.info("Endpoint with id " + endpoint.getID() + ": " +
-                overwrittenEndpoint + " has been overwritten by new " +
+                replacedEndpoint + " has been replaced by new " +
                 "endpoint with same id: " + endpoint);
         }
     }

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -956,6 +956,12 @@ public class Conference
      */
     public void addEndpoint(AbstractEndpoint endpoint)
     {
+        if (endpoint.getConference() != this)
+        {
+            throw new IllegalArgumentException("Endpoint belong to other " +
+                "conference = " + endpoint.getConference());
+        }
+
         final AbstractEndpoint overwrittenEndpoint;
         synchronized (endpoints)
         {

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -639,7 +639,9 @@ public class Conference
      * in this <tt>Conference</tt>.
      * @param id the identifier/ID of the <tt>Endpoint</tt> which will be
      * created
-     * @param iceControlling ICE control role of endpoint
+     * @param iceControlling {@code true} if the ICE agent of this endpoint's
+     * transport will initialized to serve as a controlling ICE agent;
+     * otherwise, {@code false}
      * @return an <tt>Endpoint</tt> participating in this <tt>Conference</tt>
      */
     public Endpoint createLocalEndpoint(String id, boolean iceControlling)

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -639,11 +639,13 @@ public class Conference
      * in this <tt>Conference</tt>.
      * @param id the identifier/ID of the <tt>Endpoint</tt> which will be
      * created
+     * @param iceControlling ICE control role of endpoint
      * @return an <tt>Endpoint</tt> participating in this <tt>Conference</tt>
      */
-    @NotNull
-    public Endpoint createLocalEndpoint(String id) {
-        AbstractEndpoint existingEndpoint = endpoints.get(id);
+    public Endpoint createLocalEndpoint(String id, boolean iceControlling)
+        throws IOException
+    {
+        final AbstractEndpoint existingEndpoint = endpoints.get(id);
         if (existingEndpoint instanceof OctoEndpoint)
         {
             // It is possible that an Endpoint was migrated from another bridge
@@ -660,16 +662,16 @@ public class Conference
                 + id + "already created");
         }
 
-        Endpoint endpoint;
+        final Endpoint endpoint = new Endpoint(id, this, logger);
+        endpoint.initDtlsTransport(iceControlling);
+        // The propertyChangeListener will weakly reference this
+        // Conference and will unregister itself from the endpoint
+        // sooner or later.
+        endpoint.addPropertyChangeListener(propertyChangeListener);
+
         synchronized (endpoints)
         {
-            endpoint = new Endpoint(id, this, logger);
-            // The propertyChangeListener will weakly reference this
-            // Conference and will unregister itself from the endpoint
-            // sooner or later.
-            endpoint.addPropertyChangeListener(propertyChangeListener);
             endpoints.put(id, endpoint);
-
             updateEndpointsCache();
         }
 

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -644,6 +644,7 @@ public class Conference
      * otherwise, {@code false}
      * @return an <tt>Endpoint</tt> participating in this <tt>Conference</tt>
      */
+    @NotNull
     public Endpoint createLocalEndpoint(String id, boolean iceControlling)
         throws IOException
     {
@@ -677,7 +678,7 @@ public class Conference
         if (eventAdmin != null)
         {
             eventAdmin.sendEvent(
-                    EventFactory.endpointCreated(endpoint));
+                EventFactory.endpointCreated(endpoint));
         }
 
 

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -935,6 +935,7 @@ public class Conference
         synchronized (endpoints)
         {
             removedEndpoint = endpoints.remove(endpoint.getID());
+            updateEndpointsCache();
         }
 
         if (removedEndpoint != null)
@@ -945,7 +946,6 @@ public class Conference
                 eventAdmin.sendEvent(
                     EventFactory.endpointExpired(removedEndpoint));
             }
-            updateEndpointsCache();
             endpointsChanged();
         }
     }

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -644,7 +644,7 @@ public class Conference
      * @param id the identifier/ID of the <tt>Endpoint</tt> which will be
      * created
      * @param iceControlling {@code true} if the ICE agent of this endpoint's
-     * transport will initialized to serve as a controlling ICE agent;
+     * transport will be initialized to serve as a controlling ICE agent;
      * otherwise, {@code false}
      * @return an <tt>Endpoint</tt> participating in this <tt>Conference</tt>
      */
@@ -652,7 +652,7 @@ public class Conference
     public Endpoint createLocalEndpoint(String id, boolean iceControlling)
         throws IOException
     {
-        final AbstractEndpoint existingEndpoint = endpoints.get(id);
+        final AbstractEndpoint existingEndpoint = getEndpoint(id);
         if (existingEndpoint instanceof OctoEndpoint)
         {
             // It is possible that an Endpoint was migrated from another bridge
@@ -684,7 +684,6 @@ public class Conference
             eventAdmin.sendEvent(
                 EventFactory.endpointCreated(endpoint));
         }
-
 
         return endpoint;
     }

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -630,6 +630,10 @@ public class Conference
      */
     public AbstractEndpoint getEndpoint(String id)
     {
+        if (id == null)
+        {
+            throw new IllegalArgumentException("id is null");
+        }
         return endpoints.get(id);
     }
 

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -662,8 +662,8 @@ public class Conference
                 + id + "already created");
         }
 
-        final Endpoint endpoint = new Endpoint(id, this, logger);
-        endpoint.initDtlsTransport(iceControlling);
+        final Endpoint endpoint = new Endpoint(
+            id, this, logger, iceControlling);
         // The propertyChangeListener will weakly reference this
         // Conference and will unregister itself from the endpoint
         // sooner or later.

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -628,13 +628,11 @@ public class Conference
      * @return an <tt>Endpoint</tt> participating in this <tt>Conference</tt>
      * which has the specified <tt>id</tt> or <tt>null</tt>
      */
-    public AbstractEndpoint getEndpoint(String id)
+    @Nullable
+    public AbstractEndpoint getEndpoint(@NotNull String id)
     {
-        if (id == null)
-        {
-            throw new IllegalArgumentException("id is null");
-        }
-        return endpoints.get(id);
+        return endpoints.get(
+            Objects.requireNonNull(id, "id must be non null"));
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/DtlsTransport.java
+++ b/src/main/java/org/jitsi/videobridge/DtlsTransport.java
@@ -103,11 +103,13 @@ public class DtlsTransport extends IceTransport
      * Initializes a new {@link DtlsTransport} instance for a specific endpoint.
      * @param endpoint the endpoint with which this {@link DtlsTransport} is
      *                 associated.
+     * @param controlling {@code true} if the new instance will initialized to
+     * serve as a controlling ICE agent; otherwise, {@code false}
      */
-    public DtlsTransport(Endpoint endpoint, Logger parentLogger)
+    public DtlsTransport(Endpoint endpoint, boolean controlling, Logger parentLogger)
             throws IOException
     {
-        super(endpoint, true, parentLogger);
+        super(endpoint, controlling, parentLogger);
         this.endpoint = endpoint;
 
         outgoingPacketQueue

--- a/src/main/java/org/jitsi/videobridge/DtlsTransport.java
+++ b/src/main/java/org/jitsi/videobridge/DtlsTransport.java
@@ -103,8 +103,8 @@ public class DtlsTransport extends IceTransport
      * Initializes a new {@link DtlsTransport} instance for a specific endpoint.
      * @param endpoint the endpoint with which this {@link DtlsTransport} is
      *                 associated.
-     * @param controlling {@code true} if the new instance will initialized to
-     * serve as a controlling ICE agent; otherwise, {@code false}
+     * @param controlling {@code true} if the new instance will be initialized
+     * to serve as a controlling ICE agent; otherwise, {@code false}
      */
     public DtlsTransport(Endpoint endpoint, boolean controlling, Logger parentLogger)
             throws IOException

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1062,13 +1062,18 @@ public class Endpoint
      *
      * @param transportInfo the XML extension which contains the remote
      * transport information.
+     * @param controlling true if ICE agent should start as controlling agent,
+     * false - otherwise.
      * @throws IOException if the endpoint's transport manager failed to
      * initialize.
      */
-    public void setTransportInfo(IceUdpTransportPacketExtension transportInfo)
+    public void setTransportInfo(IceUdpTransportPacketExtension transportInfo,
+                                 boolean controlling)
             throws IOException
     {
-        getTransportManager().startConnectivityEstablishment(transportInfo);
+        final DtlsTransport transportManager = getTransportManager();
+        transportManager.iceAgent.setControlling(controlling);
+        transportManager.startConnectivityEstablishment(transportInfo);
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1002,7 +1002,7 @@ public class Endpoint
                 {
                     try
                     {
-                        transportManager = new DtlsTransport(this, logger);
+                        transportManager = new DtlsTransport(this, true, logger);
                         transportManagerCreated = true;
                     }
                     catch (IOException ioe)

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1070,7 +1070,7 @@ public class Endpoint
                 {
                     try
                     {
-                        dtlsTransport = new DtlsTransport(this, true, logger);
+                        dtlsTransport = new DtlsTransport(this, controlling, logger);
                         transportManagerCreated = true;
                     }
                     catch (IOException ioe)
@@ -1087,7 +1087,6 @@ public class Endpoint
         }
 
         final DtlsTransport transportManager = getDtlsTransport();
-        transportManager.iceAgent.setControlling(controlling);
         transportManager.startConnectivityEstablishment(transportInfo);
     }
 

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1050,18 +1050,15 @@ public class Endpoint
     }
 
     /**
-     * Sets the remote transport information (ICE candidates, DTLS fingerprints).
+     * Initialize DTLS transport of this endpoint.
      *
-     * @param transportInfo the XML extension which contains the remote
-     * transport information.
      * @param controlling true if ICE agent should start as controlling agent,
      * false - otherwise.
      * @throws IOException if the endpoint's transport manager failed to
      * initialize.
      */
-    public void initDtlsTransport(IceUdpTransportPacketExtension transportInfo,
-                                  boolean controlling)
-            throws IOException
+    public void initDtlsTransport(boolean controlling)
+        throws IOException
     {
         final DtlsTransport dtlsTransport;
         if (this.dtlsTransportFuture.isDone())
@@ -1086,8 +1083,20 @@ public class Endpoint
             throw new IllegalStateException(
                 "DtlsTransport is concurrently initialized");
         }
+    }
 
-        dtlsTransport.startConnectivityEstablishment(transportInfo);
+    /**
+     * Sets the remote transport information (ICE candidates, DTLS fingerprints).
+     *
+     * @param transportInfo the XML extension which contains the remote
+     * transport information.
+     * @throws IOException if the endpoint's transport manager failed to
+     * initialize.
+     */
+    public void setTransportInfo(IceUdpTransportPacketExtension transportInfo)
+        throws IOException
+    {
+        getDtlsTransport().startConnectivityEstablishment(transportInfo);
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -197,7 +197,7 @@ public class Endpoint
      * @param conference conference this endpoint belongs to
      * @param iceControlling {@code true} if the ICE agent of this endpoint's
      * transport will initialized to serve as a controlling ICE agent;
-     * otherwise, {@code false}
+     * otherwise - {@code false}
      */
     public Endpoint(
             String id,

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -195,7 +195,9 @@ public class Endpoint
      * @param id the identifier/ID of the endpoint of a participant in a
      * <tt>Conference</tt> with which the new instance is to be initialized
      * @param conference conference this endpoint belongs to
-     * @param iceControlling ICE control role of endpoint
+     * @param iceControlling {@code true} if the ICE agent of this endpoint's
+     * transport will initialized to serve as a controlling ICE agent;
+     * otherwise, {@code false}
      */
     public Endpoint(
             String id,

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -196,7 +196,7 @@ public class Endpoint
      * <tt>Conference</tt> with which the new instance is to be initialized
      * @param conference conference this endpoint belongs to
      * @param iceControlling {@code true} if the ICE agent of this endpoint's
-     * transport will initialized to serve as a controlling ICE agent;
+     * transport will be initialized to serve as a controlling ICE agent;
      * otherwise - {@code false}
      */
     public Endpoint(
@@ -947,12 +947,11 @@ public class Endpoint
     }
 
     /**
-     * Gets this {@link Endpoint}'s DTLS transport, initializing it if it
-     * wasn't already initialized. If there was a previous unsuccessful attempt
-     * to initialize it, re-throws the same exception.
+     * Gets this {@link Endpoint}'s DTLS transport.
      *
      * @return this {@link Endpoint}'s DTLS transport.
      */
+    @NotNull
     public DtlsTransport getDtlsTransport()
     {
         return dtlsTransport;

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1052,8 +1052,8 @@ public class Endpoint
      * @throws IOException if the endpoint's transport manager failed to
      * initialize.
      */
-    public void setTransportInfo(IceUdpTransportPacketExtension transportInfo,
-                                 boolean controlling)
+    public void initDtlsTransport(IceUdpTransportPacketExtension transportInfo,
+                                  boolean controlling)
             throws IOException
     {
         boolean transportManagerCreated = false;

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -807,7 +807,7 @@ public class Endpoint
         };
         socket.listen();
         // We don't want to block the calling thread on the
-        // onDtlsTransportSet future completing to add the
+        // dtlsTransportFuture future completing to add the
         // onDtlsHandshakeComplete handler, so we'll asynchronously run the
         // code which adds the onDtlsHandshakeComplete handler from the IO pool.
         dtlsTransportFuture.thenAcceptAsync(dtlsTransport -> {

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -408,7 +408,7 @@ public class Endpoint
     {
         try
         {
-            return getTransportManager().isConnected();
+            return getDtlsTransport().isConnected();
         }
         catch (IOException ioe)
         {
@@ -985,7 +985,7 @@ public class Endpoint
      *
      * @throws IOException if the transport manager fails to initialize.
      */
-    public DtlsTransport getTransportManager()
+    public DtlsTransport getDtlsTransport()
         throws IOException
     {
         boolean transportManagerCreated = false;
@@ -1071,7 +1071,7 @@ public class Endpoint
                                  boolean controlling)
             throws IOException
     {
-        final DtlsTransport transportManager = getTransportManager();
+        final DtlsTransport transportManager = getDtlsTransport();
         transportManager.iceAgent.setControlling(controlling);
         transportManager.startConnectivityEstablishment(transportInfo);
     }
@@ -1215,7 +1215,7 @@ public class Endpoint
     public void describe(ColibriConferenceIQ.ChannelBundle channelBundle)
             throws IOException
     {
-        getTransportManager().describe(channelBundle);
+        getDtlsTransport().describe(channelBundle);
     }
 
 

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -144,7 +144,7 @@ public class Endpoint
     private final BandwidthProbing bandwidthProbing;
 
     /**
-     * This {@link Endpoint}'s transport manager.
+     * This {@link Endpoint}'s DTLS transport.
      */
     @NotNull
     private final DtlsTransport dtlsTransport;
@@ -389,7 +389,7 @@ public class Endpoint
     }
 
     /**
-     * Checks if this endpoint's transport manager is connected.
+     * Checks if this endpoint's DTLS transport is connected.
      * @return
      */
     private boolean isTransportConnected()
@@ -947,11 +947,11 @@ public class Endpoint
     }
 
     /**
-     * Gets this {@link Endpoint}'s transport manager, initializing it if it
+     * Gets this {@link Endpoint}'s DTLS transport, initializing it if it
      * wasn't already initialized. If there was a previous unsuccessful attempt
      * to initialize it, re-throws the same exception.
      *
-     * @return this {@link Endpoint}'s transport manager.
+     * @return this {@link Endpoint}'s DTLS transport.
      */
     public DtlsTransport getDtlsTransport()
     {

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -406,15 +406,7 @@ public class Endpoint
      */
     private boolean isTransportConnected()
     {
-        try
-        {
-            return getDtlsTransport().isConnected();
-        }
-        catch (IOException ioe)
-        {
-            logger.warn("Could not get transport manager: ", ioe);
-            return false;
-        }
+        return dtlsTransport != null && dtlsTransport.isConnected();
     }
 
     public double getRtt()

--- a/src/main/java/org/jitsi/videobridge/health/Health.java
+++ b/src/main/java/org/jitsi/videobridge/health/Health.java
@@ -22,7 +22,6 @@ import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.*;
 import org.jitsi.videobridge.transport.*;
 import org.jitsi.videobridge.xmpp.*;
-import org.jitsi.xmpp.extensions.jingle.*;
 
 import java.io.*;
 import java.util.*;
@@ -113,17 +112,15 @@ public class Health
 
         for (int i = 0; i < numEndpoints; ++i)
         {
-            final Endpoint endpoint
-                = conference.createLocalEndpoint(generateEndpointID());
-
-            // Trigger the creation of the transport manager.
+            final Endpoint endpoint;
             try
             {
-                endpoint.initDtlsTransport(false);
+                endpoint = conference.createLocalEndpoint(
+                    generateEndpointID(), true);
             }
-            catch (IOException ioe)
+            catch (IOException e)
             {
-                throw new RuntimeException(ioe);
+                throw new RuntimeException(e);
             }
 
             endpoints.add(endpoint);

--- a/src/main/java/org/jitsi/videobridge/health/Health.java
+++ b/src/main/java/org/jitsi/videobridge/health/Health.java
@@ -124,7 +124,7 @@ public class Health
             // Trigger the creation of the transport manager.
             try
             {
-                endpoint.getTransportManager();
+                endpoint.getDtlsTransport();
             }
             catch (IOException ioe)
             {

--- a/src/main/java/org/jitsi/videobridge/health/Health.java
+++ b/src/main/java/org/jitsi/videobridge/health/Health.java
@@ -22,6 +22,7 @@ import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.*;
 import org.jitsi.videobridge.transport.*;
 import org.jitsi.videobridge.xmpp.*;
+import org.jitsi.xmpp.extensions.jingle.*;
 
 import java.io.*;
 import java.util.*;
@@ -124,7 +125,9 @@ public class Health
             // Trigger the creation of the transport manager.
             try
             {
-                endpoint.getDtlsTransport();
+                endpoint.initDtlsTransport(
+                    new IceUdpTransportPacketExtension(),
+                    false);
             }
             catch (IOException ioe)
             {

--- a/src/main/java/org/jitsi/videobridge/health/Health.java
+++ b/src/main/java/org/jitsi/videobridge/health/Health.java
@@ -125,9 +125,7 @@ public class Health
             // Trigger the creation of the transport manager.
             try
             {
-                endpoint.initDtlsTransport(
-                    new IceUdpTransportPacketExtension(),
-                    false);
+                endpoint.initDtlsTransport(false);
             }
             catch (IOException ioe)
             {

--- a/src/main/java/org/jitsi/videobridge/health/Health.java
+++ b/src/main/java/org/jitsi/videobridge/health/Health.java
@@ -113,14 +113,8 @@ public class Health
 
         for (int i = 0; i < numEndpoints; ++i)
         {
-            Endpoint endpoint
-                = conference.getOrCreateLocalEndpoint(generateEndpointID());
-
-            // Fail as quickly as possible.
-            if (endpoint == null)
-            {
-                throw new NullPointerException("Failed to create an endpoint.");
-            }
+            final Endpoint endpoint
+                = conference.createLocalEndpoint(generateEndpointID());
 
             // Trigger the creation of the transport manager.
             try

--- a/src/main/java/org/jitsi/videobridge/health/Health.java
+++ b/src/main/java/org/jitsi/videobridge/health/Health.java
@@ -118,9 +118,9 @@ public class Health
                 endpoint = conference.createLocalEndpoint(
                     generateEndpointID(), true);
             }
-            catch (IOException e)
+            catch (IOException ioe)
             {
-                throw new RuntimeException(e);
+                throw new RuntimeException(ioe);
             }
 
             endpoints.add(endpoint);

--- a/src/main/java/org/jitsi/videobridge/health/Health.java
+++ b/src/main/java/org/jitsi/videobridge/health/Health.java
@@ -115,8 +115,9 @@ public class Health
             final Endpoint endpoint;
             try
             {
+                final boolean iceControlling = i % 2 == 0;
                 endpoint = conference.createLocalEndpoint(
-                    generateEndpointID(), true);
+                    generateEndpointID(), iceControlling);
             }
             catch (IOException ioe)
             {

--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -269,11 +269,11 @@ public class ConferenceShim
     }
 
     /**
-     * Process whole {@link ColibriConferenceIQ} and allocate and initialize
-     * found new endpoints.
+     * Process whole {@link ColibriConferenceIQ} and initialize all signaled
+     * endpoints which were not initialized before.
      * @param conferenceIQ conference IQ having endpoints
      */
-    void initializeNewEndpoints(ColibriConferenceIQ conferenceIQ)
+    void initializeSignaledEndpoints(ColibriConferenceIQ conferenceIQ)
         throws VideobridgeShim.IqProcessingException
     {
         for (ColibriConferenceIQ.Content content : conferenceIQ.getContents())
@@ -316,7 +316,6 @@ public class ConferenceShim
     private void ensureEndpointCreated(String endpointId, boolean iceControlling)
         throws VideobridgeShim.IqProcessingException
     {
-
         if (conference.getLocalEndpoint(endpointId) != null)
         {
             return;

--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -270,7 +270,7 @@ public class ConferenceShim
 
     /**
      * Process whole {@link ColibriConferenceIQ} and initialize all signaled
-     * endpoints which were not initialized before.
+     * endpoints which has not been initialized before.
      * @param conferenceIQ conference IQ having endpoints
      */
     void initializeSignaledEndpoints(ColibriConferenceIQ conferenceIQ)
@@ -316,10 +316,11 @@ public class ConferenceShim
     }
 
     /**
-     * Checks if endpoint with specified ID is initialized, if endpoint is not
-     * exist in a conference it is created and it's transport is initialized.
+     * Checks if endpoint with specified ID is initialized, if endpoint does not
+     * exist in a conference, it will be created and initialized.
      * @param endpointId identifier of endpoint to check and initialize
-     * @param iceControlling ICE control role for newly created endpoint
+     * @param iceControlling ICE control role of transport of newly created
+     * endpoint
      * @throws VideobridgeShim.IqProcessingException
      */
     private void ensureEndpointCreated(String endpointId, boolean iceControlling)

--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -107,12 +107,10 @@ public class ConferenceShim
      * Describes the channel bundles of this conference in a Colibri IQ.
      * @param iq the IQ to describe in.
      * @param endpointIds the list of IDs to describe.
-     * @throws VideobridgeShim.IqProcessingException
      */
     void describeChannelBundles(
             ColibriConferenceIQ iq,
             Set<String> endpointIds)
-            throws VideobridgeShim.IqProcessingException
     {
         for (AbstractEndpoint endpoint : conference.getEndpoints())
         {
@@ -121,16 +119,7 @@ public class ConferenceShim
             {
                 ColibriConferenceIQ.ChannelBundle responseBundleIQ
                     = new ColibriConferenceIQ.ChannelBundle(endpointId);
-                try
-                {
-                    endpoint.describe(responseBundleIQ);
-                }
-                catch (IOException ioe)
-                {
-                    throw new VideobridgeShim.IqProcessingException(
-                            XMPPError.Condition.internal_server_error,
-                            ioe.getMessage());
-                }
+                endpoint.describe(responseBundleIQ);
 
                 iq.addChannelBundle(responseBundleIQ);
             }

--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -280,16 +280,25 @@ public class ConferenceShim
         {
             for (ColibriConferenceIQ.Channel channel : content.getChannels())
             {
-                ensureEndpointCreated(
-                    channel.getEndpoint(),
-                    Boolean.TRUE.equals(channel.isInitiator()));
+                final String endpoint = channel.getEndpoint();
+                if (endpoint != null)
+                {
+                    ensureEndpointCreated(
+                        channel.getEndpoint(),
+                        Boolean.TRUE.equals(channel.isInitiator()));
+                }
             }
+
             for (ColibriConferenceIQ.SctpConnection channel
                 : content.getSctpConnections())
             {
-                ensureEndpointCreated(
-                    channel.getEndpoint(),
-                    Boolean.TRUE.equals(channel.isInitiator()));
+                final String endpoint = channel.getEndpoint();
+                if (endpoint != null)
+                {
+                    ensureEndpointCreated(
+                        channel.getEndpoint(),
+                        Boolean.TRUE.equals(channel.isInitiator()));
+                }
             }
         }
 

--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -325,12 +325,12 @@ public class ConferenceShim
         throws VideobridgeShim.IqProcessingException
     {
         final boolean newEndpoint =
-            !(conference.getEndpoint(endpointId) instanceof Endpoint);
+            conference.getLocalEndpoint(endpointId) == null;
 
         if (newEndpoint)
         {
             final Endpoint endpoint
-                = conference.getOrCreateLocalEndpoint(endpointId);
+                = conference.createLocalEndpoint(endpointId);
             initializeEndpointTransport(endpoint, iceControlling);
         }
     }

--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -270,7 +270,7 @@ public class ConferenceShim
 
     /**
      * Process whole {@link ColibriConferenceIQ} and allocate and initialize
-     * endpoints and it's transport
+     * found new endpoints.
      * @param conferenceIQ conference IQ having endpoints
      */
     void initializeNewEndpoints(ColibriConferenceIQ conferenceIQ)

--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -284,7 +284,8 @@ public class ConferenceShim
                     channel.getEndpoint(),
                     Boolean.TRUE.equals(channel.isInitiator()));
             }
-            for (ColibriConferenceIQ.SctpConnection channel : content.getSctpConnections())
+            for (ColibriConferenceIQ.SctpConnection channel
+                : content.getSctpConnections())
             {
                 ensureEndpointCreated(
                     channel.getEndpoint(),
@@ -292,12 +293,14 @@ public class ConferenceShim
             }
         }
 
-        for (ColibriConferenceIQ.ChannelBundle channelBundle : conferenceIQ.getChannelBundles())
+        for (ColibriConferenceIQ.ChannelBundle channelBundle
+            : conferenceIQ.getChannelBundles())
         {
             ensureEndpointCreated(channelBundle.getId(), false);
         }
 
-        for (ColibriConferenceIQ.Endpoint endpoint : conferenceIQ.getEndpoints())
+        for (ColibriConferenceIQ.Endpoint endpoint
+            : conferenceIQ.getEndpoints())
         {
             ensureEndpointCreated(endpoint.getId(), false);
         }
@@ -310,9 +313,7 @@ public class ConferenceShim
      * @param iceControlling ICE control role for newly created endpoint
      * @throws VideobridgeShim.IqProcessingException
      */
-    private void ensureEndpointCreated(
-        String endpointId,
-        boolean iceControlling)
+    private void ensureEndpointCreated(String endpointId, boolean iceControlling)
         throws VideobridgeShim.IqProcessingException
     {
 

--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -280,6 +280,87 @@ public class ConferenceShim
     }
 
     /**
+     * Process whole {@link ColibriConferenceIQ} and allocate and initialize
+     * endpoints and it's transport
+     * @param conferenceIQ conference IQ having endpoints
+     */
+    void initializeNewEndpoints(ColibriConferenceIQ conferenceIQ)
+        throws VideobridgeShim.IqProcessingException
+    {
+        for (ColibriConferenceIQ.Content content : conferenceIQ.getContents())
+        {
+            for (ColibriConferenceIQ.Channel channel : content.getChannels())
+            {
+                ensureEndpointInitialized(
+                    channel.getEndpoint(), Boolean.TRUE.equals(channel.isInitiator()));
+            }
+            for (ColibriConferenceIQ.SctpConnection channel : content.getSctpConnections())
+            {
+                ensureEndpointInitialized(
+                    channel.getEndpoint(), Boolean.TRUE.equals(channel.isInitiator()));
+            }
+        }
+
+        for (ColibriConferenceIQ.ChannelBundle channelBundle : conferenceIQ.getChannelBundles())
+        {
+            ensureEndpointInitialized(channelBundle.getId(), false);
+        }
+
+        for (ColibriConferenceIQ.Endpoint endpoint : conferenceIQ.getEndpoints())
+        {
+            ensureEndpointInitialized(endpoint.getId(), false);
+        }
+    }
+
+    /**
+     * Checks if endpoint with specified ID is initialized, if endpoint is not
+     * exist in a conference it is created and it's transport is initialized.
+     * @param endpointId identifier of endpoint to check and initialize
+     * @param iceControlling ICE controlling role for newly created endpoint
+     * @throws VideobridgeShim.IqProcessingException
+     */
+    private void ensureEndpointInitialized(
+        String endpointId,
+        boolean iceControlling)
+        throws VideobridgeShim.IqProcessingException
+    {
+        final boolean newEndpoint =
+            !(conference.getEndpoint(endpointId) instanceof Endpoint);
+
+        if (newEndpoint)
+        {
+            final Endpoint endpoint
+                = conference.getOrCreateLocalEndpoint(endpointId);
+            initializeEndpointTransport(endpoint, iceControlling);
+        }
+    }
+
+    /**
+     * Initializes DTLS transport of newly created endpoint
+     * @param endpoint new endpoint with DTLS transport not yet initialized
+     * @param controlling true if DTLS transport should have controlling role
+     * of its ICE agent; false - otherwise;
+     * @throws VideobridgeShim.IqProcessingException thrown when DTLS transport
+     * is failed to initialize
+     */
+    private static void initializeEndpointTransport(
+        Endpoint endpoint, boolean controlling)
+        throws VideobridgeShim.IqProcessingException
+    {
+        try
+        {
+            endpoint.initDtlsTransport(controlling);
+        }
+        catch (IOException ioe)
+        {
+            throw new VideobridgeShim.IqProcessingException(
+                XMPPError.Condition.internal_server_error,
+                "Error initializing DTLS transport for endpoint " +
+                    endpoint.getID());
+        }
+    }
+
+    /**
      * Updates an <tt>Endpoint</tt> of this <tt>Conference</tt> with the
      * information contained in <tt>colibriEndpoint</tt>. The ID of
      * <tt>colibriEndpoint</tt> is used to select the <tt>Endpoint</tt> to

--- a/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
@@ -131,7 +131,7 @@ public class ContentShim
 
             ChannelShim channelShim = new ChannelShim(
                 channelId,
-                conference.getOrCreateLocalEndpoint(endpointId),
+                conference.getLocalEndpoint(endpointId),
                 localSsrc,
                 this,
                 logger
@@ -154,8 +154,8 @@ public class ContentShim
         synchronized (channels)
         {
             Endpoint endpoint
-                    = conference.getOrCreateLocalEndpoint(endpointId);
-            if (endpoint instanceof Endpoint)
+                    = conference.getLocalEndpoint(endpointId);
+            if (endpoint != null)
             {
                 String sctpConnId = generateUniqueChannelID();
                 SctpConnectionShim connection

--- a/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
@@ -272,7 +272,6 @@ public class ContentShim
                         XMPPError.Condition.bad_request,
                         "Endpoint ID does not match channel bundle ID");
             }
-
             channelShim = createRtpChannel(endpointId);
             if (channelShim == null)
             {

--- a/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
@@ -273,22 +273,12 @@ public class ContentShim
                         "Endpoint ID does not match channel bundle ID");
             }
 
-            final boolean newEndpoint =
-                !(conference.getEndpoint(endpointId) instanceof Endpoint);
-
             channelShim = createRtpChannel(endpointId);
             if (channelShim == null)
             {
                 throw new VideobridgeShim.IqProcessingException(
                         XMPPError.Condition.internal_server_error,
                         "Error creating channel");
-            }
-
-            if (newEndpoint)
-            {
-                initializeEndpointTransport(
-                    channelShim.getEndpoint(),
-                    Boolean.TRUE.equals(channelIq.isInitiator()));
             }
         }
         else
@@ -365,18 +355,8 @@ public class ContentShim
                         "No endpoint ID specified for the new SCTP connection");
             }
 
-            final boolean newEndpoint =
-                !(conference.getEndpoint(endpointId) instanceof Endpoint);
-
             sctpConnectionShim
                     = createSctpConnection(endpointId);
-
-            if (newEndpoint)
-            {
-                initializeEndpointTransport(
-                    sctpConnectionShim.getEndpoint(),
-                    Boolean.TRUE.equals(sctpConnectionIq.isInitiator()));
-            }
         }
         else
         {
@@ -409,31 +389,6 @@ public class ContentShim
         }
 
         return sctpConnectionShim;
-    }
-
-    /**
-     * Initializes DTLS transport of newly created endpoint
-     * @param endpoint new endpoint with DTLS transport not yet initialized
-     * @param controlling true if DTLS transport should have controlling role
-     * of its ICE agent; false - otherwise;
-     * @throws VideobridgeShim.IqProcessingException thrown when DTLS transport
-     * is failed to initialize
-     */
-    private static void initializeEndpointTransport(
-        Endpoint endpoint, boolean controlling)
-        throws VideobridgeShim.IqProcessingException
-    {
-        try
-        {
-            endpoint.initDtlsTransport(controlling);
-        }
-        catch (IOException ioe)
-        {
-            throw new VideobridgeShim.IqProcessingException(
-                XMPPError.Condition.internal_server_error,
-                "Error initializing DTLS transport for endpoint " +
-                    endpoint.getID());
-        }
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
@@ -311,6 +311,18 @@ public class VideobridgeShim
         responseConferenceIQ.setGracefulShutdown(
                 videobridge.isShutdownInProgress());
 
+        try
+        {
+            conferenceShim.initializeNewEndpoints(conferenceIQ);
+        }
+        catch (IqProcessingException e)
+        {
+            return IQUtils.createError(
+                conferenceIQ,
+                XMPPError.Condition.internal_server_error,
+                "Failed to init endpoints in conference: " + conferenceId);
+        }
+
         ColibriConferenceIQ.Channel octoAudioChannel = null;
         ColibriConferenceIQ.Channel octoVideoChannel = null;
 

--- a/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
@@ -313,6 +313,7 @@ public class VideobridgeShim
 
         ColibriConferenceIQ.Channel octoAudioChannel = null;
         ColibriConferenceIQ.Channel octoVideoChannel = null;
+        boolean isControlling = false;
 
         for (ColibriConferenceIQ.Content contentIQ : conferenceIQ.getContents())
         {
@@ -335,6 +336,14 @@ public class VideobridgeShim
                     = new ColibriConferenceIQ.Content(contentType.toString());
 
             responseConferenceIQ.addContent(responseContentIQ);
+
+            for (ColibriConferenceIQ.Channel channel : contentIQ.getChannels()) {
+                Boolean isInitiator = channel.isInitiator();
+                if (isInitiator != null)
+                {
+                    isControlling |= isInitiator;
+                }
+            }
 
             try
             {
@@ -411,7 +420,7 @@ public class VideobridgeShim
                     = conference.getOrCreateLocalEndpoint(channelBundleIq.getId());
             try
             {
-                endpoint.setTransportInfo(transportIq);
+                endpoint.setTransportInfo(transportIq, isControlling);
             }
             catch (IOException ioe)
             {

--- a/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
@@ -24,7 +24,6 @@ import org.jitsi.xmpp.util.*;
 import org.jivesoftware.smack.packet.*;
 import org.jxmpp.jid.*;
 
-import java.io.*;
 import java.util.*;
 
 /**
@@ -313,7 +312,7 @@ public class VideobridgeShim
 
         try
         {
-            conferenceShim.initializeNewEndpoints(conferenceIQ);
+            conferenceShim.initializeSignaledEndpoints(conferenceIQ);
         }
         catch (IqProcessingException e)
         {

--- a/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
@@ -420,17 +420,11 @@ public class VideobridgeShim
             }
 
             final String endpointId = channelBundleIq.getId();
-            final boolean newEndpoint =
-                !(conference.getEndpoint(endpointId) instanceof Endpoint);
 
             final Endpoint endpoint
-                = conference.getOrCreateLocalEndpoint(endpointId);
+                = conference.getLocalEndpoint(endpointId);
             try
             {
-                if (newEndpoint)
-                {
-                    endpoint.initDtlsTransport(false);
-                }
                 endpoint.setTransportInfo(transportIq);
             }
             catch (IOException ioe)

--- a/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
@@ -313,7 +313,6 @@ public class VideobridgeShim
 
         ColibriConferenceIQ.Channel octoAudioChannel = null;
         ColibriConferenceIQ.Channel octoVideoChannel = null;
-        boolean isControlling = false;
 
         for (ColibriConferenceIQ.Content contentIQ : conferenceIQ.getContents())
         {
@@ -336,14 +335,6 @@ public class VideobridgeShim
                     = new ColibriConferenceIQ.Content(contentType.toString());
 
             responseConferenceIQ.addContent(responseContentIQ);
-
-            for (ColibriConferenceIQ.Channel channel : contentIQ.getChannels()) {
-                Boolean isInitiator = channel.isInitiator();
-                if (isInitiator != null)
-                {
-                    isControlling |= isInitiator;
-                }
-            }
 
             try
             {
@@ -416,11 +407,19 @@ public class VideobridgeShim
                 continue;
             }
 
-            Endpoint endpoint
-                    = conference.getOrCreateLocalEndpoint(channelBundleIq.getId());
+            final String endpointId = channelBundleIq.getId();
+            final boolean newEndpoint =
+                !(conference.getEndpoint(endpointId) instanceof Endpoint);
+
+            final Endpoint endpoint
+                = conference.getOrCreateLocalEndpoint(endpointId);
             try
             {
-                endpoint.initDtlsTransport(transportIq, isControlling);
+                if (newEndpoint)
+                {
+                    endpoint.initDtlsTransport(false);
+                }
+                endpoint.setTransportInfo(transportIq);
             }
             catch (IOException ioe)
             {

--- a/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
@@ -421,8 +421,13 @@ public class VideobridgeShim
 
             final String endpointId = channelBundleIq.getId();
 
-            final Endpoint endpoint
-                = conference.getLocalEndpoint(endpointId);
+            final Endpoint endpoint = conference.getLocalEndpoint(endpointId);
+            if (endpoint == null)
+            {
+                // Endpoint is expired and removed as part of handling IQ
+                continue;
+            }
+
             try
             {
                 endpoint.setTransportInfo(transportIq);

--- a/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
@@ -428,33 +428,12 @@ public class VideobridgeShim
                 continue;
             }
 
-            try
-            {
-                endpoint.setTransportInfo(transportIq);
-            }
-            catch (IOException ioe)
-            {
-                logger.error(
-                    "Error processing channel-bundle: " + ioe.toString());
-                return IQUtils.createError(
-                        conferenceIQ,
-                        XMPPError.Condition.internal_server_error,
-                        "Failed to set transport: " + ioe.getMessage());
-            }
+            endpoint.setTransportInfo(transportIq);
         }
 
-        Set<String> channelBundleIdsToDescribe
-                = getAllSignaledChannelBundleIds(conferenceIQ);
-        try
-        {
-            conferenceShim.describeChannelBundles(
-                    responseConferenceIQ,
-                    channelBundleIdsToDescribe);
-        }
-        catch (IqProcessingException e)
-        {
-            return IQUtils.createError(conferenceIQ, e.condition, e.errorMessage);
-        }
+        conferenceShim.describeChannelBundles(
+            responseConferenceIQ,
+            getAllSignaledChannelBundleIds(conferenceIQ));
 
         // Update the endpoint information of Videobridge with the endpoint
         // information of the IQ.

--- a/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
@@ -420,7 +420,7 @@ public class VideobridgeShim
                     = conference.getOrCreateLocalEndpoint(channelBundleIq.getId());
             try
             {
-                endpoint.setTransportInfo(transportIq, isControlling);
+                endpoint.initDtlsTransport(transportIq, isControlling);
             }
             catch (IOException ioe)
             {


### PR DESCRIPTION
This is the first step in restoring ability to control `JVB 2.0` ICE role during connection establishment.
`JVB 1.0` had ability to be either controlling/controlled agent based on `initiator` field in `IQ`.
Currently I'm suffering from [ICE role conflict issue](https://github.com/jitsi/ice4j/pull/187), but even when it is resolved there still be an issue with Firefox (I'm still investigating that Firefox bug).

So I'd like to have an explicit control over `JVB 2.0` ICE role, so I'll not rely on role conflict resolution implementation. This PR is first step to bringing back configurable ICE role of `JVB`.