### PR TITLE
Debian: postinst - fix AUTHORIZED_SOURCE_REGEXP

### DIFF
--- a/resources/install/debian/postinst
+++ b/resources/install/debian/postinst
@@ -97,7 +97,7 @@ case "$1" in
         sed -i 's/\$JVB_EXTRA_JVM_PARAMS//g' $CONFIG
 
         if ! grep -q "org.jitsi.videobridge.AUTHORIZED_SOURCE_REGEXP" "$NEW_JITSI_CONFIG" ;then
-            echo "org.jitsi.videobridge.AUTHORIZED_SOURCE_REGEXP=focus@auth.${JVB_HOSTNAME}/.*" >> $NEW_JITSI_CONFIG
+            echo "org.jitsi.videobridge.AUTHORIZED_SOURCE_REGEXP=focus@auth\.${JVB_HOSTNAME//./\\.}/.*" >> $NEW_JITSI_CONFIG
         fi
 
         # we don't want to start the daemon as root


### PR DESCRIPTION
Commit ac6c098277 introduces a bug in `resources/install/debian/postinst`
during installation that in some, rare, circumstances could cause extremely
hard to detect issues.

The problem here is that as a regular expression the domain-part separating dots
in JVB_HOSTNAME are interpreted as regular expression "match anything"
symbols so that all these would match:

JVB_HOSTNAME=meet.domain.tld

focus@auth1meet.domain.tld/.*
focus@auth.meet2domain.tld/.*
focus@auth3meet4domain.tld/.*
focus@auth5meet.domain6tld/.*

Signed-off-by: Tj <hacker@iam.tj>

Author:    Tj <hacker@iam.tj>