### PR TITLE
Track SCTP packet activity

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -560,6 +560,8 @@ public class Endpoint
      */
     void dtlsAppPacketReceived(PacketInfo dtlsAppPacket)
     {
+        getTransceiver().getPacketIOActivity()
+            .setLastSctpPacketReceivedTimestamp(clock.instant());
         sctpHandler.consume(dtlsAppPacket);
     }
 
@@ -756,6 +758,8 @@ public class Endpoint
         // Create the SctpManager and provide it a method for sending SCTP data
         this.sctpManager = new SctpManager(
                 (data, offset, length) -> {
+                    getTransceiver().getPacketIOActivity()
+                        .setLastSctpPacketSentTimestamp(clock.instant());
                     PacketInfo packet
                         = new PacketInfo(new UnparsedPacket(data, offset, length));
                     dtlsTransport.sendDtlsData(packet);


### PR DESCRIPTION
This PR adds fields to track last SCTP activity, which is necessary to more precisely track connectivity status - endpoint having only SCTP activity will not be treated as having connection issue.
Depend on: https://github.com/jitsi/jitsi-media-transform/pull/151