### PR TITLE
change VideobridgeStatistics to report just the local endpoint count

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -735,13 +735,23 @@ public class Conference
     }
 
     /**
-     * Returns the number of <tt>Endpoint</tt>s in this <tt>Conference</tt>.
+     * Returns the number of local AND remote {@link Endpoint}s in this {@link Conference}.
      *
-     * @return the number of <tt>Endpoint</tt>s in this <tt>Conference</tt>.
+     * @return the number of local AND remote {@link Endpoint}s in this {@link Conference}.
      */
     public int getEndpointCount()
     {
         return endpoints.size();
+    }
+
+    /**
+     * Returns the number of local {@link Endpoint}s in this {@link Conference}.
+     *
+     * @return the number of local {@link Endpoint}s in this {@link Conference}.
+     */
+    public int getLocalEndpointCount()
+    {
+        return getLocalEndpoints().size();
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -222,7 +222,7 @@ public class VideobridgeStatistics
                 continue;
             }
             conferences++;
-            int numConferenceEndpoints = conference.getEndpointCount();
+            int numConferenceEndpoints = conference.getLocalEndpointCount();
             if (numConferenceEndpoints > largestConferenceSize)
             {
                 largestConferenceSize = numConferenceEndpoints;


### PR DESCRIPTION
from what i can tell, `getEndpointCount` used to return only the count
of local (i.e. non-octo) endpoints, as we used to keep `OctoEndpoint`s
and `Endpoint`s in different data structures.  i believe the other code
which calls `getEndpointCount` _is_ looking for a total endpoint count
(not just a local one) but i'm hoping @bgrozev can help clarify things
there, as this code didn't exist in 1.0.  to minimize the change, i've
added a new explicit `getLocalEndpointCount` and had the stats call
that, leaving the other code alone.

cc @aaronkvanmeerten 