### PR TITLE
pass the lib dir as the classpath instead of every file in it

### DIFF
--- a/resources/install/linux-64/jvb.sh
+++ b/resources/install/linux-64/jvb.sh
@@ -16,7 +16,8 @@ fi
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 mainClass="org.jitsi.videobridge.Main"
-cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*.jar
+cp=$(JARS=($SCRIPT_DIR/jitsi-videobridge*.jar); IFS=:; echo "${JARS[*]}")
+cp=$cp:$SCRIPT_DIR/lib/
 libs="$SCRIPT_DIR/lib/native/linux-64"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
 videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"

--- a/resources/install/linux-64/jvb.sh
+++ b/resources/install/linux-64/jvb.sh
@@ -16,7 +16,7 @@ fi
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 mainClass="org.jitsi.videobridge.Main"
-cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*.jar
+cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*
 libs="$SCRIPT_DIR/lib/native/linux-64"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
 videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"

--- a/resources/install/linux-64/jvb.sh
+++ b/resources/install/linux-64/jvb.sh
@@ -16,7 +16,7 @@ fi
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 mainClass="org.jitsi.videobridge.Main"
-cp=$(JARS=($SCRIPT_DIR/jitsi-videobridge*.jar $SCRIPT_DIR/lib/*.jar); IFS=:; echo "${JARS[*]}")
+cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*.jar
 libs="$SCRIPT_DIR/lib/native/linux-64"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
 videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"

--- a/resources/install/linux-64/jvb.sh
+++ b/resources/install/linux-64/jvb.sh
@@ -16,8 +16,7 @@ fi
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 mainClass="org.jitsi.videobridge.Main"
-cp=$(JARS=($SCRIPT_DIR/jitsi-videobridge*.jar); IFS=:; echo "${JARS[*]}")
-cp=$cp:$SCRIPT_DIR/lib/
+cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*.jar
 libs="$SCRIPT_DIR/lib/native/linux-64"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
 videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"

--- a/resources/install/linux/jvb.sh
+++ b/resources/install/linux/jvb.sh
@@ -16,7 +16,7 @@ fi
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 mainClass="org.jitsi.videobridge.Main"
-cp=$(JARS=($SCRIPT_DIR/jitsi-videobridge*.jar $SCRIPT_DIR/lib/*.jar); IFS=:; echo "${JARS[*]}")
+cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*.jar
 libs="$SCRIPT_DIR/lib/native/linux"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
 videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"

--- a/resources/install/linux/jvb.sh
+++ b/resources/install/linux/jvb.sh
@@ -16,7 +16,8 @@ fi
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 mainClass="org.jitsi.videobridge.Main"
-cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*.jar
+cp=$(JARS=($SCRIPT_DIR/jitsi-videobridge*.jar); IFS=:; echo "${JARS[*]}")
+cp=$cp:$SCRIPT_DIR/lib/
 libs="$SCRIPT_DIR/lib/native/linux"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
 videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"

--- a/resources/install/linux/jvb.sh
+++ b/resources/install/linux/jvb.sh
@@ -16,8 +16,7 @@ fi
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 mainClass="org.jitsi.videobridge.Main"
-cp=$(JARS=($SCRIPT_DIR/jitsi-videobridge*.jar); IFS=:; echo "${JARS[*]}")
-cp=$cp:$SCRIPT_DIR/lib/
+cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*.jar
 libs="$SCRIPT_DIR/lib/native/linux"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
 videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"

--- a/resources/install/linux/jvb.sh
+++ b/resources/install/linux/jvb.sh
@@ -16,7 +16,7 @@ fi
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 mainClass="org.jitsi.videobridge.Main"
-cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*.jar
+cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*
 libs="$SCRIPT_DIR/lib/native/linux"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
 videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"

--- a/resources/install/macosx/jvb.sh
+++ b/resources/install/macosx/jvb.sh
@@ -16,7 +16,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 mainClass="org.jitsi.videobridge.Main"
-cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*.jar
+cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*
 libs="$SCRIPT_DIR/lib/native/macosx"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
 videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"

--- a/resources/install/macosx/jvb.sh
+++ b/resources/install/macosx/jvb.sh
@@ -16,7 +16,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 mainClass="org.jitsi.videobridge.Main"
-cp=$(JARS=($SCRIPT_DIR/jitsi-videobridge*.jar $SCRIPT_DIR/lib/*.jar); IFS=:; echo "${JARS[*]}")
+cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*.jar
 libs="$SCRIPT_DIR/lib/native/macosx"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
 videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"

--- a/resources/install/macosx/jvb.sh
+++ b/resources/install/macosx/jvb.sh
@@ -16,8 +16,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 mainClass="org.jitsi.videobridge.Main"
-cp=$(JARS=($SCRIPT_DIR/jitsi-videobridge*.jar); IFS=:; echo "${JARS[*]}")
-cp=$cp:$SCRIPT_DIR/lib/
+cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*.jar
 libs="$SCRIPT_DIR/lib/native/macosx"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
 videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"

--- a/resources/install/macosx/jvb.sh
+++ b/resources/install/macosx/jvb.sh
@@ -16,7 +16,8 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 mainClass="org.jitsi.videobridge.Main"
-cp=$SCRIPT_DIR/jitsi-videobridge.jar:$SCRIPT_DIR/lib/*.jar
+cp=$(JARS=($SCRIPT_DIR/jitsi-videobridge*.jar); IFS=:; echo "${JARS[*]}")
+cp=$cp:$SCRIPT_DIR/lib/
 libs="$SCRIPT_DIR/lib/native/macosx"
 logging_config="$SCRIPT_DIR/lib/logging.properties"
 videobridge_rc="$SCRIPT_DIR/lib/videobridge.rc"


### PR DESCRIPTION
individually

I often check `ps` to verify bridge is running and to check the command-line arguments which were passed. but right now we pass every file from the `lib` dir individually to the classpath, which makes it difficult to parse.  Instead, we can pass the directory name and achieve the same result.  Soon I'll be adding another argument for the new config file, so it will be even more useful to make this more readable.


Before this change, when checking `ps aux | grep videobridge` the result will contain:
> java -agentpath:/home/bbaldino/YourKit-JavaProfiler-2019.8/bin/linux-x86-64/libyjpagent.so=probe_disable=*,delay=10000,port=3478,listen=all -Xmx3072m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -Djava.library.path=/usr/share/jitsi-videobridge/lib/native/linux-64 -XX:+PreserveFramePointer -Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/etc/jitsi -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=videobridge -Dnet.java.sip.communicator.SC_LOG_DIR_LOCATION=/var/log/jitsi -Djava.util.logging.config.file=/etc/jitsi/videobridge/logging.properties -cp /usr/share/jitsi-videobridge/jitsi-videobridge.jar:/usr/share/jitsi-videobridge/lib/agafua-syslog-0.4.jar:/usr/share/jitsi-videobridge/lib/annotations-15.0.jar:/usr/share/jitsi-videobridge/lib/bccontrib-1.0.jar:/usr/share/jitsi-videobridge/lib/bcpkix-jdk15on-1.54.jar:/usr/share/jitsi-videobridge/lib/bcprov-jdk15on-1.54.jar:/usr/share/jitsi-videobridge/lib/callstats-java-sdk-5.0.0.jar:/usr/share/jitsi-videobridge/lib/cglib-nodep-2.2.2.jar:/usr/share/jitsi-videobridge/lib/commons-codec-1.6.jar:/usr/share/jitsi-videobridge/lib/commons-lang3-3.1.jar:/usr/share/jitsi-videobridge/lib/commons-logging-1.2.jar:/usr/share/jitsi-videobridge/lib/concurrentlinkedhashmap-lru-1.0_jdk5.jar:/usr/share/jitsi-videobridge/lib/core-2.0.1.jar:/usr/share/jitsi-videobridge/lib/dnsjava-2.1.7.jar:/usr/share/jitsi-videobridge/lib/dom4j-1.6.1.jar:/usr/share/jitsi-videobridge/lib/fmj-1.0-20161207.221530-23.jar:/usr/share/jitsi-videobridge/lib/gson-2.3.1.jar:/usr/share/jitsi-videobridge/lib/guava-15.0.jar:/usr/share/jitsi-videobridge/lib/httpclient-4.4.jar:/usr/share/jitsi-videobridge/lib/httpcore-4.4.jar:/usr/share/jitsi-videobridge/lib/ice4j-2.0.0-20181005.221549-11.jar:/usr/share/jitsi-videobridge/lib/jain-sip-ri-ossonly-1.2.98c7f8c-jitsi-oss1.jar:/usr/share/jitsi-videobridge/lib/java-dogstatsd-client-2.5.jar:/usr/share/jitsi-videobridge/lib/java-sdp-nist-bridge-1.1.jar:/usr/share/jitsi-videobridge/lib/javax.servlet-api-3.1.0.jar:/usr/share/jitsi-videobridge/lib/jbosh-0.9.0.jar:/usr/share/jitsi-videobridge/lib/jcip-annotations-1.0.jar:/usr/share/jitsi-videobridge/lib/jcl-core-2.8.jar:/usr/share/jitsi-videobridge/lib/jetty-client-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/jetty-continuation-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/jetty-http-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/jetty-io-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/jetty-proxy-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/jetty-rewrite-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/jetty-security-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/jetty-server-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/jetty-servlet-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/jetty-servlets-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/jetty-util-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/jetty-webapp-7.0.1.v20091125.jar:/usr/share/jitsi-videobridge/lib/jetty-xml-7.0.1.v20091125.jar:/usr/share/jitsi-videobridge/lib/jicoco-1.1-20180821.201527-7.jar:/usr/share/jitsi-videobridge/lib/jitsi-android-osgi-1.0-20180322.162617-2.jar:/usr/share/jitsi-videobridge/lib/jitsi-configuration-2.13.f6042d3.jar:/usr/share/jitsi-videobridge/lib/jitsi-dnsservice-2.9-20150723.181644-1.jar:/usr/share/jitsi-videobridge/lib/jitsi-fileaccess-2.13.f6042d3.jar:/usr/share/jitsi-videobridge/lib/jitsi-netaddr-2.13.f6042d3.jar:/usr/share/jitsi-videobridge/lib/jitsi-packetlogging-2.13.f6042d3.jar:/usr/share/jitsi-videobridge/lib/jitsi-protocol-2.13.f6042d3.jar:/usr/share/jitsi-videobridge/lib/jitsi-protocol-jabber-2.13.f6042d3.jar:/usr/share/jitsi-videobridge/lib/jitsi-protocol-media-2.13.f6042d3.jar:/usr/share/jitsi-videobridge/lib/jitsi-resourcemanager-2.13.f6042d3.jar:/usr/share/jitsi-videobridge/lib/jitsi-stats-1.0-20180523.024051-5.jar:/usr/share/jitsi-videobridge/lib/jitsi-ui-service-2.13.f6042d3.jar:/usr/share/jitsi-videobridge/lib/jitsi-util-2.13.f6042d3.jar:/usr/share/jitsi-videobridge/lib/jna-4.1.0.jar:/usr/share/jitsi-videobridge/lib/jnsapi-0.0.3-jitsi-smack4.2-3.jar:/usr/share/jitsi-videobridge/lib/jose4j-0.5.1.jar:/usr/share/jitsi-videobridge/lib/json-simple-1.1.1.jar:/usr/share/jitsi-videobridge/lib/jul-to-slf4j-1.7.7.jar:/usr/share/jitsi-videobridge/lib/jxmpp-core-0.6.0.jar:/usr/share/jitsi-videobridge/lib/jxmpp-jid-0.6.0.jar:/usr/share/jitsi-videobridge/lib/jxmpp-util-cache-0.6.0.jar:/usr/share/jitsi-videobridge/lib/libidn-1.15.jar:/usr/share/jitsi-videobridge/lib/libjitsi-1.0-20190130.211714-376.jar:/usr/share/jitsi-videobridge/lib/log4j-1.2.15.jar:/usr/share/jitsi-videobridge/lib/log4j-api-2.3.jar:/usr/share/jitsi-videobridge/lib/log4j-core-2.3.jar:/usr/share/jitsi-videobridge/lib/object-cloner-0.1.jar:/usr/share/jitsi-videobridge/lib/objenesis-2.2.jar:/usr/share/jitsi-videobridge/lib/okhttp-3.9.1.jar:/usr/share/jitsi-videobridge/lib/okio-1.13.0.jar:/usr/share/jitsi-videobridge/lib/orange-extensions-1.3.0.jar:/usr/share/jitsi-videobridge/lib/org.apache.felix.framework-4.4.0.jar:/usr/share/jitsi-videobridge/lib/org.apache.felix.main-4.4.0.jar:/usr/share/jitsi-videobridge/lib/org.osgi.core-4.3.1.jar:/usr/share/jitsi-videobridge/lib/osgi-over-slf4j-1.7.7.jar:/usr/share/jitsi-videobridge/lib/sdes4j-1.1.3.jar:/usr/share/jitsi-videobridge/lib/sdp-api-1.0.jar:/usr/share/jitsi-videobridge/lib/sigar-1.6.4.jar:/usr/share/jitsi-videobridge/lib/slf4j-api-1.7.7.jar:/usr/share/jitsi-videobridge/lib/slf4j-jdk14-1.7.7.jar:/usr/share/jitsi-videobridge/lib/slf4j-simple-1.6.1.jar:/usr/share/jitsi-videobridge/lib/smack-bosh-4.2.1.jar:/usr/share/jitsi-videobridge/lib/smack-core-4.2.2-b1c107f.jar:/usr/share/jitsi-videobridge/lib/smack-debug-4.2.1.jar:/usr/share/jitsi-videobridge/lib/smack-experimental-4.2.1.jar:/usr/share/jitsi-videobridge/lib/smack-extensions-4.2.2-b1c107f.jar:/usr/share/jitsi-videobridge/lib/smack-im-4.2.2-b1c107f.jar:/usr/share/jitsi-videobridge/lib/smack-java7-4.2.1.jar:/usr/share/jitsi-videobridge/lib/smack-legacy-4.2.1.jar:/usr/share/jitsi-videobridge/lib/smack-resolver-javax-4.2.1.jar:/usr/share/jitsi-videobridge/lib/smack-sasl-javax-4.2.1.jar:/usr/share/jitsi-videobridge/lib/smack-tcp-4.2.2-b1c107f.jar:/usr/share/jitsi-videobridge/lib/tinder-1.3.0.jar:/usr/share/jitsi-videobridge/lib/websocket-api-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/websocket-client-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/websocket-common-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/websocket-server-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/websocket-servlet-9.2.10.v20150310.jar:/usr/share/jitsi-videobridge/lib/weupnp-0.1.4.jar:/usr/share/jitsi-videobridge/lib/xml-apis-1.0.b2.jar:/usr/share/jitsi-videobridge/lib/xmlpull-1.1.3.4a.jar:/usr/share/jitsi-videobridge/lib/xpp3-1.1.4c.jar:/usr/share/jitsi-videobridge/lib/zrtp4j-light-3.2.0-jitsi-1-20150723.002345-1.jar org.jitsi.videobridge.Main --host=localhost --domain=somedomain --port=5347 --secret=somesecret --apis=rest --subdomain=jvb-1 --min-port=10001

After, it looks like:
> java -agentpath:/home/bbaldino/YourKit-JavaProfiler-2019.8/bin/linux-x86-64/libyjpagent.so=probe_disable=*,delay=10000,port=3478,listen=all -Xmx3072m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -Djava.library.path=/usr/share/jitsi-videobridge/lib/native/linux-64 -XX:+PreserveFramePointer -Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/etc/jitsi -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=videobridge -Dnet.java.sip.communicator.SC_LOG_DIR_LOCATION=/var/log/jitsi -Djava.util.logging.config.file=/etc/jitsi/videobridge/logging.properties -cp /usr/share/jitsi-videobridge/jitsi-videobridge.jar:/usr/share/jitsi-videobridge/lib/*.jar org.jitsi.videobridge.Main --host=localhost --domain=somedomain --port=5347 --secret=somesecret --apis=rest --subdomain=jvb-1 --min-port=10001