### PR TITLE
default the colibri rest resource to enabled

### DIFF
--- a/src/main/java/org/jitsi/videobridge/rest/annotations/EnabledByConfig.java
+++ b/src/main/java/org/jitsi/videobridge/rest/annotations/EnabledByConfig.java
@@ -21,7 +21,9 @@ import java.lang.annotation.*;
 /**
  * An annotation which allows a REST resource to be enabled by
  * a property value in config.  'value' should be set to the String
- * key of a boolean stored in a config.
+ * key of a boolean stored in a config.  'defaultValue' can be provided
+ * to give a default value if the 'value' key is not present in the
+ * config (false by default).
  *
  * See {@link org.jitsi.videobridge.rest.filters.ConfigFilter}
  */
@@ -31,4 +33,6 @@ import java.lang.annotation.*;
 public @interface EnabledByConfig
 {
     String value();
+
+    boolean defaultValue() default false;
 }

--- a/src/main/java/org/jitsi/videobridge/rest/filters/ConfigFilter.java
+++ b/src/main/java/org/jitsi/videobridge/rest/filters/ConfigFilter.java
@@ -60,7 +60,7 @@ public class ConfigFilter implements ContainerRequestFilter
             if  (clazz.isAnnotationPresent(EnabledByConfig.class))
             {
                 EnabledByConfig anno = clazz.getAnnotation(EnabledByConfig.class);
-                if (!(configProvider.get().getBoolean(anno.value(), false)))
+                if (!(configProvider.get().getBoolean(anno.value(), anno.defaultValue())))
                 {
                     throw new NotFoundException();
                 }

--- a/src/main/java/org/jitsi/videobridge/rest/filters/ConfigFilter.java
+++ b/src/main/java/org/jitsi/videobridge/rest/filters/ConfigFilter.java
@@ -27,8 +27,9 @@ import javax.ws.rs.core.*;
 /**
  * A filter which returns 404 not found for any path which:
  * 1) Is marked with the {@link EnabledByConfig} annotation and
- * 2) The value corresponding to the provided configuration key
- * is either not present or returns a value of false.
+ * 2) The resulting value corresponding to the provided configuration key
+ * after checking the config file (and potentially falling back to the
+ * default value) is false
  */
 public class ConfigFilter implements ContainerRequestFilter
 {

--- a/src/main/java/org/jitsi/videobridge/rest/root/colibri/ColibriResource.java
+++ b/src/main/java/org/jitsi/videobridge/rest/root/colibri/ColibriResource.java
@@ -25,7 +25,7 @@ import org.jitsi.videobridge.rest.annotations.*;
  * on /colibri/ are gated by the {@link Constants#ENABLE_REST_COLIBRI_PNAME}
  * config value
  */
-@EnabledByConfig(Constants.ENABLE_REST_COLIBRI_PNAME)
+@EnabledByConfig(value = Constants.ENABLE_REST_COLIBRI_PNAME, defaultValue = true)
 public class ColibriResource
 {
 }


### PR DESCRIPTION
this change allows a default value to be passed to the EnabledByConfig
annotation and, in the case of colibri resources, sets that default
value to true (enabled)