### PR TITLE
don't include with jitsi-videobridge-with-dependencies jar in the

### DIFF
--- a/src/assembly/linux-x64-bin-archive.xml
+++ b/src/assembly/linux-x64-bin-archive.xml
@@ -23,6 +23,9 @@
       <includes>
         <include>*.jar</include>
       </includes>
+      <excludes>
+        <exclude>*-with-dependencies.jar</exclude>
+      </excludes>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/lib</directory>

--- a/src/assembly/linux-x86-bin-archive.xml
+++ b/src/assembly/linux-x86-bin-archive.xml
@@ -23,6 +23,9 @@
       <includes>
         <include>*.jar</include>
       </includes>
+      <excludes>
+        <exclude>*-with-dependencies.jar</exclude>
+      </excludes>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/lib</directory>

--- a/src/assembly/macosx-bin-archive.xml
+++ b/src/assembly/macosx-bin-archive.xml
@@ -23,6 +23,9 @@
       <includes>
         <include>*.jar</include>
       </includes>
+      <excludes>
+        <exclude>*-with-dependencies.jar</exclude>
+      </excludes>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/lib</directory>

--- a/src/assembly/windows-x64-bin-archive.xml
+++ b/src/assembly/windows-x64-bin-archive.xml
@@ -23,6 +23,9 @@
       <includes>
         <include>*.jar</include>
       </includes>
+      <excludes>
+        <exclude>*-with-dependencies.jar</exclude>
+      </excludes>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/lib</directory>

--- a/src/assembly/windows-x86-bin-archive.xml
+++ b/src/assembly/windows-x86-bin-archive.xml
@@ -23,6 +23,9 @@
       <includes>
         <include>*.jar</include>
       </includes>
+      <excludes>
+        <exclude>*-with-dependencies.jar</exclude>
+      </excludes>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/lib</directory>


### PR DESCRIPTION
archives

i took a look at also renaming the videobridge jar to `jitsi-videobridge.jar`, but that's a bit trickier.  so will save that for (maybe) another PR.