### PR TITLE
change rest api sys prop name

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -115,9 +115,16 @@ public class Videobridge
     /**
      * The (base) <tt>System</tt> and/or <tt>ConfigurationService</tt> property
      * of the REST-like HTTP/JSON API of Jitsi Videobridge.
+     *
+     * NOTE: Previously, the rest API name ("org.jitsi.videobridge.rest")
+     * conflicted with other values in the new config, since we have
+     * other properties scoped *under* "org.jitsi.videobridge.rest".   The
+     * long term solution will be to port the command-line args to new config,
+     * but for now we rename the property used to signal the rest API is
+     * enabled so it doesn't conflict.
      */
     public static final String REST_API_PNAME
-        = "org.jitsi.videobridge." + REST_API;
+        = "org.jitsi.videobridge." + REST_API + "_api_temp";
 
     /**
      * The property that specifies allowed entities for turning on graceful


### PR DESCRIPTION
The new config converts .properties values into a HOCON object, which is slightly lossy compared to a properties file. For example, in a properties like so:
```
a.b.c = true
a.b.c.d = 42
```
Is fine, but in a HOCON object there's an issue: `a.b.c` has to be one of the two values (a boolean or an object), so the value of `a.b.c` ends up as an object, making it impossible to test as a boolean.

This scenario was happening with `org.jitsi.videobridge.rest`.  Soon, we'll port the handling of the API properties to new config, but for now we'll change the value so there's no conflict.