### PR TITLE
always rename the jvb jar to jitsi-videobridge.jar in the archive

### DIFF
--- a/src/assembly/linux-x64-bin-archive.xml
+++ b/src/assembly/linux-x64-bin-archive.xml
@@ -16,6 +16,13 @@
       <unpack>false</unpack>
     </dependencySet>
   </dependencySets>
+  <files>
+    <file>
+        <source>${project.basedir}/target/${project.artifactId}-${project.version}.jar</source>
+        <outputDirectory>/</outputDirectory>
+        <destName>jitsi-videobridge.jar</destName>
+    </file>
+  </files>
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}</directory>
@@ -25,6 +32,7 @@
       </includes>
       <excludes>
         <exclude>*-with-dependencies.jar</exclude>
+        <exclude>${project.artifactId}-${project.version}.jar</exclude>
       </excludes>
     </fileSet>
     <fileSet>

--- a/src/assembly/linux-x86-bin-archive.xml
+++ b/src/assembly/linux-x86-bin-archive.xml
@@ -16,6 +16,13 @@
       <unpack>false</unpack>
     </dependencySet>
   </dependencySets>
+  <files>
+    <file>
+        <source>${project.basedir}/target/${project.artifactId}-${project.version}.jar</source>
+        <outputDirectory>/</outputDirectory>
+        <destName>jitsi-videobridge.jar</destName>
+    </file>
+  </files>
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}</directory>
@@ -25,6 +32,7 @@
       </includes>
       <excludes>
         <exclude>*-with-dependencies.jar</exclude>
+        <exclude>${project.artifactId}-${project.version}.jar</exclude>
       </excludes>
     </fileSet>
     <fileSet>

--- a/src/assembly/macosx-bin-archive.xml
+++ b/src/assembly/macosx-bin-archive.xml
@@ -16,6 +16,13 @@
       <unpack>false</unpack>
     </dependencySet>
   </dependencySets>
+  <files>
+    <file>
+        <source>${project.basedir}/target/${project.artifactId}-${project.version}.jar</source>
+        <outputDirectory>/</outputDirectory>
+        <destName>jitsi-videobridge.jar</destName>
+    </file>
+  </files>
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}</directory>
@@ -25,6 +32,7 @@
       </includes>
       <excludes>
         <exclude>*-with-dependencies.jar</exclude>
+        <exclude>${project.artifactId}-${project.version}.jar</exclude>
       </excludes>
     </fileSet>
     <fileSet>

--- a/src/assembly/windows-x64-bin-archive.xml
+++ b/src/assembly/windows-x64-bin-archive.xml
@@ -16,6 +16,13 @@
       <unpack>false</unpack>
     </dependencySet>
   </dependencySets>
+  <files>
+    <file>
+        <source>${project.basedir}/target/${project.artifactId}-${project.version}.jar</source>
+        <outputDirectory>/</outputDirectory>
+        <destName>jitsi-videobridge.jar</destName>
+    </file>
+  </files>
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}</directory>
@@ -25,6 +32,7 @@
       </includes>
       <excludes>
         <exclude>*-with-dependencies.jar</exclude>
+        <exclude>${project.artifactId}-${project.version}.jar</exclude>
       </excludes>
     </fileSet>
     <fileSet>

--- a/src/assembly/windows-x86-bin-archive.xml
+++ b/src/assembly/windows-x86-bin-archive.xml
@@ -16,6 +16,13 @@
       <unpack>false</unpack>
     </dependencySet>
   </dependencySets>
+  <files>
+    <file>
+        <source>${project.basedir}/target/${project.artifactId}-${project.version}.jar</source>
+        <outputDirectory>/</outputDirectory>
+        <destName>jitsi-videobridge.jar</destName>
+    </file>
+  </files>
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}</directory>
@@ -25,6 +32,7 @@
       </includes>
       <excludes>
         <exclude>*-with-dependencies.jar</exclude>
+        <exclude>${project.artifactId}-${project.version}.jar</exclude>
       </excludes>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
the thinking here was that it would be better to be able to assume a specific name for the videobridge jar (e.g. [this](https://github.com/jitsi/jitsi-videobridge/pull/951) PR could be made to use a specific filename instead of a wildcard for the jvb jar).  we considered the idea of having a versioned-jar filename with a symlink `jitsi-videobridge.jar` pointing to it, but decided that the version is available via other means so this was unnecessary. 