### PR TITLE
tell jetty to use jul

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
     <jitsi-desktop.version>2.13.cb5485e</jitsi-desktop.version>
     <kotlin.version>1.2.41</kotlin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <slf4j.version>1.7.26</slf4j.version>
     <smack.version>4.2.4-47d17fc</smack.version>
   </properties>
 

--- a/src/main/java/org/jitsi/videobridge/Main.java
+++ b/src/main/java/org/jitsi/videobridge/Main.java
@@ -117,6 +117,14 @@ public class Main
                     HOST_ARG_NAME,
                     domain == null ? HOST_ARG_VALUE : domain);
 
+        // Some of our dependencies bring in slf4j, which means Jetty will default to using
+        // slf4j as its logging backend.  The version of slf4j brought in, however, is too old
+        // for Jetty so it throws errors.  We use java.util.logging so tell Jetty to use that
+        // as its logging backend.
+        //TODO: Instead of setting this here, we should integrate it with the infra/debian scripts
+        // to be passed.
+        System.setProperty("org.eclipse.jetty.util.log.class", "org.eclipse.jetty.util.log.JavaUtilLog");
+
         // Before initializing the application programming interfaces (APIs) of
         // Jitsi Videobridge, set any System properties which they use and which
         // may be specified by the command-line arguments.


### PR DESCRIPTION
The lack of this was causing Jetty to find an old slf4j version (brought in by dependencies) and throw exceptions, which was breaking the REST API.