### PR TITLE
New config

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -58,3 +58,37 @@ Previously, we [read from a set of legacy videobridge properties](https://github
 
 ##### [4] Stats transports
 Previously, stats transports were set via a comma-separated string in the `org.jitsi.videobridge.STATISTICS_TRANSPORT` property.  The `pubsub` stats transport had extra settings which were set by the `org.jitsi.videobridge.PUBSUB_SERVICE` and `org.jitsi.videobridge.PUBSUB_NODE` properties.  The new config defines a `videobridge.stats.transports` property which is a list of stats transport config objects, correlating to the `org.jitsi.videobridge.stats.config.StatsTransportConfig` object.  There is a subclass `org.jitsi.videobridge.stats.config.PubSubStatsTransportConfig` for pubsub which holds the extra data relevant to the pubsub config.  The data in the config value is parsed directly into this config file instances and used in the code to instantiate the stats transports.
+
+## Legacy config
+In some places, JVB may use other Jitsi libraries which rely on the old `ConfigurationService` interface.  Other libraries, which still use the old `ConfigurationService` still rely on these libraries, so we don't want to migrate them to the new config.  For these, JVB defines its own `ConfigurationService` implementation: `LegacyConfigurationServiceShim` which provides the existing interface but reads from the new config.  Known properties that rely on this path are:
+
+##### AbstractJettyBundleActivator
+* `org.jitsi.videobridge.rest.private.jetty.sslContextFactory.keyStorePath`
+* `org.jitsi.videobridge.rest.private.jetty.port`
+* `org.jitsi.videobridge.rest`
+* `org.jitsi.videobridge.rest.jetty.sslContextFactory.keyStorePath`
+* `org.jitsi.videobridge.rest.jetty.port`
+
+##### PublicClearPortRedirectBundleAcivator
+* `org.jitsi.videobridge.rest.jetty.tls.port`
+
+##### BandwidthEstimatoImpl (This will go away when JMT is updated to use new config)
+* `org.jitsi.impl.neomedia.rtp.sendsidebandwidthestimation.BandwidthEstimatorImpl.START_BITRATE_BPS`
+* `org.jitsi_modified.impl.neomedia.rtp.sendsidebandwidthestimation.SendSideBandwidthEstimation.lossExperimentProbability`
+* `org.jitsi_modified.impl.neomedia.rtp.sendsidebandwidthestimation.SendSideBandwidthEstimation.timeoutExperimentProbability`
+*
+
+##### MucClientConfiguration (the usage here can be changed to use `loadFromMap` instead of `loadFromConfigurationService`)
+* All props with perfix `org.jitsi.videobridge.xmpp.user.`
+
+##### OctoRelayService (this will change to use new config)
+* `org.jitsi.videobridge.octo.BIND_ADDRESS`
+* `org.jitsi.videobridge.octo.PUBLIC_ADDRESS`
+* `org.jitsi.videobridge.octo.BIND_PORT`
+
+##### ComponentMain
+* `ConfigurationService#logConfigurationProperties`
+
+##### EndpointConnectionStatus (this will change to use new config)
+* `org.jitsi.videobridge.EndpointConnectionStatus.FIRST_TRANSFER_TIMEOUT`
+* `org.jitsi.videobridge.EndpointConnectionStatus.MAX_INACTIVITY_LIMIT`

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,60 @@
+# New Config
+JVB has transitioned to using a new library for Configuration and there are some changes that result from that.
+
+TODO: information about reference.conf and application.conf
+TODO: script for translation old config to new
+
+
+###  Mappings from old properties to new properties
+* `org.jitsi.videobridge.REGION` -> `videobridge.octo.region`
+* `org.jitsi.videobridge.health.INTERVAL` -> `videobridge.health.interval`
+* `org.jitsi.videobridge.health.TIMEOUT` -> `videobridge.health.timeout`
+* `org.jitsi.videobridge.health.STICKY_FAILURES` -> `videobridge.health.sticky-failures`
+* `org.jitsi.videobridge.EXPIRE_CHECK_SLEEP_SEC` -> `videobridge.expire-thread-interval`
+* `org.jitsi.videobridge.DISABLE_RTX_PROBING` -> removed (it wasn't being used)
+* `org.jitsi.videobridge.PADDING_PERIOD_MS` -> `videobridge.cc.padding-period`
+* `org.jitsi.videobridge.BWE_CHANGE_THRESHOLD_PCT` -> `videobridge.cc.bwe-change-threshold-percent`
+* `org.jitsi.videobridge.THUMBNAIL_MAX_HEIGHT` -> `videobridge.cc.thumbnail-max-height-px`
+* `org.jitsi.videobridge.ONSTAGE_PREFERRED_HEIGHT` -> `videobridge.cc.onstage-preferred-height-px`
+* `org.jitsi.videobridge.ONSTAGE_PREFERRED_FRAME_RATE` -> `videobridge.cc.onstage-preferred-framerate-fps`
+* `org.jitsi.videobridge.ENABLE_ONSTAGE_VIDEO_SUSPEND` -> `videobridge.cc.onstage-video-suspension-enabled`
+* `org.jitsi.videobridge.TRUST_BWE` -> `videobridge.cc.trust-bwe`
+* `org.jitsi.videobridge.ICE_UFRAG_PREFIX` -> `videobridge.transport.ice.ufrag-prefix`
+* `org.jitsi.videobridge.USE_COMPONENT_SOCKET` -> `videobridge.transport.ice.use-component-socket`
+* `org.jitsi.videobridge.KEEP_ALIVE_STRATEGY` -> `videobridge.transport.ice.keep-alive-strategy`
+* `org.jitsi.videobridge.DISABLE_TCP_HARVESTER` -> `videobridge.transport.ice.disable-tcp-harvester`
+* `org.jitsi.videobridge.SINGLE_PORT_HARVESTER_PORT` -> `videobridge.transport.ice.single-port-harvester-port`
+* `org.jitsi.videobridge.TCP_HARVESTER_MAPPED_PORT` -> `videobridge.transport.ice.tcp-harvester-mapped-port`
+* `org.jitsi.videobridge.TCP_HARVESTER_PORT` -> See [1] below
+* `org.jitsi.videobridge.TCP_HARVESTER_SSLTCP` ->  `videobridge.transport.ice.use-ssltcp`
+* `org.jitsi.videobridge.defaultOptions` -> `videobridge.xmpp.processing-options`
+* `org.jitsi.videobridge.shutdown.ALLOWED_SOURCE_REGEXP` -> `videobridge.xmpp.shutdown-allowed-source-regex`
+* `org.jitsi.videobridge.AUTHORIZED_SOURCE_REGEXP` -> `videobridge.xmpp.authorized-source-regex`
+* `org.jitsi.videobridge.xmpp` -> `videobridge.enabled-apis`  See [2] below
+* Legacy ICE4J properties -> see [3] below
+* `org.jitsi.videobridge.ENABLE_STATISTICS` -> `videobridge.stats.enabled`
+* `org.jitsi.videobridge.STATISTICS_INTERVAL` -> `videobridge.stats.interval`
+* `org.jitsi.videobridge.STATISTICS_TRANSPORT`, `org.jitsi.videobridge.PUBSUB_NODE` and `org.jitsi.videobridge.PUBSUB_SERVICE` -> See [4] below
+* `org.jitsi.videobridge.rest.COLIBRI_WS_DOMAIN` -> `videobridge.websockets.domain`
+* `org.jitsi.videobridge.rest.COLIBRI_WS_SERVER_ID` -> `videobridge.websockets.server-id`
+* `org.jitsi.videobridge.rest.COLIBRI_WS_DISABLE` -> `videobridge.websockets.enabled` **NOTE** it has been inverted from `disable` to `enable`
+* `org.jitsi.videobridge.rest.COLIBRI_WS_TLS` -> `videobridge.websockets.tls`
+
+
+##### [1] Setting TCP harvester ports
+The old behavior around TCP harvester ports was the following:
+
+>If TCP harvesting was enabled, we'd check for the presence of a `org.jitsi.videobridge.TCP_HARVESTER_PORT` setting.  If it was set, we'd try to use that port for TCP and fail if it failed. If no `org.jitsi.videobridge.TCP_HARVESTER_PORT` was set, we'd use the `TCP_DEFAULT_PORT` (set to 443, not configurable) and fallback to `TCP_FALLBACK_PORT`  (set to 4443, not configurable) if it failed.
+
+The new code operates this way:
+
+>If TCP harvesting is enabled, we read the `videobridge.transport.ice.tcp-harvester-ports` property, which is a list of prots that will be tried for TCP harvesting (in the order they are given). By default the list contains `443` and `4443`, but it can be overridden with any values (and any amount of values) a user wants.
+
+##### [2] Enabling APIs
+Previously, APIs were enabled via setting individual fields: `org.jitsi.videobridge.xmpp`, for example.  Now we have a single `enabled-apis` field where the enabled APIs are listed.
+
+##### [3] Legacy ICE4J properties
+Previously, we [read from a set of legacy videobridge properties](https://github.com/jitsi/jitsi-videobridge/blob/6afe06c99f2e4046bff409e6bb80631330b26a32/src/main/java/org/jitsi/videobridge/Videobridge.java#L979-L1018) (which had since been moved to ICE4J itself).  This functionality has been removed (because the change happened long ago and it should no longer be needed) but therer is support for reading from an `ice4j` section of the config and inserting every property there into the system properties.
+
+##### [4] Stats transports
+Previously, stats transports were set via a comma-separated string in the `org.jitsi.videobridge.STATISTICS_TRANSPORT` property.  The `pubsub` stats transport had extra settings which were set by the `org.jitsi.videobridge.PUBSUB_SERVICE` and `org.jitsi.videobridge.PUBSUB_NODE` properties.  The new config defines a `videobridge.stats.transports` property which is a list of stats transport config objects, correlating to the `org.jitsi.videobridge.stats.config.StatsTransportConfig` object.  There is a subclass `org.jitsi.videobridge.stats.config.PubSubStatsTransportConfig` for pubsub which holds the extra data relevant to the pubsub config.  The data in the config value is parsed directly into this config file instances and used in the code to instantiate the stats transports.

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -42,6 +42,8 @@ TODO: script for translation old config to new
 * `org.jitsi.videobridge.octo.BIND_ADDRESS` -> `videobridge.octo.bind-address`
 * `org.jitsi.videobridge.octo.PUBLIC_ADDRESS` -> `videobridge.octo.public-address`
 * `org.jitsi.videobridge.octo.BIND_PORT` -> `videobridge.octo.port`
+* `org.jitsi.videobridge.EndpointConnectionStatus.FIRST_TRANSFER_TIMEOUT` -> `videobridge.endpoint-connection-status.first-transfer-timeout`
+
 
 
 ##### [1] Setting TCP harvester ports
@@ -86,7 +88,3 @@ In some places, JVB may use other Jitsi libraries which rely on the old `Configu
 
 ##### ComponentMain
 * `ConfigurationService#logConfigurationProperties`
-
-##### EndpointConnectionStatus (this will change to use new config)
-* `org.jitsi.videobridge.EndpointConnectionStatus.FIRST_TRANSFER_TIMEOUT`
-* `org.jitsi.videobridge.EndpointConnectionStatus.MAX_INACTIVITY_LIMIT`

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -39,6 +39,9 @@ TODO: script for translation old config to new
 * `org.jitsi.videobridge.rest.COLIBRI_WS_SERVER_ID` -> `videobridge.websockets.server-id`
 * `org.jitsi.videobridge.rest.COLIBRI_WS_DISABLE` -> `videobridge.websockets.enabled` **NOTE** it has been inverted from `disable` to `enable`
 * `org.jitsi.videobridge.rest.COLIBRI_WS_TLS` -> `videobridge.websockets.tls`
+* `org.jitsi.videobridge.octo.BIND_ADDRESS` -> `videobridge.octo.bind-address`
+* `org.jitsi.videobridge.octo.PUBLIC_ADDRESS` -> `videobridge.octo.public-address`
+* `org.jitsi.videobridge.octo.BIND_PORT` -> `videobridge.octo.port`
 
 
 ##### [1] Setting TCP harvester ports
@@ -80,11 +83,6 @@ In some places, JVB may use other Jitsi libraries which rely on the old `Configu
 
 ##### MucClientConfiguration (the usage here can be changed to use `loadFromMap` instead of `loadFromConfigurationService`)
 * All props with perfix `org.jitsi.videobridge.xmpp.user.`
-
-##### OctoRelayService (this will change to use new config)
-* `org.jitsi.videobridge.octo.BIND_ADDRESS`
-* `org.jitsi.videobridge.octo.PUBLIC_ADDRESS`
-* `org.jitsi.videobridge.octo.BIND_PORT`
 
 ##### ComponentMain
 * `ConfigurationService#logConfigurationProperties`

--- a/pom.xml
+++ b/pom.xml
@@ -414,6 +414,13 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty.version}</version>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.0</version>
+        <configuration>
+            <reuseForks>false</reuseForks>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
       <artifactId>annotations</artifactId>
       <version>15.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+      <version>1.3.4</version>
+    </dependency>
     <!-- org.jitsi -->
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/EndpointConnectionStatus.java
+++ b/src/main/java/org/jitsi/videobridge/EndpointConnectionStatus.java
@@ -15,14 +15,16 @@
  */
 package org.jitsi.videobridge;
 
+import com.typesafe.config.*;
 import org.jitsi.eventadmin.*;
 import org.jitsi.osgi.*;
-import org.jitsi.service.configuration.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.shim.*;
+import org.jitsi.videobridge.util.*;
 import org.osgi.framework.*;
 
 import java.util.*;
+import java.util.concurrent.*;
 
 import static org.jitsi.videobridge.EndpointMessageBuilder.*;
 
@@ -48,36 +50,6 @@ import static org.jitsi.videobridge.EndpointMessageBuilder.*;
 public class EndpointConnectionStatus
     extends EventHandlerActivator
 {
-    /**
-     * The base for config property names constants.
-     */
-    private final static String CFG_PNAME_BASE
-        = "org.jitsi.videobridge.EndpointConnectionStatus";
-
-    /**
-     * The name of the configuration property which configures
-     * {@link #firstTransferTimeout}.
-     */
-    public final static String CFG_PNAME_FIRST_TRANSFER_TIMEOUT
-        = CFG_PNAME_BASE + ".FIRST_TRANSFER_TIMEOUT";
-
-    /**
-     * The name of the configuration property which configures
-     * {@link #maxInactivityLimit}.
-     */
-    public static final String CFG_PNAME_MAX_INACTIVITY_LIMIT
-        = CFG_PNAME_BASE + ".MAX_INACTIVITY_LIMIT";
-
-    /**
-     * The default value for {@link #firstTransferTimeout}.
-     */
-    private final static long DEFAULT_FIRST_TRANSFER_TIMEOUT = 15000L;
-
-    /**
-     * The default value for {@link #maxInactivityLimit}.
-     */
-    private final static long DEFAULT_MAX_INACTIVITY_LIMIT = 3000L;
-
     /**
      * The logger instance used by this class.
      */
@@ -151,16 +123,13 @@ public class EndpointConnectionStatus
             logger.error("Endpoint connection monitoring is already running");
         }
 
-        ConfigurationService config = ServiceUtils2.getService(
-                bundleContext, ConfigurationService.class);
+        Config endpointConnectionStatusConfig =
+                JvbConfig.getConfig().getConfig("videobridge.endpoint-connection-status");
+        firstTransferTimeout =
+                endpointConnectionStatusConfig.getDuration("first-transfer-timeout", TimeUnit.MILLISECONDS);
 
-        firstTransferTimeout = config.getLong(
-                CFG_PNAME_FIRST_TRANSFER_TIMEOUT,
-                DEFAULT_FIRST_TRANSFER_TIMEOUT);
-
-        maxInactivityLimit = config.getLong(
-                CFG_PNAME_MAX_INACTIVITY_LIMIT,
-                DEFAULT_MAX_INACTIVITY_LIMIT);
+        maxInactivityLimit =
+                endpointConnectionStatusConfig.getDuration("max-inactivity-limit", TimeUnit.MILLISECONDS);
 
         if (firstTransferTimeout <= maxInactivityLimit)
         {

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge;
 
+import com.typesafe.config.*;
 import kotlin.*;
 import org.ice4j.ice.harvest.*;
 import org.ice4j.stack.*;
@@ -852,13 +853,14 @@ public class Videobridge
         UlimitCheck.printUlimits();
 
         ConfigurationService cfg = getConfigurationService();
+        Config jvbConfig = JvbConfig.getConfig().getConfig("videobridge");
 
         videobridgeExpireThread.start(bundleContext);
         if (health != null)
         {
             health.stop();
         }
-        health = new Health(this, cfg);
+        health = new Health(this, jvbConfig.getConfig("health"));
 
         defaultProcessingOptions
             = (cfg == null)

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -855,7 +855,7 @@ public class Videobridge
         ConfigurationService cfg = getConfigurationService();
         Config jvbConfig = JvbConfig.getConfig().getConfig("videobridge");
 
-        videobridgeExpireThread.start(bundleContext);
+        videobridgeExpireThread.start();
         if (health != null)
         {
             health.stop();
@@ -1060,7 +1060,7 @@ public class Videobridge
         }
         finally
         {
-            videobridgeExpireThread.stop(bundleContext);
+            videobridgeExpireThread.stop();
             this.bundleContext = null;
         }
     }

--- a/src/main/java/org/jitsi/videobridge/VideobridgeExpireThread.java
+++ b/src/main/java/org/jitsi/videobridge/VideobridgeExpireThread.java
@@ -93,7 +93,7 @@ public class VideobridgeExpireThread
     void start()
     {
         Config jvbConfig = JvbConfig.getConfig().getConfig("videobridge");
-        //TODO: change expireCheckSleepSec (and PeriodicRunnable) to use Duration
+        //TODO: change expireCheckSleepSec to use Duration
         int expireCheckSleepSec = (int)jvbConfig.getDuration("expire-thread-interval", TimeUnit.SECONDS);
 
         logger.info(

--- a/src/main/java/org/jitsi/videobridge/cc/BandwidthProbing.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BandwidthProbing.java
@@ -15,36 +15,21 @@
  */
 package org.jitsi.videobridge.cc;
 
- import org.jitsi.service.configuration.*;
- import org.jitsi.service.libjitsi.*;
- import org.jitsi.utils.concurrent.*;
- import org.jitsi.utils.logging.*;
- import org.jitsi_modified.service.neomedia.rtp.*;
- import org.json.simple.*;
+import org.jitsi.utils.concurrent.*;
+import org.jitsi.utils.logging.*;
+import org.jitsi.videobridge.util.*;
+import org.jitsi_modified.service.neomedia.rtp.*;
+import org.json.simple.*;
 
- import java.util.*;
+import java.util.*;
+import java.util.concurrent.*;
 
- /**
+/**
   * @author George Politis
   */
  public class BandwidthProbing
      extends PeriodicRunnable implements BandwidthEstimator.Listener
  {
-     /**
-      * The system property name that holds a boolean that determines whether or
-      * not to activate the RTX bandwidth probing mechanism that implements
-      * stream protection.
-      */
-     public static final String
-         DISABLE_RTX_PROBING_PNAME = "org.jitsi.videobridge.DISABLE_RTX_PROBING";
-
-     /**
-      * The system property name that holds the interval/period in milliseconds
-      * at which {@link #run()} is to be invoked.
-      */
-     public static final String
-         PADDING_PERIOD_MS_PNAME = "org.jitsi.videobridge.PADDING_PERIOD_MS";
-
      /**
       * The {@link TimeSeriesLogger} to be used by this instance to print time
       * series.
@@ -53,24 +38,11 @@ package org.jitsi.videobridge.cc;
          = TimeSeriesLogger.getTimeSeriesLogger(BandwidthProbing.class);
 
      /**
-      * The ConfigurationService to get config values from.
-      */
-     private static final ConfigurationService
-         cfg = LibJitsi.getConfigurationService();
-
-     /**
       * the interval/period in milliseconds at which {@link #run()} is to be
       * invoked.
       */
      private static final long PADDING_PERIOD_MS =
-         cfg != null ? cfg.getInt(PADDING_PERIOD_MS_PNAME, 15) : 15;
-
-     /**
-      * A boolean that determines whether or not to activate the RTX bandwidth
-      * probing mechanism that implements stream protection.
-      */
-     private static final boolean DISABLE_RTX_PROBING =
-         cfg != null && cfg.getBoolean(DISABLE_RTX_PROBING_PNAME, false);
+         JvbConfig.getConfig().getDuration("videobridge.cc.padding-period", TimeUnit.MILLISECONDS);
 
      /**
       * The sequence number to use if probing with the JVB's SSRC.

--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -20,13 +20,11 @@ import org.jitsi.nlj.*;
 import org.jitsi.nlj.format.*;
 import org.jitsi.nlj.rtp.*;
 import org.jitsi.rtp.rtcp.*;
-import org.jitsi.service.configuration.*;
-import org.jitsi.service.libjitsi.*;
 import org.jitsi.utils.*;
 import org.jitsi.utils.logging.*;
-import org.jitsi.utils.logging2.*;
 import org.jitsi.utils.logging2.Logger;
 import org.jitsi.videobridge.*;
+import org.jitsi.videobridge.util.*;
 import org.jitsi_modified.impl.neomedia.rtp.*;
 import org.json.simple.*;
 
@@ -92,82 +90,10 @@ import java.util.concurrent.*;
 public class BitrateController
 {
     /**
-     * The property name that holds the bandwidth estimation threshold.
-     */
-    public static final String BWE_CHANGE_THRESHOLD_PCT_PNAME
-        = "org.jitsi.videobridge.BWE_CHANGE_THRESHOLD_PCT";
-
-    /**
-     * The property name of the max resolution to allocate for the thumbnails.
-     */
-    public static final String THUMBNAIL_MAX_HEIGHT_PNAME
-        = "org.jitsi.videobridge.THUMBNAIL_MAX_HEIGHT";
-
-    /**
-     * The property name of the preferred resolution to allocate for the onstage
-     * participant, before allocating bandwidth for the thumbnails.
-     */
-    public static final String ONSTAGE_PREFERRED_HEIGHT_PNAME
-        = "org.jitsi.videobridge.ONSTAGE_PREFERRED_HEIGHT";
-
-    /**
-     * The property name of the preferred frame rate to allocate for the onstage
-     * participant.
-     */
-    public static final String ONSTAGE_PREFERRED_FRAME_RATE_PNAME
-        = "org.jitsi.videobridge.ONSTAGE_PREFERRED_FRAME_RATE";
-
-    /**
-     * The property name of the option that enables/disables video suspension
-     * for the on-stage participant.
-     */
-    public static final String ENABLE_ONSTAGE_VIDEO_SUSPEND_PNAME
-        = "org.jitsi.videobridge.ENABLE_ONSTAGE_VIDEO_SUSPEND";
-
-    /**
-     * The name of the property used to trust bandwidth estimations.
-     */
-    public static final String TRUST_BWE_PNAME
-        = "org.jitsi.videobridge.TRUST_BWE";
-
-    /**
      * An reusable empty array of {@link RateSnapshot} to reduce allocations.
      */
     private static final RateSnapshot[] EMPTY_RATE_SNAPSHOT_ARRAY
         = new RateSnapshot[0];
-
-    /**
-     * The default max resolution to allocate for the thumbnails.
-     */
-    private static final int THUMBNAIL_MAX_HEIGHT_DEFAULT = 180;
-
-    /**
-     * The default preferred resolution to allocate for the onstage participant,
-     * before allocating bandwidth for the thumbnails.
-     */
-    private static final int ONSTAGE_PREFERRED_HEIGHT_DEFAULT = 360;
-
-    /**
-     * The default preferred frame rate to allocate for the onstage participant.
-     */
-    private static final double ONSTAGE_PREFERRED_FRAME_RATE_DEFAULT = 30;
-
-    /**
-     * The video for the onstage participant can be disabled by default.
-     */
-    private static final boolean ENABLE_ONSTAGE_VIDEO_SUSPEND_DEFAULT = false;
-
-    /**
-     * The default value of the bandwidth change threshold above which we react
-     * with a new bandwidth allocation.
-     */
-    private static final int BWE_CHANGE_THRESHOLD_PCT_DEFAULT = 15;
-
-    /**
-     * The ConfigurationService to get config values from.
-     */
-    private static final ConfigurationService
-        cfg = LibJitsi.getConfigurationService();
 
     /**
      * In order to limit the resolution changes due to bandwidth changes we
@@ -175,40 +101,33 @@ public class BitrateController
      * last bandwidth estimation.
      */
     private static final int BWE_CHANGE_THRESHOLD_PCT
-        = cfg != null ? cfg.getInt(BWE_CHANGE_THRESHOLD_PCT_PNAME,
-        BWE_CHANGE_THRESHOLD_PCT_DEFAULT) : BWE_CHANGE_THRESHOLD_PCT_DEFAULT;
+        = JvbConfig.getConfig().getInt("videobridge.cc.bwe-change-threshold-percent");
 
     /**
      * The max resolution to allocate for the thumbnails.
      */
     private static final int THUMBNAIL_MAX_HEIGHT
-        = cfg != null ? cfg.getInt(THUMBNAIL_MAX_HEIGHT_PNAME,
-        THUMBNAIL_MAX_HEIGHT_DEFAULT) : THUMBNAIL_MAX_HEIGHT_DEFAULT;
+        = JvbConfig.getConfig().getInt("videobridge.cc.thumbnail-max-height-px");
 
     /**
      * The preferred resolution to allocate for the onstage participant, before
      * allocating bandwidth for the thumbnails.
      */
     private static final int ONSTAGE_PREFERRED_HEIGHT
-        = cfg != null ? cfg.getInt(ONSTAGE_PREFERRED_HEIGHT_PNAME,
-        ONSTAGE_PREFERRED_HEIGHT_DEFAULT) : ONSTAGE_PREFERRED_HEIGHT_DEFAULT;
+        = JvbConfig.getConfig().getInt("videobridge.cc.onstage-preferred-height-px");
 
     /**
      * The preferred frame rate to allocate for the onstage participant.
      */
     private static final double ONSTAGE_PREFERRED_FRAME_RATE
-        = cfg != null ? cfg.getDouble(ONSTAGE_PREFERRED_FRAME_RATE_PNAME,
-        ONSTAGE_PREFERRED_FRAME_RATE_DEFAULT)
-        : ONSTAGE_PREFERRED_FRAME_RATE_DEFAULT;
+        = JvbConfig.getConfig().getInt("videobridge.cc.onstage-preferred-framerate-fps");
 
     /**
      * Determines whether or not we're allowed to suspend the video of the
      * on-stage participant.
      */
     private static final boolean ENABLE_ONSTAGE_VIDEO_SUSPEND
-        = cfg != null ? cfg.getBoolean(ENABLE_ONSTAGE_VIDEO_SUSPEND_PNAME,
-                ENABLE_ONSTAGE_VIDEO_SUSPEND_DEFAULT)
-        : ENABLE_ONSTAGE_VIDEO_SUSPEND_DEFAULT;
+        = JvbConfig.getConfig().getBoolean("videobridge.cc.onstage-video-suspension-enabled");
 
     /**
      * The {@link Logger} to be used by this instance to print debug
@@ -343,9 +262,7 @@ public class BitrateController
         this.diagnosticContext = diagnosticContext;
         this.logger = parentLogger.createChildLogger(BitrateController.class.getName());
 
-        ConfigurationService cfg = LibJitsi.getConfigurationService();
-
-        trustBwe = cfg != null && cfg.getBoolean(TRUST_BWE_PNAME, true);
+        trustBwe = JvbConfig.getConfig().getBoolean("videobridge.cc.trust-bwe");
         enableVideoQualityTracing = timeSeriesLogger.isTraceEnabled();
     }
 

--- a/src/main/java/org/jitsi/videobridge/octo/OctoRelayService.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoRelayService.java
@@ -15,9 +15,9 @@
  */
 package org.jitsi.videobridge.octo;
 
-import org.jitsi.osgi.*;
-import org.jitsi.service.configuration.*;
+import com.typesafe.config.*;
 import org.jitsi.utils.logging.*;
+import org.jitsi.videobridge.util.*;
 import org.osgi.framework.*;
 
 import java.net.*;
@@ -36,27 +36,6 @@ public class OctoRelayService
      */
     private static final Logger logger
         = Logger.getLogger(OctoRelayService.class);
-
-    /**
-     * The name of the configuration property which controls the address on
-     * which the Octo relay should bind.
-     */
-    public static final String ADDRESS_PNAME
-        = "org.jitsi.videobridge.octo.BIND_ADDRESS";
-        
-    /**
-     * The name of the configuration property which controls the public address
-     * which will be used as part of relayId.
-     */
-    public static final String PUBLIC_ADDRESS_PNAME
-        = "org.jitsi.videobridge.octo.PUBLIC_ADDRESS";
-
-    /**
-     * The name of the property which controls the port number which the Octo
-     * relay should use.
-     */
-    public static final String PORT_PNAME
-        = "org.jitsi.videobridge.octo.BIND_PORT";
 
     /**
      * The Octo relay instance used by this {@link OctoRelayService}.
@@ -78,33 +57,40 @@ public class OctoRelayService
     @Override
     public void start(BundleContext bundleContext)
     {
-        ConfigurationService cfg
-            = ServiceUtils2.getService(
-                    bundleContext, ConfigurationService.class);
+        Config octoConfig = JvbConfig.getConfig().getConfig("videobridge.octo");
 
-        String address = cfg.getString(ADDRESS_PNAME, null);
-        String publicAddress = cfg.getString(PUBLIC_ADDRESS_PNAME, address);
-        int port = cfg.getInt(PORT_PNAME, -1);
-
-        if (address != null && (1024 <= port && port <= 0xffff))
+        String address;
+        String publicAddress;
+        UnprivilegedPort port;
+        try
         {
-            try
-            {
-                relay = new OctoRelay(address, port);
-                relay.setPublicAddress(publicAddress);
-                bundleContext
-                    .registerService(OctoRelayService.class.getName(), this,
-                                     null);
-            }
-            catch (UnknownHostException | SocketException e)
-            {
-                logger.error("Failed to initialize Octo relay with address "
-                                 + address + ":" + port + ". ", e);
-            }
+            address = octoConfig.getString("bind-address");
+            publicAddress = octoConfig.getString("public-address");
+            port = new UnprivilegedPort(octoConfig.getInt("port"));
         }
-        else
+        catch (ConfigException.Missing ex)
         {
             logger.info("Octo relay not configured.");
+            return;
+        }
+        catch (UnprivilegedPort.InvalidUnprivilegedPortException ex)
+        {
+            logger.error(ex.toString());
+            return;
+        }
+
+        try
+        {
+            relay = new OctoRelay(address, port.get());
+            relay.setPublicAddress(publicAddress);
+            bundleContext
+                    .registerService(OctoRelayService.class.getName(), this,
+                            null);
+        }
+        catch (UnknownHostException | SocketException e)
+        {
+            logger.error("Failed to initialize Octo relay with address "
+                             + address + ":" + port.get() + ". ", e);
         }
     }
 
@@ -119,4 +105,5 @@ public class OctoRelayService
             relay.stop();
         }
     }
+
 }

--- a/src/main/java/org/jitsi/videobridge/osgi/ConfigurationActivator.java
+++ b/src/main/java/org/jitsi/videobridge/osgi/ConfigurationActivator.java
@@ -18,6 +18,7 @@ package org.jitsi.videobridge.osgi;
 import org.jitsi.service.configuration.*;
 import org.jitsi.service.libjitsi.*;
 import org.jitsi.utils.logging.*;
+import org.jitsi.videobridge.util.*;
 import org.osgi.framework.*;
 
 /**
@@ -37,19 +38,12 @@ public class ConfigurationActivator
     @Override
     public void start(BundleContext bundleContext)
     {
-        ConfigurationService cfg = LibJitsi.getConfigurationService();
-        if (cfg != null)
-        {
-            bundleContext.registerService(
-                    ConfigurationService.class.getName(),
-                    cfg,
-                    null);
-            logger.info("Registered the LibJitsi ConfigurationService in OSGi.");
-        }
-        else
-        {
-            logger.warn("Failed to register the Configuration service.");
-        }
+        ConfigurationService cfg = new LegacyConfigurationServiceShim();
+        bundleContext.registerService(
+                ConfigurationService.class.getName(),
+                cfg,
+                null);
+        logger.info("Registered the legacy ConfigurationService in OSGi.");
     }
 
     @Override

--- a/src/main/java/org/jitsi/videobridge/rest/PublicRESTBundleActivator.java
+++ b/src/main/java/org/jitsi/videobridge/rest/PublicRESTBundleActivator.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.rest;
 
+import com.typesafe.config.*;
 import org.eclipse.jetty.rewrite.handler.*;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.*;
@@ -25,6 +26,7 @@ import org.jitsi.rest.*;
 import org.jitsi.util.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.rest.ssi.*;
+import org.jitsi.videobridge.util.*;
 import org.osgi.framework.*;
 
 import javax.servlet.*;
@@ -525,8 +527,10 @@ public class PublicRESTBundleActivator
         }
 
         // Colibri WebSockets
+        WebsocketConfig websocketConfig =
+                ConfigBeanFactory.create(JvbConfig.getConfig().getConfig("videobridge.websockets"), WebsocketConfig.class);
         ColibriWebSocketService colibriWebSocketService
-            = new ColibriWebSocketService(bundleContext, isTls());
+            = new ColibriWebSocketService(websocketConfig, isTls());
         servletHolder
             = colibriWebSocketService.initializeColibriWebSocketServlet(
                     bundleContext,

--- a/src/main/java/org/jitsi/videobridge/rest/WebsocketConfig.java
+++ b/src/main/java/org/jitsi/videobridge/rest/WebsocketConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.rest;
+
+import com.typesafe.config.*;
+import org.jetbrains.annotations.*;
+
+public class WebsocketConfig
+{
+    protected boolean enabled;
+    protected String domain;
+    protected @Optional Boolean tls;
+    protected String serverId;
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+    }
+
+    public String getDomain()
+    {
+        return domain;
+    }
+
+    public void setDomain(String domain)
+    {
+        this.domain = domain;
+    }
+
+    public Boolean getTls()
+    {
+        return tls;
+    }
+
+    public void setTls(Boolean tls)
+    {
+        this.tls = tls;
+    }
+
+    public String getServerId()
+    {
+        return serverId;
+    }
+
+    public void setServerId(String serverId)
+    {
+        this.serverId = serverId;
+    }
+}

--- a/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -23,11 +23,11 @@ import java.util.concurrent.locks.*;
 import org.jitsi.nlj.stats.*;
 import org.jitsi.nlj.transform.node.incoming.*;
 import org.jitsi.osgi.*;
-import org.jitsi.service.configuration.*;
 import org.jitsi.utils.*;
 import org.jitsi.videobridge.*;
 import org.jitsi.videobridge.octo.*;
 import org.jitsi.videobridge.shim.*;
+import org.jitsi.videobridge.util.*;
 import org.json.simple.*;
 import org.osgi.framework.*;
 
@@ -57,11 +57,6 @@ public class VideobridgeStatistics
      * The currently configured region.
      */
     public static String region = null;
-
-    /**
-     * The name of the property used to configure the region.
-     */
-    public static final String REGION_PNAME = "org.jitsi.videobridge.REGION";
 
     static
     {
@@ -95,12 +90,7 @@ public class VideobridgeStatistics
         BundleContext bundleContext
             = StatsManagerBundleActivator.getBundleContext();
 
-        ConfigurationService cfg
-            = ServiceUtils2.getService(bundleContext, ConfigurationService.class);
-        if (cfg != null)
-        {
-            region = cfg.getString(REGION_PNAME, region);
-        }
+        region = JvbConfig.getConfig().getString("videobridge.octo.region");
 
         // Is it necessary to set initial values for all of these?
         unlockedSetStat(BITRATE_DOWNLOAD, 0);
@@ -465,7 +455,7 @@ public class VideobridgeStatistics
             {
                 unlockedSetStat(RELAY_ID, octoRelay.getId());
             }
-            if (region != null)
+            if (!StringUtils.isNullOrEmpty(region))
             {
                 unlockedSetStat(REGION, region);
             }

--- a/src/main/java/org/jitsi/videobridge/stats/config/PubSubStatsTransportConfig.java
+++ b/src/main/java/org/jitsi/videobridge/stats/config/PubSubStatsTransportConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.stats.config;
+
+public class PubSubStatsTransportConfig extends StatsTransportConfig
+{
+    protected String serviceName;
+    protected String nodeName;
+
+    public String getServiceName()
+    {
+        return serviceName;
+    }
+
+    public void setServiceName(String serviceName)
+    {
+        this.serviceName = serviceName;
+    }
+
+    public String getNodeName()
+    {
+        return nodeName;
+    }
+
+    public void setNodeName(String nodeName)
+    {
+        this.nodeName = nodeName;
+    }
+}

--- a/src/main/java/org/jitsi/videobridge/stats/config/StatsTransportConfig.java
+++ b/src/main/java/org/jitsi/videobridge/stats/config/StatsTransportConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.stats.config;
+
+import org.jitsi.videobridge.stats.*;
+
+import java.time.*;
+
+public class StatsTransportConfig
+{
+    /**
+     * The name of the stats transport.  This should
+     * match one of the strings in {@link StatsManagerBundleActivator}
+     * TODO: change to an enum
+     */
+    protected String name;
+    protected Duration interval;
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String name)
+    {
+        this.name = name;
+    }
+
+    public Duration getInterval()
+    {
+        return interval;
+    }
+
+    public void setInterval(Duration interval)
+    {
+        this.interval = interval;
+    }
+}

--- a/src/main/java/org/jitsi/videobridge/stats/config/StatsTransportConfigBeanFactory.java
+++ b/src/main/java/org/jitsi/videobridge/stats/config/StatsTransportConfigBeanFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.stats.config;
+
+import com.typesafe.config.*;
+import org.jitsi.videobridge.stats.*;
+
+import java.util.*;
+
+/**
+ * A bean factory to create {@link StatsTransportConfig} instances
+ * from a config.  This differs from the built-in bean factory in
+ * that is aware of the available stat classes and will create
+ * the correct instance based on the config
+ */
+public class StatsTransportConfigBeanFactory
+{
+    public static StatsTransportConfig create(Config transportConfig)
+    {
+        final String name = transportConfig.getString("name");
+        if (StatsManagerBundleActivator.STAT_TRANSPORT_PUBSUB.equalsIgnoreCase(name))
+        {
+            return ConfigBeanFactory.create(transportConfig, PubSubStatsTransportConfig.class);
+        }
+        else
+        {
+            return ConfigBeanFactory.create(transportConfig, StatsTransportConfig.class);
+        }
+    }
+}

--- a/src/main/java/org/jitsi/videobridge/stats/config/StatsTransportFactory.java
+++ b/src/main/java/org/jitsi/videobridge/stats/config/StatsTransportFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.stats.config;
+
+import org.jitsi.videobridge.stats.*;
+import org.jivesoftware.smackx.pubsub.packet.*;
+import org.jxmpp.jid.*;
+import org.jxmpp.jid.impl.*;
+import org.jxmpp.stringprep.*;
+
+/**
+ * Given a {@link StatsTransportConfig}, create the appropriate
+ * {@link org.jitsi.videobridge.stats.StatsTransport}
+ */
+public class StatsTransportFactory
+{
+    public static StatsTransport create(StatsTransportConfig config)
+    {
+        if (StatsManagerBundleActivator.STAT_TRANSPORT_CALLSTATS_IO.equalsIgnoreCase(config.name))
+        {
+            return new CallStatsIOTransport();
+        }
+        else if (StatsManagerBundleActivator.STAT_TRANSPORT_COLIBRI.equalsIgnoreCase(config.name))
+        {
+            return new ColibriStatsTransport();
+        }
+        else if (StatsManagerBundleActivator.STAT_TRANSPORT_MUC.equalsIgnoreCase(config.name))
+        {
+            return new MucStatsTransport();
+        } else if (StatsManagerBundleActivator.STAT_TRANSPORT_PUBSUB.equalsIgnoreCase(config.getName()))
+        {
+            PubSubStatsTransportConfig pubSubStatsTransportConfig =
+                    (PubSubStatsTransportConfig)config;
+            Jid service;
+            try
+            {
+                service = JidCreate.from(pubSubStatsTransportConfig.serviceName);
+            }
+            catch (XmppStringprepException e)
+            {
+                return null;
+            }
+
+            return new PubSubStatsTransport(service, pubSubStatsTransportConfig.nodeName);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/jitsi/videobridge/util/JvbConfig.java
+++ b/src/main/java/org/jitsi/videobridge/util/JvbConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.util;
+
+import com.typesafe.config.*;
+import org.jetbrains.annotations.*;
+import org.jitsi.utils.logging2.*;
+
+public class JvbConfig
+{
+    protected static Config config = ConfigFactory.load();
+    protected static Logger logger = new LoggerImpl(JvbConfig.class.getName());
+
+    static
+    {
+        logger.info("Loaded config: " + config.root().render());
+    }
+
+    public static @NotNull Config getConfig()
+    {
+        return config;
+    }
+}

--- a/src/main/java/org/jitsi/videobridge/util/JvbConfig.java
+++ b/src/main/java/org/jitsi/videobridge/util/JvbConfig.java
@@ -27,7 +27,8 @@ public class JvbConfig
 
     static
     {
-        logger.info("Loaded config: " + config.root().render());
+        logger.debug("Loaded complete config: " + config.root().render());
+        logger.info("Loaded JVB config: " + config.getConfig("videobridge").root().render());
     }
 
     public static @NotNull Config getConfig()

--- a/src/main/java/org/jitsi/videobridge/util/LegacyConfigurationServiceShim.java
+++ b/src/main/java/org/jitsi/videobridge/util/LegacyConfigurationServiceShim.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.util;
+
+import com.typesafe.config.*;
+import org.jitsi.service.configuration.*;
+
+import java.beans.*;
+import java.io.*;
+import java.util.*;
+import java.util.stream.*;
+
+public class LegacyConfigurationServiceShim implements ConfigurationService
+{
+    @Override
+    public Object getProperty(String s)
+    {
+        throw new RuntimeException("needed?");
+    }
+
+    @Override
+    public List<String> getAllPropertyNames()
+    {
+        return getConfig().entrySet()
+                .stream()
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> getPropertyNamesByPrefix(String prefix, boolean exactMatch)
+    {
+        return getAllPropertyNames()
+                .stream()
+                .filter(propName -> {
+                    if (exactMatch)
+                    {
+                        int index = propName.lastIndexOf(".");
+                        if (index == -1)
+                        {
+                            return false;
+                        }
+                        String propPrefix = propName.substring(0, index);
+                        return prefix.equals(propPrefix);
+                    }
+                    else
+                    {
+                        return propName.startsWith(prefix);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> getPropertyNamesBySuffix(String suffix)
+    {
+        return getAllPropertyNames()
+                .stream()
+                .filter(propName -> {
+                    int index = propName.lastIndexOf(".");
+                    return index != -1 && suffix.equals(propName.substring(index + 1));
+
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getString(String propName)
+    {
+        return getConfig().getString(propName);
+    }
+
+    private boolean hasProp(String propName)
+    {
+        return getConfig().hasPath(propName);
+    }
+
+    private Config getConfig()
+    {
+        return JvbConfig.getConfig().getConfig("legacy");
+    }
+
+    @Override
+    public String getString(String propName, String defaultValue)
+    {
+        if (hasProp(propName))
+        {
+            return getConfig().getString(propName);
+        }
+        return defaultValue;
+   }
+
+    @Override
+    public boolean getBoolean(String propName, boolean defaultValue)
+    {
+        if (hasProp(propName))
+        {
+            return getConfig().getBoolean(propName);
+        }
+        return defaultValue;
+    }
+
+    @Override
+    public int getInt(String propName, int defaultValue)
+    {
+        if (hasProp(propName))
+        {
+            return getConfig().getInt(propName);
+        }
+        return defaultValue;
+    }
+
+    @Override
+    public double getDouble(String propName, double defaultValue)
+    {
+        if (hasProp(propName))
+        {
+            return getConfig().getDouble(propName);
+        }
+        return defaultValue;
+    }
+
+    @Override
+    public long getLong(String propName, long defaultValue)
+    {
+        if (hasProp(propName))
+        {
+            return getConfig().getLong(propName);
+        }
+        return defaultValue;
+    }
+
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener propertyChangeListener)
+    {
+        throw new RuntimeException("Not supported in Config shim");
+    }
+
+    @Override
+    public void addPropertyChangeListener(String s, PropertyChangeListener propertyChangeListener)
+    {
+        throw new RuntimeException("Not supported in Config shim");
+    }
+
+    @Override
+    public void addVetoableChangeListener(ConfigVetoableChangeListener configVetoableChangeListener)
+    {
+        throw new RuntimeException("Not supported in Config shim");
+    }
+
+    @Override
+    public void addVetoableChangeListener(String s, ConfigVetoableChangeListener configVetoableChangeListener)
+    {
+        throw new RuntimeException("Not supported in Config shim");
+    }
+
+    @Override
+    public void removePropertyChangeListener(PropertyChangeListener propertyChangeListener)
+    {
+        System.out.println("remove prop change listener");
+    }
+
+    @Override
+    public void removePropertyChangeListener(String s, PropertyChangeListener propertyChangeListener)
+    {
+        System.out.println("remove prop change listener 2");
+    }
+
+    @Override
+    public void removeVetoableChangeListener(ConfigVetoableChangeListener configVetoableChangeListener)
+    {
+        System.out.println("remove vetoable prop change listener");
+    }
+
+    @Override
+    public void removeVetoableChangeListener(String s, ConfigVetoableChangeListener configVetoableChangeListener)
+    {
+        System.out.println("remove vetoable prop change listener 2");
+    }
+
+    @Override
+    public void storeConfiguration() throws IOException
+    {
+        throw new RuntimeException("Not supported in Config shim");
+    }
+
+    @Override
+    public void reloadConfiguration() throws IOException
+    {
+        System.out.println("reload");
+        // No op? TODO?
+    }
+
+    @Override
+    public void purgeStoredConfiguration()
+    {
+        System.out.println("purge");
+        // No op? TODO?
+    }
+
+    @Override
+    public void logConfigurationProperties(String s)
+    {
+        System.out.println("log");
+        // No op? TODO?
+    }
+
+    @Override
+    public String getScHomeDirLocation()
+    {
+        throw new RuntimeException("Not supported in Config shim");
+    }
+
+    @Override
+    public String getScHomeDirName()
+    {
+        throw new RuntimeException("Not supported in Config shim");
+    }
+
+    @Override
+    public String getConfigurationFilename()
+    {
+        throw new RuntimeException("Not supported in Config shim");
+    }
+
+    // Modification is not supported in the shim
+    @Override
+    public void removeProperty(String s)
+    {
+        throw new RuntimeException("Config shim doesn't support modification");
+    }
+
+    @Override
+    public void setProperty(String s, Object o)
+    {
+        throw new RuntimeException("Config shim doesn't support modification");
+    }
+
+    @Override
+    public void setProperties(Map<String, Object> map)
+    {
+        throw new RuntimeException("Config shim doesn't support modification");
+    }
+
+    @Override
+    public void setProperty(String s, Object o, boolean b)
+    {
+        throw new RuntimeException("Config shim doesn't support modification");
+    }
+}

--- a/src/main/java/org/jitsi/videobridge/util/UnprivilegedPort.java
+++ b/src/main/java/org/jitsi/videobridge/util/UnprivilegedPort.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.util;
+
+/**
+ * A helper class to validate/ensure that a supplied port
+ * is a valid, non-privileged port.  {@link InvalidUnprivilegedPortException}
+ * is thrown if the given port is not a valid, unprivileged port.
+ */
+public class UnprivilegedPort
+{
+    private final int port;
+    public UnprivilegedPort(int portNum) throws InvalidUnprivilegedPortException
+    {
+        if ((portNum < 1024) || (portNum > 0xffff))
+        {
+            throw new InvalidUnprivilegedPortException("Valid, unprivileged port required, "
+                    + portNum + " is unacceptable");
+        }
+        this.port = portNum;
+    }
+
+    public int get()
+    {
+        return this.port;
+    }
+
+    public static class InvalidUnprivilegedPortException extends Exception
+    {
+        public InvalidUnprivilegedPortException(String reason)
+        {
+            super(reason);
+        }
+    }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -55,6 +55,18 @@ videobridge {
     # TODO: use an allow-all regexp string by default instead of empty string
     authorized-source-regex=""
   }
+  stats {
+    enabled=true
+    # The default interval for stats
+    interval=1 second
+    # Example transport configs.  See StatsTransportConfig.
+    transports=[
+      {
+        name="muc"
+        interval=1 second
+      }
+    ]
+  }
   transport {
     ice {
       # A prefix which can be added to the ICE ufrag

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -120,6 +120,12 @@ videobridge {
     # The port number which the Octo relay should use.
     port=-1
   }
+  endpoint-connection-status {
+    # How long it can take an endpoint to send first data, before it will
+    # be marked as inactive.
+    first-transfer-timeout=15 seconds
+    max-inactivity-limit=3 seconds
+  }
 }
 
 ice4j {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -36,6 +36,44 @@ videobridge {
     # a default of some maximum bandwidth)
     trust-bwe=true
   }
+  transport {
+    ice {
+      # A prefix which can be added to the ICE ufrag
+      ufrag-prefix=""
+      # Whether the "component socket" feature of ice4j should be used. If this
+      # feature is used, ice4j will create a separate merging socket instance
+      # for each component, which reads from the sockets of all successful
+      # candidate pairs. Otherwise, this merging socket instance is not created,
+      # and the sockets from the individual candidate pairs should be used
+      # directly.
+      use-component-socket=true
+      # The {@link KeepAliveStrategy} to configure for ice4j {@link Component}s,
+      # which will dictate which candidate pairs to keep alive.
+      # Default to keeping alive the selected pair and any TCP pairs.
+      # Maps to org.ice4j.ice.KeepAliveStrategy
+      keep-alive-strategy="SELECTED_AND_TCP"
+      # TODO: create a harvester type enum and change these to something like:
+      # 'ports' is a priority-ordered list of ports to try
+      # harvesters=[
+      #   {
+      #     type=single_port_udp
+      #     ports=[10000,...]
+      #   },
+      #   {
+      #     type=single_port_tcp
+      #     mode=ssltcpp
+      #     port=...
+      #   }
+      #]
+      # The port used for SinglePortHarvester
+      single-port-harvester-port=10000
+      # Whether or not the TCP harvester should be disabled
+      disable-tcp-harvester=false
+      tcp-harvester-ports=[443, 4443]
+      tcp-harvester-mapped-port=-1
+      use-ssltcp=true
+    }
+  }
   octo {
     # The octo region of this JVB
     region=""

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -113,6 +113,12 @@ videobridge {
   octo {
     # The octo region of this JVB
     region=""
+    # The address on which the Octo relay should bind.
+    bind-address=""
+    # The public address which will be used as part of relayId
+    public-address=${bind-address}
+    # The port number which the Octo relay should use.
+    port=-1
   }
 }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,5 +1,7 @@
 # Default configuration values for the bridge
 videobridge {
+  # The interval at which the expire thread runs
+  expire-thread-interval=1 minute
   health {
     # The interval between health checks
     interval=10 seconds

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -120,3 +120,25 @@ ice4j {
   # Old name we use to support backwards compatibility
 
 }
+
+# Note: we need to wrap these 'legacy' properties as I've seen conflicts arise with
+# the way the config library handles paths.  For example, the old code had properties:
+# org.jitsi.videobridge.rest
+# org.jitsi.videobridge.rest.private...
+# Which results in a conflcit (in one, the property 'org.jitsi.videobridge.rest` is
+# a boolean, in the other it's an object containing further config.
+legacy {
+  org {
+    jitsi {
+      videobridge {
+        rest {
+          private {
+            jetty {
+              #port=4242
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -36,6 +36,25 @@ videobridge {
     # a default of some maximum bandwidth)
     trust-bwe=true
   }
+  enabled-apis=[rest]
+  xmpp {
+    #TODO: replace with a nested class of individual options, i.e.:
+    #processing-options {
+    #    allow-any-focus=false
+    #    allow-no-focus=false
+    #}
+    processing-options=0
+    # The property that specifies allowed entities for turning on graceful
+    # shutdown mode. For XMPP API this is "from" JID. In case of REST
+    # the source IP is being copied into the "from" field of the IQ.
+    # TODO: use an allow-all regexp string by default instead of empty string
+    shutdown-allowed-source-regex=""
+    # The property that specifies entities authorized to operate the bridge.
+    # For XMPP API this is "from" JID. In case of REST the source IP is being
+    # copied into the "from" field of the IQ.
+    # TODO: use an allow-all regexp string by default instead of empty string
+    authorized-source-regex=""
+  }
   transport {
     ice {
       # A prefix which can be added to the ICE ufrag
@@ -78,4 +97,9 @@ videobridge {
     # The octo region of this JVB
     region=""
   }
+}
+
+ice4j {
+  # Old name we use to support backwards compatibility
+
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -37,6 +37,7 @@ videobridge {
     trust-bwe=true
   }
   enabled-apis=[rest]
+  # XMPP API options (rename?)
   xmpp {
     #TODO: replace with a nested class of individual options, i.e.:
     #processing-options {
@@ -54,6 +55,10 @@ videobridge {
     # copied into the "from" field of the IQ.
     # TODO: use an allow-all regexp string by default instead of empty string
     authorized-source-regex=""
+  }
+  # XMPP client options
+  xmpp-client {
+    configs=[]
   }
   stats {
     enabled=true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -12,6 +12,10 @@ videobridge {
     # go back to a healthy state)
     sticky-failures=false
   }
+  cc {
+    # The interval at which bandwidth probing runs
+    padding-period=15ms
+  }
   octo {
     # The octo region of this JVB
     region=""

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -105,6 +105,11 @@ videobridge {
       use-ssltcp=true
     }
   }
+  websockets {
+    enabled=true
+    server-id="default-id"
+    domain=""
+  }
   octo {
     # The octo region of this JVB
     region=""

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,7 @@
+# Default configuration values for the bridge
+videobridge {
+  octo {
+    # The octo region of this JVB
+    region=""
+  }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -15,6 +15,26 @@ videobridge {
   cc {
     # The interval at which bandwidth probing runs
     padding-period=15ms
+    # The percentage change the estimated bandwidth must drop
+    # by before we'll update the bitrate allocation.
+    # "This is an ugly hack to prevent too many resolution/UI
+    # changes in case the bridge produces too low bandwidth
+    # estimate, at the risk of clogging the receiver's pipe"
+    bwe-change-threshold-percent=15
+    # The max resolution to allocate for thumbnails
+    thumbnail-max-height-px=180
+    # The preferred resolution to allocate for the onstage
+    # participant, before allocating bandwidth for the thumbnails
+    onstage-preferred-height-px=360
+    # The preferred frame rate to allocate for the onstage
+    # participant
+    onstage-preferred-framerate-fps=30
+    # Whether or not we're allowed to suspend the video of
+    # the on-stage participant
+    onstage-video-suspension-enabled=false
+    # Whether or not the BWE estimates should be used (vs.
+    # a default of some maximum bandwidth)
+    trust-bwe=true
   }
   octo {
     # The octo region of this JVB

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,5 +1,15 @@
 # Default configuration values for the bridge
 videobridge {
+  health {
+    # The interval between health checks
+    interval=10 seconds
+    # The timeout for a health check
+    timeout=30 seconds
+    # Whether or not health check failures should be 'sticky'
+    # (i.e. once the bridge becomes unhealthy, it will never
+    # go back to a healthy state)
+    sticky-failures=false
+  }
   octo {
     # The octo region of this JVB
     region=""

--- a/src/test/java/org/jitsi/videobridge/BridgeShutdownTest.java
+++ b/src/test/java/org/jitsi/videobridge/BridgeShutdownTest.java
@@ -15,7 +15,9 @@
  */
 package org.jitsi.videobridge;
 
+import com.typesafe.config.*;
 import org.jitsi.meet.*;
+import org.jitsi.videobridge.util.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jivesoftware.smack.packet.*;
 import org.jivesoftware.smack.packet.IQ;
@@ -54,8 +56,8 @@ public class BridgeShutdownTest
     {
         // Allow focus JID
         System.setProperty(
-            Videobridge.SHUTDOWN_ALLOWED_SOURCE_REGEXP_PNAME,
-            "focus.*");
+                "videobridge.xmpp.shutdown-allowed-source-regex",
+                "focus.*");
 
         osgiHandler.start();
 

--- a/src/test/java/org/jitsi/videobridge/rest/WebsocketConfigTest.java
+++ b/src/test/java/org/jitsi/videobridge/rest/WebsocketConfigTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.rest;
+
+import com.typesafe.config.*;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+public class WebsocketConfigTest
+{
+    private Config getConfig(String configName)
+    {
+        return ConfigFactory.parseResources("websocket-test.conf").getConfig(configName);
+    }
+
+    @Test
+    public void testNoTlsSet()
+    {
+        Config config = getConfig("websocket-config-no-tls");
+        WebsocketConfig websocketConfig  = ConfigBeanFactory.create(config, WebsocketConfig.class);
+        assertTrue(websocketConfig.enabled);
+        assertEquals("default-id", websocketConfig.serverId);
+        assertEquals("domain", websocketConfig.domain);
+        assertNull(websocketConfig.tls);
+    }
+
+    @Test
+    public void testTlsSet()
+    {
+        Config config = getConfig("websocket-config-tls-set");
+        WebsocketConfig websocketConfig  = ConfigBeanFactory.create(config, WebsocketConfig.class);
+        assertTrue(websocketConfig.enabled);
+        assertEquals("default-id", websocketConfig.serverId);
+        assertEquals("domain", websocketConfig.domain);
+        assertEquals(false, websocketConfig.tls);
+    }
+}

--- a/src/test/java/org/jitsi/videobridge/xmpp/ClientConnectionImplTest.java
+++ b/src/test/java/org/jitsi/videobridge/xmpp/ClientConnectionImplTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.xmpp;
+
+import com.typesafe.config.*;
+import org.jitsi.xmpp.mucclient.*;
+import org.junit.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+import static org.junit.Assert.*;
+
+public class ClientConnectionImplTest
+{
+    private Config getConfig(String configName)
+    {
+        return ConfigFactory.parseResources("muc-client-configuration.conf").getConfig(configName);
+    }
+    @Test
+    public void testBeanParsing()
+    {
+        List<? extends Config> c =
+                ConfigFactory.parseResources("muc-client-configuration.conf").getConfigList("muc-client-configs");
+        assertEquals(2, c.size());
+        List<MucClientConfiguration> mccs =
+                c.stream()
+                        .map(config -> ConfigBeanFactory.create(config, MucClientConfiguration.class))
+                        .collect(Collectors.toList());
+        for (int i = 0; i < mccs.size(); ++i)
+        {
+            MucClientConfiguration mcc = mccs.get(i);
+            if (i == 0)
+            {
+                assertEquals("1", mcc.getId());
+                assertEquals("hostname", mcc.getHostname());
+                assertEquals("domain", mcc.getDomain());
+                assertEquals("username", mcc.getUsername());
+                assertEquals("password", mcc.getPassword());
+                assertEquals(2, mcc.getMucJids().size());
+                assertTrue(mcc.getMucJids().contains("jid1@muc"));
+                assertTrue(mcc.getMucJids().contains("jid2@muc2"));
+                assertEquals("nickname", mcc.getMucNickname());
+                assertTrue(mcc.getDisableCertificateVerification());
+                assertEquals("iq handlermode", mcc.getIqHandlerMode());
+            }
+            else
+            {
+                assertEquals("2", mcc.getId());
+                assertEquals("hostname-2", mcc.getHostname());
+                assertEquals("domain-2", mcc.getDomain());
+                assertEquals("username-2", mcc.getUsername());
+                assertEquals("password-2", mcc.getPassword());
+                assertEquals(2, mcc.getMucJids().size());
+                assertTrue(mcc.getMucJids().contains("jid1@muc"));
+                assertTrue(mcc.getMucJids().contains("jid2@muc2"));
+                assertEquals("nickname-2", mcc.getMucNickname());
+                //TODO: this is hard-coded to true in the class.  fix it there?
+                //assertFalse(mcc.getDisableCertificateVerification());
+                assertEquals("iq handlermode-2", mcc.getIqHandlerMode());
+
+            }
+        }
+    }
+
+}

--- a/src/test/resources/muc-client-configuration.conf
+++ b/src/test/resources/muc-client-configuration.conf
@@ -1,0 +1,30 @@
+muc-client-configs=[
+  {
+    id="1"
+    hostname="hostname"
+    domain="domain"
+    username="username"
+    password="password"
+    muc-jids=[
+      "jid1@muc",
+      "jid2@muc2"
+    ]
+    muc-nickname="nickname"
+    disable-certificate-verification=true
+    iq-handler-mode="iq handlermode"
+  },
+  {
+    id="2"
+    hostname="hostname-2"
+    domain="domain-2"
+    username="username-2"
+    password="password-2"
+    muc-jids=[
+      "jid1@muc",
+      "jid2@muc2"
+    ]
+    muc-nickname="nickname-2"
+    disable-certificate-verification=false
+    iq-handler-mode="iq handlermode-2"
+  }
+]

--- a/src/test/resources/websocket-test.conf
+++ b/src/test/resources/websocket-test.conf
@@ -1,0 +1,12 @@
+websocket-config-no-tls {
+  enabled=true
+  server-id="default-id"
+  domain="domain"
+}
+
+websocket-config-tls-set {
+  enabled=true
+  server-id="default-id"
+  domain="domain"
+  tls=false
+}


### PR DESCRIPTION
This ports most of the `ConfigurationService` uses in JVB over to new config.

Some notes:

- For the most part I tried to just port things as they were, sometimes making notes of potential future improvements. There were one or two places where I  did refactor things a bit though.
- I didn't do constants for the config params.  They're only ever used in a single place, and, unlike the old code, the config *file* holds the documentation on each param (whereas before we had this on the constant for the config  key). Definitely open to other opinions on this one, but those were  my thoughts.
- The  `JvbConfig.getConfig().getConfig("...")` calls feel a little weird to me, I'm going to look at improving that.
- In a couple places where there were clusters of config values used I created a config class and parsed the config into that, I think there are a couple more places which could benefit from this so I may tweak those.

Some remaining TODOs before this is finished:

- [ ] Write some documentation on the new config scheme
- [x] Write a doc which includes a mapping of old config fields to new ones
- [ ] Some method of automatically translating old config fields to new ones
- [ ] More testing (unit tests and some more real calls)
