### PR TITLE
use new legacy config service shim, remove libjitsi dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <smack.version>4.2.4-47d17fc</smack.version>
     <jitsi.utils.version>1.0-24-g8f17c70</jitsi.utils.version>
-    <jicoco.version>1.1-SNAPSHOT</jicoco.version>
+    <jicoco.version>1.1-12-g2b135ca</jicoco.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <smack.version>4.2.4-47d17fc</smack.version>
     <jitsi.utils.version>1.0-24-g8f17c70</jitsi.utils.version>
-    <jicoco.version>1.1-9-gffbb6dd</jicoco.version>
+    <jicoco.version>1.1-SNAPSHOT</jicoco.version>
   </properties>
 
   <dependencyManagement>
@@ -139,12 +139,6 @@
       <artifactId>jitsi-utils-kotlin</artifactId>
       <version>${jitsi.utils.version}</version>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>libjitsi</artifactId>
-      <version>1.0-4-g07f0dfa</version>
-    </dependency>
-
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -1084,7 +1084,7 @@ public class Videobridge
         if (cfg != null)
         {
             List<String> ice4jPropertyNames
-                = cfg.getPropertyNamesByPrefix("org.ice4j.", false);
+                = cfg.getPropertyNamesByPrefix("org.ice4j", false);
 
             if (ice4jPropertyNames != null && !ice4jPropertyNames.isEmpty())
             {

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -979,7 +979,7 @@ public class Videobridge
         if (cfg != null)
         {
             List<String> ice4jPropertyNames
-                = cfg.getPropertyNamesByPrefix("org.ice4j.", false);
+                = cfg.getPropertyNamesByPrefix("org.ice4j", false);
 
             if (ice4jPropertyNames != null && !ice4jPropertyNames.isEmpty())
             {

--- a/src/main/java/org/jitsi/videobridge/osgi/BundleConfig.java
+++ b/src/main/java/org/jitsi/videobridge/osgi/BundleConfig.java
@@ -15,12 +15,12 @@
  */
 package org.jitsi.videobridge.osgi;
 
-import java.util.*;
 import org.ice4j.*;
 import org.ice4j.ice.harvest.*;
 import org.jitsi.meet.*;
 import org.jitsi.stats.media.*;
-import org.jitsi.videobridge.xmpp.*;
+
+import java.util.*;
 
 /**
  * OSGi bundles description for the Jitsi Videobridge.
@@ -42,9 +42,6 @@ public class BundleConfig
         = {
         {
             "org/jitsi/eventadmin/Activator"
-        },
-        {
-            "org/jitsi/service/libjitsi/LibJitsiActivator"
         },
         {
             "org/jitsi/videobridge/osgi/ConfigurationActivator"

--- a/src/main/java/org/jitsi/videobridge/osgi/ConfigurationActivator.java
+++ b/src/main/java/org/jitsi/videobridge/osgi/ConfigurationActivator.java
@@ -15,13 +15,13 @@
  */
 package org.jitsi.videobridge.osgi;
 
+import org.jitsi.config.*;
 import org.jitsi.service.configuration.*;
-import org.jitsi.service.libjitsi.*;
 import org.jitsi.utils.logging2.*;
 import org.osgi.framework.*;
 
 /**
- * Registers LibJitsi's configuration service.
+ * Registers the legacy configuration service shim
  *
  * @author Boris Grozev
  */
@@ -37,19 +37,12 @@ public class ConfigurationActivator
     @Override
     public void start(BundleContext bundleContext)
     {
-        ConfigurationService cfg = LibJitsi.getConfigurationService();
-        if (cfg != null)
-        {
-            bundleContext.registerService(
-                    ConfigurationService.class.getName(),
-                    cfg,
-                    null);
-            logger.info("Registered the LibJitsi ConfigurationService in OSGi.");
-        }
-        else
-        {
-            logger.warn("Failed to register the Configuration service.");
-        }
+        ConfigurationService cfg = new LegacyConfigurationServiceShim();
+        bundleContext.registerService(
+            ConfigurationService.class.getName(),
+            cfg,
+            null);
+        logger.info("Registered the LegacyConfigurationServiceShim in OSGi.");
     }
 
     @Override

--- a/src/main/java/org/jitsi/videobridge/osgi/ConfigurationActivator.java
+++ b/src/main/java/org/jitsi/videobridge/osgi/ConfigurationActivator.java
@@ -37,10 +37,9 @@ public class ConfigurationActivator
     @Override
     public void start(BundleContext bundleContext)
     {
-        ConfigurationService cfg = new LegacyConfigurationServiceShim();
         bundleContext.registerService(
             ConfigurationService.class.getName(),
-            cfg,
+            JitsiConfig.getLegacyConfigShim(),
             null);
         logger.info("Registered the LegacyConfigurationServiceShim in OSGi.");
     }

--- a/src/test/java/org/jitsi/videobridge/BridgeShutdownTest.java
+++ b/src/test/java/org/jitsi/videobridge/BridgeShutdownTest.java
@@ -15,14 +15,12 @@
  */
 package org.jitsi.videobridge;
 
+import org.jitsi.config.*;
 import org.jitsi.meet.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jivesoftware.smack.packet.*;
-import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.util.*;
-
 import org.junit.*;
-
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.impl.*;
 import org.xmlpull.v1.*;
@@ -56,6 +54,7 @@ public class BridgeShutdownTest
         System.setProperty(
             Videobridge.SHUTDOWN_ALLOWED_SOURCE_REGEXP_PNAME,
             "focus.*");
+        JitsiConfig.Companion.reload();
 
         osgiHandler.start();
 


### PR DESCRIPTION
This change installs the legacy configuration service shim defined in jicoco  as the supplier for `ConfigurationService`, removing the need for libjitsi in JVB 💥  

Depends on https://github.com/jitsi/jicoco/pull/61