### PR TITLE
Populate source and source groups from all channel when tracks are re-created.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1167,17 +1167,19 @@ public class Endpoint
     @Override
     public void recreateMediaStreamTracks()
     {
-        final Stream<ChannelShim> videoChannels = channelShims
+        final Supplier<Stream<ChannelShim>> videoChannels = () -> channelShims
             .stream()
             .filter(c -> MediaType.VIDEO.equals(c.getMediaType()));
 
         final List<SourcePacketExtension> sources = videoChannels
+            .get()
             .map(ChannelShim::getSources)
             .filter(Objects::nonNull)
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
 
         final List<SourceGroupPacketExtension> sourceGroups = videoChannels
+            .get()
             .map(ChannelShim::getSourceGroups)
             .filter(Objects::nonNull)
             .flatMap(Collection::stream)

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1170,8 +1170,16 @@ public class Endpoint
         final ArrayList<SourcePacketExtension> sources = new ArrayList<>();
         for (ChannelShim channelShim : channelShims) {
             if (MediaType.VIDEO.equals(channelShim.getMediaType())) {
-                sourceGroups.addAll(channelShim.getSourceGroups());
-                sources.addAll(channelShim.getSources());
+                final Collection<SourceGroupPacketExtension> channelSourceGroups
+                    = channelShim.getSourceGroups();
+                if (channelSourceGroups != null) {
+                    sourceGroups.addAll(channelSourceGroups);
+                }
+                final Collection<SourcePacketExtension> channelSources
+                    = channelShim.getSources();
+                if (channelSources != null) {
+                    sources.addAll(channelSources);
+                }
             }
         }
 

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1166,33 +1166,22 @@ public class Endpoint
     @Override
     public void recreateMediaStreamTracks()
     {
-        ChannelShim videoChannel = getChannelOfMediaType(MediaType.VIDEO);
-        if (videoChannel != null)
-        {
+        final ArrayList<SourceGroupPacketExtension> sourceGroups = new ArrayList<>();
+        final ArrayList<SourcePacketExtension> sources = new ArrayList<>();
+        for (ChannelShim channelShim : channelShims) {
+            if (MediaType.VIDEO.equals(channelShim.getMediaType())) {
+                sourceGroups.addAll(channelShim.getSourceGroups());
+                sources.addAll(channelShim.getSources());
+            }
+        }
+
+        if (!sources.isEmpty() || !sourceGroups.isEmpty()) {
             MediaStreamTrackDesc[] tracks =
-                    MediaStreamTrackFactory.createMediaStreamTracks(
-                            videoChannel.getSources(),
-                            videoChannel.getSourceGroups());
+                MediaStreamTrackFactory.createMediaStreamTracks(
+                    sources,
+                    sourceGroups);
             setMediaStreamTracks(tracks);
         }
-    }
-
-    /**
-     * Gets this {@link AbstractEndpoint}'s channel of media type
-     * {@code mediaType} (although it's not strictly enforced, endpoints have
-     * at most one channel with a given media type).
-     *
-     * @param mediaType the media type of the channel.
-     *
-     * @return the channel.
-     */
-    private ChannelShim getChannelOfMediaType(MediaType mediaType)
-    {
-        return
-                channelShims.stream()
-                        .filter(c -> c.getMediaType().equals(mediaType))
-                        .findAny().orElse(null);
-
     }
 
     /**


### PR DESCRIPTION
Not sure if this PR is valid according to JVB design, but at least it could serve as my question regarding proper scenario handling described below:

I want to have multiple video streams from single endpoint, for example in scenario when both screen sharing and camera are turned on.
There are two options to achieve this via Colibri request:
1. Have single endpoint with multiple video channels each having it's own ssrc/ssrc groups signaled;
2. Have single endpoint with single video channel, but multiple ssrcs/ssrc groups signaled for that channel.

1 option does not properly work due to current `recreateMediaStreamTracks` implementation, with this PR both options should work well.

For me it would be convenient if option 1 also work. 
What do you think about the change (it should not break any existing code)? 
What is a "official" way to handle scenario of multiple audio/video streams from single endpoint?