### PR TITLE
Updates the bitrate controller when an OctoEndpoint's tracks change.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 **/.idea/
 *.iml
 .mvn/
+.kotlintest

--- a/src/main/java/org/jitsi/videobridge/octo/OctoTentacle.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoTentacle.java
@@ -223,10 +223,10 @@ public class OctoTentacle extends PropertyChangeNotifier implements PotentialPac
                     .filter(Objects::nonNull)
                     .collect(Collectors.toSet());
 
-        if (octoEndpoints.setEndpoints(endpointIds))
-        {
-            conference.endpointTracksChanged(null);
-        }
+        // We only need to call this if the tracks of any endpoint actually
+        // changed, but that's not easy to detect. It's safe to call it more
+        // often.
+        conference.endpointTracksChanged(null);
 
         endpointIds.forEach(endpointId ->
         {


### PR DESCRIPTION
We used to only trigger an update when the list of endpoint change. We also need to call it when the tracks of an existing endpoint change (which happens when presenter mode is enabled or disabled in jitsi-meet).