### PR TITLE
Move to new PacketIOActivity fields based on Instant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-media-transform</artifactId>
-      <version>1.0-62-g32dc524</version>
+      <version>1.0-63-g2a8ef9f</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge;
 
+import org.jitsi.nlj.util.*;
 import org.jitsi.utils.*;
 import org.jitsi.utils.event.*;
 import org.jitsi.utils.logging2.*;
@@ -23,6 +24,7 @@ import org.jitsi_modified.impl.neomedia.rtp.*;
 import org.json.simple.*;
 
 import java.io.*;
+import java.time.*;
 import java.util.*;
 
 /**
@@ -244,9 +246,9 @@ public abstract class AbstractEndpoint extends PropertyChangeNotifier
      * Get the last 'activity' (packets received or packets sent) this endpoint has seen
      * @return the timestamp, in milliseconds, of the last activity of this endpoint
      */
-    public long getLastActivity()
+    public Instant getLastActivity()
     {
-        return 0;
+        return ClockUtils.NEVER;
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -31,9 +31,7 @@ import org.jitsi.rtp.rtp.*;
 import org.jitsi.utils.concurrent.*;
 import org.jitsi.utils.logging.*;
 import org.jitsi.utils.*;
-import org.jitsi.utils.logging2.*;
 import org.jitsi.utils.logging2.Logger;
-import org.jitsi.utils.logging2.LoggerImpl;
 import org.jitsi.videobridge.cc.*;
 import org.jitsi.videobridge.datachannel.*;
 import org.jitsi.videobridge.datachannel.protocol.*;
@@ -104,7 +102,7 @@ public class Endpoint
     /**
      * The time at which this endpoint was created (in millis since epoch)
      */
-    private final Instant creationTimeMillis;
+    private final Instant creationTime;
 
     /**
      * How long we'll give an endpoint to either successfully establish
@@ -229,7 +227,7 @@ public class Endpoint
 
         this.clock = clock;
 
-        creationTimeMillis = clock.instant();
+        creationTime = clock.instant();
         diagnosticContext = conference.newDiagnosticContext();
         transceiver = new Transceiver(
             id,
@@ -238,7 +236,7 @@ public class Endpoint
             TaskPools.SCHEDULED_POOL,
             diagnosticContext,
             logger,
-            Clock.systemUTC()
+            clock
         );
         transceiver.setIncomingPacketHandler(
             new ConsumerNode("receiver chain handler")
@@ -631,7 +629,7 @@ public class Endpoint
         Instant now = clock.instant();
         if (lastActivity == ClockUtils.NEVER)
         {
-            Duration timeSinceCreation = Duration.between(creationTimeMillis, now);
+            Duration timeSinceCreation = Duration.between(creationTime, now);
             if (timeSinceCreation.compareTo(EP_TIMEOUT) > 0) {
                 logger.info("Endpoint's ICE connection has neither failed nor connected " +
                     "after " + timeSinceCreation + ", expiring");

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -580,11 +580,11 @@ public class Endpoint
      * {@inheritDoc}
      */
     @Override
-    public long getLastActivity()
+    public Instant getLastActivity()
     {
         PacketIOActivity packetIOActivity
                 = this.transceiver.getPacketIOActivity();
-        return packetIOActivity.getLatestOverallActivity().toEpochMilli();
+        return packetIOActivity.getLatestOverallActivity();
     }
 
     /**
@@ -1298,13 +1298,12 @@ public class Endpoint
     /**
      * @return  the timestamp of the most recently created channel shim.
      */
-    long getMostRecentChannelCreatedTime()
+    Instant getMostRecentChannelCreatedTime()
     {
         return channelShims.stream()
             .map(ChannelShim::getCreationTimestamp)
             .max(Comparator.comparing(Function.identity()))
-            .orElse(ClockUtils.NEVER)
-            .toEpochMilli();
+            .orElse(ClockUtils.NEVER);
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -23,8 +23,7 @@ import org.jitsi.nlj.rtp.bandwidthestimation.*;
 import org.jitsi.nlj.srtp.*;
 import org.jitsi.nlj.stats.*;
 import org.jitsi.nlj.transform.node.*;
-import org.jitsi.nlj.util.LocalSsrcAssociation;
-import org.jitsi.nlj.util.RemoteSsrcAssociation;
+import org.jitsi.nlj.util.*;
 import org.jitsi.rtp.*;
 import org.jitsi.rtp.rtcp.*;
 import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.*;
@@ -55,6 +54,7 @@ import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
+import java.util.function.*;
 
 import static org.jitsi.videobridge.EndpointMessageBuilder.*;
 
@@ -1301,9 +1301,10 @@ public class Endpoint
     long getMostRecentChannelCreatedTime()
     {
         return channelShims.stream()
-                .mapToLong(ChannelShim::getCreationTimestampMs)
-                .max()
-                .orElse(0);
+            .map(ChannelShim::getCreationTimestamp)
+            .max(Comparator.comparing(Function.identity()))
+            .orElse(ClockUtils.NEVER)
+            .toEpochMilli();
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
@@ -25,6 +25,7 @@ import org.jitsi.videobridge.util.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jitsi.xmpp.extensions.jingle.*;
 
+import java.time.*;
 import java.util.*;
 
 /**
@@ -164,9 +165,9 @@ public class ChannelShim
      * Gets this channel's creation timestamp.
      * @return
      */
-    public long getCreationTimestampMs()
+    public Instant getCreationTimestamp()
     {
-        return creationTimestampMs;
+        return Instant.ofEpochMilli(creationTimestampMs);
     }
 
     /**

--- a/src/test/java/org/jitsi/videobridge/EndpointConnectionStatusTest.java
+++ b/src/test/java/org/jitsi/videobridge/EndpointConnectionStatusTest.java
@@ -19,26 +19,28 @@ package org.jitsi.videobridge;
 import org.jitsi.testutils.*;
 import org.junit.*;
 
+import java.time.*;
+
 public class EndpointConnectionStatusTest
 {
     @Test
     public void testFirstTransferTimePropertyConfig()
     {
-        ConfigPropertyTest<EndpointConnectionStatus.Config.FirstTransferTimeoutProperty, Long>
+        ConfigPropertyTest<EndpointConnectionStatus.Config.FirstTransferTimeoutProperty, Duration>
             configPropertyTest = new ConfigPropertyTest<>();
 
         configPropertyTest.runBasicTests(
             EndpointConnectionStatus.Config.FirstTransferTimeoutProperty.legacyPropName,
-            new ConfigPropertyTest.ParamResult<>("5000", 5000L),
+            new ConfigPropertyTest.ParamResult<>("5000", Duration.ofSeconds(5)),
             EndpointConnectionStatus.Config.FirstTransferTimeoutProperty.propName,
-            new ConfigPropertyTest.ParamResult<>("10 seconds", 10000L),
+            new ConfigPropertyTest.ParamResult<>("10 seconds", Duration.ofSeconds(10)),
             EndpointConnectionStatus.Config.FirstTransferTimeoutProperty::new
         );
 
         configPropertyTest.runReadOnceTest(
             EndpointConnectionStatus.Config.FirstTransferTimeoutProperty.propName,
-            new ConfigPropertyTest.ParamResult<>("5 seconds", 5000L),
-            new ConfigPropertyTest.ParamResult<>("15 seconds", 15000L),
+            new ConfigPropertyTest.ParamResult<>("5 seconds", Duration.ofSeconds(5)),
+            new ConfigPropertyTest.ParamResult<>("15 seconds", Duration.ofSeconds(15)),
             EndpointConnectionStatus.Config.FirstTransferTimeoutProperty::new
         );
     }
@@ -46,21 +48,21 @@ public class EndpointConnectionStatusTest
     @Test
     public void testMaxInactivityLimitProperty()
     {
-        ConfigPropertyTest<EndpointConnectionStatus.Config.MaxInactivityLimitProperty, Long>
+        ConfigPropertyTest<EndpointConnectionStatus.Config.MaxInactivityLimitProperty, Duration>
             configPropertyTest = new ConfigPropertyTest<>();
 
         configPropertyTest.runBasicTests(
             EndpointConnectionStatus.Config.MaxInactivityLimitProperty.legacyPropName,
-            new ConfigPropertyTest.ParamResult<>("5000", 5000L),
+            new ConfigPropertyTest.ParamResult<>("5000", Duration.ofSeconds(5)),
             EndpointConnectionStatus.Config.MaxInactivityLimitProperty.propName,
-            new ConfigPropertyTest.ParamResult<>("10 seconds", 10000L),
+            new ConfigPropertyTest.ParamResult<>("10 seconds", Duration.ofSeconds(10)),
             EndpointConnectionStatus.Config.MaxInactivityLimitProperty::new
         );
 
         configPropertyTest.runReadOnceTest(
             EndpointConnectionStatus.Config.MaxInactivityLimitProperty.propName,
-            new ConfigPropertyTest.ParamResult<>("5 seconds", 5000L),
-            new ConfigPropertyTest.ParamResult<>("15 seconds", 15000L),
+            new ConfigPropertyTest.ParamResult<>("5 seconds", Duration.ofSeconds(5)),
+            new ConfigPropertyTest.ParamResult<>("15 seconds", Duration.ofSeconds(15)),
             EndpointConnectionStatus.Config.MaxInactivityLimitProperty::new
         );
     }


### PR DESCRIPTION
Fun fact: `Instant.MIN`, which we use for our definition of `NEVER` is unable to be converted to a number of milliseconds-since-epoch.  This is probably good for `NEVER`, but broke some things here, so had to migrate away from the usage of the old properties and use `Instant` everywhere.

I think `EndpointConnectionStatus` could really use a unit test for its logic, but it'll need to be refactored so we can swap in a fake executor service, etc. so left that for future work.