### PR TITLE
Fixed weak reference NPE.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
@@ -346,12 +346,10 @@ public class AdaptiveTrackProjection
     {
         if (context == null)
         {
-            MediaStreamTrackDesc track = getSource();
-            long ssrc = track.getRTPEncodings()[0].getPrimarySSRC();
             // TODO If '1' are the starting seq number and timestamp, should
             // we use random values?
             return new RtpState(
-                ssrc,
+                this.targetSsrc,
                 1 /* maxSequenceNumber */,
                 1 /* maxTimestamp */) ;
         }


### PR DESCRIPTION
With a [object retention fix](https://github.com/jitsi/jitsi-videobridge/pull/1006) it seems that there is no strong references to [`trackBitrateAllocation.track`](https://github.com/jitsi/jitsi-videobridge/blob/ffb77f93c743dc1fa4501e07c1ca97fe016a7623/src/main/java/org/jitsi/videobridge/cc/BitrateController.java#L749). Or I just can't find any strong references on it, it causes `NPE` exception happen.

@gpolitis could you please have a look at this PR? Thanks a lot in advance!