### PR TITLE
force a reload of the config after setting system properties

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Main.java
+++ b/src/main/java/org/jitsi/videobridge/Main.java
@@ -16,6 +16,7 @@
 package org.jitsi.videobridge;
 
 import org.jitsi.cmd.*;
+import org.jitsi.config.*;
 import org.jitsi.meet.*;
 import org.jitsi.videobridge.osgi.*;
 import org.jitsi.videobridge.xmpp.*;
@@ -134,6 +135,9 @@ public class Main
         System.setProperty(
                 Videobridge.XMPP_API_PNAME,
                 Boolean.toString(apis.contains(Videobridge.XMPP_API)));
+
+        // Need to force a reload to see the updated system properties
+        JitsiConfig.Companion.reload();
 
         ComponentMain main = new ComponentMain();
         BundleConfig osgiBundles = new BundleConfig();

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -18,6 +18,7 @@ package org.jitsi.videobridge;
 import kotlin.*;
 import org.ice4j.ice.harvest.*;
 import org.ice4j.stack.*;
+import org.jitsi.config.*;
 import org.jitsi.eventadmin.*;
 import org.jitsi.meet.*;
 import org.jitsi.nlj.*;
@@ -1015,6 +1016,8 @@ public class Videobridge
                     System.setProperty(newPropertyName, propertyValue);
                 }
             }
+            // Reload for all the new system properties to be seen
+            JitsiConfig.Companion.reload();
         }
 
         // Initialize the the host candidate interface filters in the ice4j


### PR DESCRIPTION
the config library caches the results, so to see new values we need to
reload.