### PR TITLE
Optimize vp8 frame projection map

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveTrackProjectionContext.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveTrackProjectionContext.java
@@ -311,10 +311,22 @@ public class VP8AdaptiveTrackProjectionContext
             return null;
         }
 
+        if (lastVP8FrameProjection.getSSRC() != nextVP8FrameProjection.getSSRC())
+        {
+            /* We've changed the encoding we're forwarding, so previous frames
+             * in the map are no longer relevant.
+             */
+            vp8FrameProjectionMap.clear();
+        }
+        else
+        {
+            /* Remove projections of old frames from the map. */
+            cleanupFrameProjectionMap(rtpPacket.getTimestamp());
+        }
+
         // We have successfully projected the incoming frame and we've allocated
         // a starting sequence number for it. Any previous frames can no longer
         // grow.
-        cleanupFrameProjectionMap(rtpPacket.getTimestamp());
         vp8FrameProjectionMap.put(rtpPacket.getTimestamp(), nextVP8FrameProjection);
         // The frame attached to the "last" projection is no longer the "last".
         lastVP8FrameProjection = nextVP8FrameProjection;

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveTrackProjectionContext.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveTrackProjectionContext.java
@@ -201,8 +201,7 @@ public class VP8AdaptiveTrackProjectionContext
      *
      * Caller should be synchronized.
      * */
-    private
-    void cleanupFrameProjectionMap(long newTimestamp)
+    private void cleanupFrameProjectionMap(long newTimestamp)
     {
         if (vp8FrameProjectionMap.isEmpty())
         {
@@ -225,7 +224,7 @@ public class VP8AdaptiveTrackProjectionContext
         while (it.hasNext())
         {
             Long key = it.next();
-            if (RtpUtils.isNewerTimestampThan(threshold, key))
+            if (RtpUtils.isOlderTimestampThan(key, threshold))
             {
                 it.remove();
             }


### PR DESCRIPTION
This will fix the performance bottleneck from clearing old entries from the VP8 frame projection map.