### PR TITLE
move the configuration of config source suppliers to another file

### DIFF
--- a/src/main/java/org/jitsi/videobridge/util/config/ConfigSupplierSettings.java
+++ b/src/main/java/org/jitsi/videobridge/util/config/ConfigSupplierSettings.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.util.config;
+
+import com.typesafe.config.*;
+import org.jitsi.utils.logging2.*;
+
+import java.nio.file.*;
+import java.util.function.*;
+
+public class ConfigSupplierSettings
+{
+    protected static Logger logger = new LoggerImpl(ConfigSupplierSettings.class.getName());
+    /**
+     * The supplier to load the new config.  Overridable for testing
+     */
+    public static Supplier<Config> configSupplier = ConfigFactory::load;
+
+    /**
+     * The supplier to load the legacy config.  Overridable for testing
+     */
+    public static Supplier<Config> legacyConfigSupplier = () -> {
+        String oldConfigHomeDirLocation = System.getProperty("net.java.sip.communicator.SC_HOME_DIR_LOCATION");
+        String oldConfigHomeDirName = System.getProperty("net.java.sip.communicator.SC_HOME_DIR_NAME");
+        try
+        {
+            Config config = ConfigFactory.parseFile(
+                Paths.get(oldConfigHomeDirLocation, oldConfigHomeDirName, "sip-communicator.properties")
+                    .toFile());
+            logger.info("Found a legacy config file: \n" + config.root().render());
+            return config;
+        }
+        catch (InvalidPathException | NullPointerException e)
+        {
+            logger.info("No legacy config file found");
+            return ConfigFactory.parseString("");
+        }
+    };
+
+    /**
+     * The supplier to load the command-line arguments.  Overridable for testing
+     */
+    public static Supplier<String[]> commandLineArgsSupplier = () -> new String[0];
+}

--- a/src/main/java/org/jitsi/videobridge/util/config/JvbConfig.java
+++ b/src/main/java/org/jitsi/videobridge/util/config/JvbConfig.java
@@ -22,8 +22,6 @@ import org.jitsi.utils.logging2.*;
 
 import java.util.*;
 
-import static org.jitsi.videobridge.util.config.ConfigSupplierSettings.*;
-
 /**
  * Helper class for retrieving configuration sources.  Currently, this supports reading config from
  * 1) Command line arguments
@@ -47,10 +45,10 @@ public class JvbConfig
 
     public static void loadConfig()
     {
-        legacyConfig = legacyConfigSupplier.get();
-        commandLineArgs = commandLineArgsSupplier.get();
+        legacyConfig = ConfigSupplierSettings.legacyConfigSupplier.get();
+        commandLineArgs = ConfigSupplierSettings.commandLineArgsSupplier.get();
 
-        config = configSupplier.get();
+        config = ConfigSupplierSettings.configSupplier.get();
         if (config.hasPath("videobridge"))
         {
             logger.info("Loaded JVB config: " + config.getConfig("videobridge").root().render());

--- a/src/main/java/org/jitsi/videobridge/util/config/JvbConfig.java
+++ b/src/main/java/org/jitsi/videobridge/util/config/JvbConfig.java
@@ -20,9 +20,9 @@ import com.typesafe.config.*;
 import org.jetbrains.annotations.*;
 import org.jitsi.utils.logging2.*;
 
-import java.nio.file.*;
 import java.util.*;
-import java.util.function.*;
+
+import static org.jitsi.videobridge.util.config.ConfigSupplierSettings.*;
 
 /**
  * Helper class for retrieving configuration sources.  Currently, this supports reading config from
@@ -40,37 +40,6 @@ public class JvbConfig
     protected static Config config;
     protected static Config legacyConfig;
     protected static String[] commandLineArgs;
-
-    /**
-     * The supplier to load the new config.  Overridable for testing
-     */
-    public static Supplier<Config> configSupplier = ConfigFactory::load;
-
-    /**
-     * The supplier to load the legacy config.  Overridable for testing
-     */
-    public static Supplier<Config> legacyConfigSupplier = () -> {
-        String oldConfigHomeDirLocation = System.getProperty("net.java.sip.communicator.SC_HOME_DIR_LOCATION");
-        String oldConfigHomeDirName = System.getProperty("net.java.sip.communicator.SC_HOME_DIR_NAME");
-        try
-        {
-            Config config = ConfigFactory.parseFile(
-                    Paths.get(oldConfigHomeDirLocation, oldConfigHomeDirName, "sip-communicator.properties")
-                            .toFile());
-            logger.info("Found a legacy config file: \n" + config.root().render());
-            return config;
-        }
-        catch (InvalidPathException | NullPointerException e)
-        {
-            logger.info("No legacy config file found");
-            return ConfigFactory.parseString("");
-        }
-    };
-
-    /**
-     * The supplier to load the command-line arguments.  Overridable for testing
-     */
-    public static Supplier<String[]> commandLineArgsSupplier = () -> new String[0];
 
     static {
         loadConfig();

--- a/src/test/java/org/jitsi/testutils/ConfigSetup.java
+++ b/src/test/java/org/jitsi/testutils/ConfigSetup.java
@@ -69,7 +69,7 @@ public class ConfigSetup
         // Make sure config doesn't see any command line args from a previous setup
         if (commandLineArgs.isEmpty())
         {
-            ConfigSupplierSettings.commandLineArgsSupplier =() -> new String[0];
+            ConfigSupplierSettings.commandLineArgsSupplier = () -> new String[0];
         }
         else
         {

--- a/src/test/java/org/jitsi/testutils/ConfigSetup.java
+++ b/src/test/java/org/jitsi/testutils/ConfigSetup.java
@@ -69,14 +69,14 @@ public class ConfigSetup
         // Make sure config doesn't see any command line args from a previous setup
         if (commandLineArgs.isEmpty())
         {
-            JvbConfig.commandLineArgsSupplier =() -> new String[0];
+            ConfigSupplierSettings.commandLineArgsSupplier =() -> new String[0];
         }
         else
         {
-            JvbConfig.commandLineArgsSupplier = () -> commandLineArgs.toArray(new String[0]);
+            ConfigSupplierSettings.commandLineArgsSupplier = () -> commandLineArgs.toArray(new String[0]);
         }
-        JvbConfig.legacyConfigSupplier = legacyConfigSupplier;
-        JvbConfig.configSupplier = newConfigSupplier;
+        ConfigSupplierSettings.legacyConfigSupplier = legacyConfigSupplier;
+        ConfigSupplierSettings.configSupplier = newConfigSupplier;
 
         JvbConfig.reloadConfig();
     }


### PR DESCRIPTION
i noticed this when working on another PR when i tried setting the
command-line args supplier to include the args given in main.  the
problem was that, since JvbConfig loaded the config in a static block,
any access on JvbConfig would trigger it--this includes setting a
supplier.  for the command-line args case, this means that when you
called JvbConfig.commandLineArgsSupplier = ..., the config would load
and log that no command line args were present (since the assignment was
not yet complete) which was misleading.  it also had the annoying
behavior of dumping any default-loaded config during tests when the
suppliers were overriden.

by separating that config out, we can manipulate the config source
suppliers without triggering a loading of the config, which makes more
sense.