### PR TITLE
Updateable media direction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.jitsi</groupId>
   <artifactId>jitsi-videobridge</artifactId>
-  <version>2.1-SNAPSHOT</version>
+  <version>2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>jitsi-videobridge</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.jitsi</groupId>
   <artifactId>jitsi-videobridge</artifactId>
-  <version>2.2-SNAPSHOT</version>
+  <version>2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>jitsi-videobridge</name>

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1325,20 +1325,15 @@ public class Endpoint
         boolean acceptVideo = false;
         for (ChannelShim channelShim : channelShims)
         {
-            String direction = channelShim.getDirection();
-            if (direction != null)
+            if (channelShim.allowsReceivingMedia())
             {
-                if ("sendrecv".equalsIgnoreCase(direction) ||
-                    "recvonly".equalsIgnoreCase(direction))
+                if (MediaType.AUDIO == channelShim.getMediaType())
                 {
-                    if (MediaType.AUDIO == channelShim.getMediaType())
-                    {
-                        acceptAudio = true;
-                    }
-                    else if (MediaType.VIDEO == channelShim.getMediaType())
-                    {
-                        acceptVideo = true;
-                    }
+                    acceptAudio = true;
+                }
+                else if (MediaType.VIDEO == channelShim.getMediaType())
+                {
+                    acceptVideo = true;
                 }
             }
         }

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1290,7 +1290,7 @@ public class Endpoint
     {
         if (channelShims.add(channelShim))
         {
-            refreshMediaDirection();
+            updateAcceptedMediaTypes();
         }
     }
 
@@ -1308,18 +1308,18 @@ public class Endpoint
             }
             else
             {
-                refreshMediaDirection();
+                updateAcceptedMediaTypes();
             }
         }
     }
 
     /**
-     * Refresh media direction based on direction of
-     * {@link ChannelShim}. An endpoint can accept
+     * Update accepted media types based on directions of
+     * {@link ChannelShim}s. An endpoint can accept
      * media, if its {@link ChannelShim} has either
      * 'sendrecv' or 'recvonly' media direction.
      */
-    public void refreshMediaDirection()
+    public void updateAcceptedMediaTypes()
     {
         boolean acceptAudio = false;
         boolean acceptVideo = false;

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -126,7 +126,7 @@ public class Endpoint
     /**
      * A count of how many endpoints have 'selected' this endpoint
      */
-    private AtomicInteger selectedCount = new AtomicInteger(0);
+    private final AtomicInteger selectedCount = new AtomicInteger(0);
 
     /**
      * The diagnostic context of this instance.

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -490,6 +490,7 @@ public class Endpoint
             {
                 transceiver.sendPacket(new PacketInfo(videoRtpPacket));
             }
+            return;
         }
         else if (packet instanceof RtcpSrPacket)
         {
@@ -505,8 +506,9 @@ public class Endpoint
                         + ", timestamp="
                         + rtcpSrPacket.getSenderInfo().getRtpTimestamp());
             }
-            transceiver.sendPacket(packetInfo);
         }
+
+        transceiver.sendPacket(packetInfo);
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1327,13 +1327,14 @@ public class Endpoint
         {
             if (channelShim.allowsReceivingMedia())
             {
-                if (MediaType.AUDIO == channelShim.getMediaType())
+                switch (channelShim.getMediaType())
                 {
-                    acceptAudio = true;
-                }
-                else if (MediaType.VIDEO == channelShim.getMediaType())
-                {
-                    acceptVideo = true;
+                    case AUDIO:
+                        acceptAudio = true;
+                        break;
+                    case VIDEO:
+                        acceptVideo = true;
+                        break;
                 }
             }
         }

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1314,10 +1314,9 @@ public class Endpoint
     }
 
     /**
-     * Update accepted media types based on directions of
-     * {@link ChannelShim}s. An endpoint can accept
-     * media, if its {@link ChannelShim} has either
-     * 'sendrecv' or 'recvonly' media direction.
+     * Update accepted media types based on
+     * {@link ChannelShim} permission to receive
+     * media
      */
     public void updateAcceptedMediaTypes()
     {

--- a/src/main/java/org/jitsi/videobridge/EndpointConnectionStatus.java
+++ b/src/main/java/org/jitsi/videobridge/EndpointConnectionStatus.java
@@ -231,7 +231,7 @@ public class EndpointConnectionStatus
         Endpoint endpoint = (Endpoint) abstractEndpoint;
         String endpointId = endpoint.getID();
 
-        long mostRecentChannelCreated = endpoint.channelShims.stream()
+        long mostRecentChannelCreated = endpoint.getChannelShims().stream()
                 .mapToLong(ChannelShim::getCreationTimestampMs)
                 .max()
                 .orElse(0);

--- a/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
@@ -366,12 +366,24 @@ public class ChannelShim
     }
 
     /**
-     * Sets the direction of this channel.
+     * Get the media direction of this channel.
+     */
+    public String getDirection()
+    {
+        return this.direction;
+    }
+
+    /**
+     * Sets the media direction of this channel.
      * @param direction the direction to set.
      */
     public void setDirection(String direction)
     {
-        this.direction = direction;
+        if (!Objects.equals(this.direction, direction))
+        {
+            this.direction = direction;
+            this.endpoint.refreshMediaDirection();
+        }
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
@@ -382,7 +382,7 @@ public class ChannelShim
         if (!Objects.equals(this.direction, direction))
         {
             this.direction = direction;
-            this.endpoint.refreshMediaDirection();
+            this.endpoint.updateAcceptedMediaTypes();
         }
     }
 

--- a/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
@@ -366,11 +366,12 @@ public class ChannelShim
     }
 
     /**
-     * Get the media direction of this channel.
+     * Checks if this media channel allows receiving media
      */
-    public String getDirection()
+    public boolean allowsReceivingMedia()
     {
-        return this.direction;
+        return "sendrecv".equalsIgnoreCase(direction) ||
+            "recvonly".equalsIgnoreCase(direction);
     }
 
     /**


### PR DESCRIPTION
The `JVB 1.0` [allowed to update media direction of `RTPChannel`](https://github.com/jitsi/jitsi-videobridge/blob/c29af045ca7081dce457ebd25a025248cfda3a67/src/main/java/org/jitsi/videobridge/RtpChannel.java#L1381-L1399) during it's lifetime either directly or [via colibri](https://github.com/jitsi/jitsi-videobridge/blob/c29af045ca7081dce457ebd25a025248cfda3a67/src/main/java/org/jitsi/videobridge/Videobridge.java#L953-L954) request.

This ability was used in a project I'm working on to implement hold functionality: leave connection between client and JVB, but do not forward media to a client.
I hope it was not intentional design decision to remove such functionality from `JVB 2.0`, so I've implemented it for `JVB 2.0`.
