### PR TITLE
[ChannelShim::describe] Fill sourceGroup in channel IQ

### DIFF
--- a/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
@@ -251,6 +251,10 @@ public class ChannelShim
 
                 iq.setSSRCs(ssrcs);
             }
+
+            if (sourceGroups != null) {
+                sourceGroups.forEach(iq::addSourceGroup);
+            }
         }
     }
 


### PR DESCRIPTION
in JVB 2.0 in coparison with JVB 1.0 sourceGroup attribute is missing.