### PR TITLE
When projecting VideoRtpPackets that aren't ParsedVideoPackets, don't wait for keyframes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-media-transform</artifactId>
-      <version>1.0-72-ga759af5</version>
+      <version>1.0-75-g9d471d4</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/cc/GenericAdaptiveTrackProjectionContext.java
+++ b/src/main/java/org/jitsi/videobridge/cc/GenericAdaptiveTrackProjectionContext.java
@@ -157,7 +157,17 @@ class GenericAdaptiveTrackProjectionContext
         boolean accept;
         if (needsKeyframe)
         {
-            if (rtpPacket.isKeyframe())
+            if (!(rtpPacket instanceof ParsedVideoPacket))
+            {
+                /* We don't know how to parse this packet's codec type, so
+                 * isKeyframe will never be true.  The best we can do is
+                 * to start forwarding it immediately.  Hopefully the receiver
+                 * will send a PLI/FIR if it needs a keyframe.
+                 */
+                needsKeyframe = false;
+                accept = true;
+            }
+            else if (((ParsedVideoPacket)rtpPacket).isKeyframe())
             {
                 needsKeyframe = false;
                 // resume after being suspended, we compute the new seqnum delta


### PR DESCRIPTION
Since we'll never see one.

(This updates JVB for recent JMT API changes.)