### PR TITLE
Migrate to using mucs for jvb

### DIFF
--- a/lib/logging.properties
+++ b/lib/logging.properties
@@ -23,3 +23,5 @@ com.agafua.syslog.SyslogHandler.escapeNewlines = false
 
 # to disable double timestamps in syslog uncomment next line
 #net.java.sip.communicator.util.ScLogFormatter.disableTimestamp=true
+
+org.jitsi.xmpp.mucclient.MucClientManager.level=SEVERE

--- a/resources/install/debian/control
+++ b/resources/install/debian/control
@@ -10,7 +10,7 @@ Homepage: https://jitsi.org/videobridge
 Package: jitsi-videobridge
 Architecture: any
 Pre-Depends: openjdk-8-jre-headless | openjdk-11-jre-headless
-Depends: ${misc:Depends}, procps
+Depends: ${misc:Depends}, procps, uuid-runtime
 Description: WebRTC compatible Selective Forwarding Unit (SFU)
  Jitsi Videobridge is a WebRTC compatible Selective Forwarding Unit
  (SFU) for multiuser video communication. It is an essential part

--- a/resources/install/debian/postinst
+++ b/resources/install/debian/postinst
@@ -56,7 +56,7 @@ case "$1" in
             echo "JVB_SECRET=$JVB_SECRET" >> $CONFIG
             echo >> $CONFIG
             echo '# extra options to pass to the JVB daemon' >> $CONFIG
-            echo "JVB_OPTS=\"\"" >> $CONFIG
+            echo "JVB_OPTS=\"--apis=rest\"" >> $CONFIG
             echo >> $CONFIG
 
         fi
@@ -96,8 +96,23 @@ case "$1" in
         # and this breaks startup script
         sed -i 's/\$JVB_EXTRA_JVM_PARAMS//g' $CONFIG
 
-        if ! grep -q "org.jitsi.videobridge.AUTHORIZED_SOURCE_REGEXP" "$NEW_JITSI_CONFIG" ;then
-            echo "org.jitsi.videobridge.AUTHORIZED_SOURCE_REGEXP=focus@auth.${JVB_HOSTNAME}/.*" >> $NEW_JITSI_CONFIG
+        if ! grep -q "#org.jitsi.videobridge.AUTHORIZED_SOURCE_REGEXP" "$NEW_JITSI_CONFIG" ;then
+            sed -i 's/org.jitsi.videobridge.AUTHORIZED_SOURCE_REGEXP/#org.jitsi.videobridge.AUTHORIZED_SOURCE_REGEXP/g' $NEW_JITSI_CONFIG
+        fi
+
+        if ! grep -q "org.jitsi.videobridge.xmpp.user.shard.MUC_JIDS" "$NEW_JITSI_CONFIG" ;then
+            echo "org.jitsi.videobridge.ENABLE_STATISTICS=true" >> $NEW_JITSI_CONFIG
+            echo "org.jitsi.videobridge.STATISTICS_TRANSPORT=muc" >> $NEW_JITSI_CONFIG
+            echo "org.jitsi.videobridge.xmpp.user.shard.HOSTNAME=localhost" >> $NEW_JITSI_CONFIG
+            echo "org.jitsi.videobridge.xmpp.user.shard.DOMAIN=auth.$JVB_HOSTNAME" >> $NEW_JITSI_CONFIG
+            echo "org.jitsi.videobridge.xmpp.user.shard.USERNAME=jvb" >> $NEW_JITSI_CONFIG
+            echo "org.jitsi.videobridge.xmpp.user.shard.PASSWORD=$JVB_SECRET" >> $NEW_JITSI_CONFIG
+            echo "org.jitsi.videobridge.xmpp.user.shard.MUC_JIDS=JvbBrewery@internal.auth.$JVB_HOSTNAME" >> $NEW_JITSI_CONFIG
+            echo "org.jitsi.videobridge.xmpp.user.shard.MUC_NICKNAME=$(uuidgen)" >> $NEW_JITSI_CONFIG
+        fi
+
+        if ! grep -q "--apis=rest" "$CONFIG" ;then
+            sed -i 's/JVB_OPTS=\"\"/JVB_OPTS=\"--apis=rest\"/g' $CONFIG
         fi
 
         # we don't want to start the daemon as root

--- a/resources/install/debian/postinst
+++ b/resources/install/debian/postinst
@@ -56,7 +56,7 @@ case "$1" in
             echo "JVB_SECRET=$JVB_SECRET" >> $CONFIG
             echo >> $CONFIG
             echo '# extra options to pass to the JVB daemon' >> $CONFIG
-            echo "JVB_OPTS=\"--apis=rest\"" >> $CONFIG
+            echo "JVB_OPTS=\"--apis=,\"" >> $CONFIG
             echo >> $CONFIG
 
         fi
@@ -111,8 +111,8 @@ case "$1" in
             echo "org.jitsi.videobridge.xmpp.user.shard.MUC_NICKNAME=$(uuidgen)" >> $NEW_JITSI_CONFIG
         fi
 
-        if ! grep -q "--apis=rest" "$CONFIG" ;then
-            sed -i 's/JVB_OPTS=\"\"/JVB_OPTS=\"--apis=rest\"/g' $CONFIG
+        if ! grep -q "--apis=," "$CONFIG" ;then
+            sed -i 's/JVB_OPTS=\"\"/JVB_OPTS=\"--apis=,\"/g' $CONFIG
         fi
 
         # we don't want to start the daemon as root


### PR DESCRIPTION
Not sure which one to merge first, I think tests that test the debian package deployment will fail till we have all 3 components jitsi-meet, jicofo and jvb changes merged.
Once this is merged I will cherry-pick it for jvb2.

https://github.com/jitsi/jitsi-meet/pull/4956
https://github.com/jitsi/jicofo/pull/413