### PR TITLE
Fix encodings manager exception

### DIFF
--- a/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -38,7 +38,6 @@ import java.util.*;
  * @author Brian Baldino
  */
 public abstract class AbstractEndpoint extends PropertyChangeNotifier
-    implements EncodingsManager.EncodingsUpdateListener
 {
     /**
      * The (unique) identifier/ID of the endpoint of a participant in a

--- a/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -86,8 +86,6 @@ public abstract class AbstractEndpoint extends PropertyChangeNotifier
         context.put("epId", id);
         logger = parentLogger.createChildLogger(this.getClass().getName(), context);
         this.id = Objects.requireNonNull(id, "id");
-
-        conference.encodingsManager.subscribe(this);
     }
 
     /**
@@ -228,7 +226,6 @@ public abstract class AbstractEndpoint extends PropertyChangeNotifier
         if (conference != null)
         {
             conference.endpointExpired(this);
-            conference.encodingsManager.unsubscribe(this);
         }
     }
 

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -65,7 +65,8 @@ import static org.jitsi.videobridge.EndpointMessageBuilder.*;
  * @author George Politis
  */
 public class Endpoint
-    extends AbstractEndpoint implements PotentialPacketHandler
+    extends AbstractEndpoint implements PotentialPacketHandler,
+    EncodingsManager.EncodingsUpdateListener
 {
     /**
      * The name of the <tt>Endpoint</tt> property <tt>pinnedEndpoint</tt> which

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -268,6 +268,7 @@ public class Endpoint
             bitrateController.bandwidthChanged((long)newValueBps.getBps());
         });
         transceiver.onBandwidthEstimateChanged(bandwidthProbing);
+        conference.encodingsManager.subscribe(this);
 
         bandwidthProbing.enabled = true;
         recurringRunnableExecutor.registerRecurringRunnable(bandwidthProbing);
@@ -690,6 +691,7 @@ public class Endpoint
         }
         bandwidthProbing.enabled = false;
         recurringRunnableExecutor.deRegisterRecurringRunnable(bandwidthProbing);
+        getConference().encodingsManager.unsubscribe(this);
 
         dtlsTransport.close();
 

--- a/src/main/java/org/jitsi/videobridge/octo/OctoEndpoint.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoEndpoint.java
@@ -111,7 +111,14 @@ public class OctoEndpoint
             long secondarySsrc,
             SsrcAssociationType type)
     {
-        /* Octo endpoints don't care about SSRC associations. */
+        if (epId.equalsIgnoreCase(getID()))
+        {
+            streamInformationStore.addSsrcAssociation(new LocalSsrcAssociation(primarySsrc, secondarySsrc, type));
+        }
+        else
+        {
+            streamInformationStore.addSsrcAssociation(new RemoteSsrcAssociation(primarySsrc, secondarySsrc, type));
+        }
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/octo/OctoEndpoint.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoEndpoint.java
@@ -104,23 +104,6 @@ public class OctoEndpoint
         return l.toArray(new MediaStreamTrackDesc[0]);
     }
 
-    @Override
-    public void onNewSsrcAssociation(
-            String epId,
-            long primarySsrc,
-            long secondarySsrc,
-            SsrcAssociationType type)
-    {
-        if (epId.equalsIgnoreCase(getID()))
-        {
-            streamInformationStore.addSsrcAssociation(new LocalSsrcAssociation(primarySsrc, secondarySsrc, type));
-        }
-        else
-        {
-            streamInformationStore.addSsrcAssociation(new RemoteSsrcAssociation(primarySsrc, secondarySsrc, type));
-        }
-    }
-
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
https://github.com/jitsi/jitsi-videobridge/pull/1005 caused an exception because we subscribed to encodingManager notifications before the constructor completed.