### PR TITLE
LogContext improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <kotlin.version>1.3.61</kotlin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <smack.version>4.2.4-47d17fc</smack.version>
-    <jitsi.utils.version>1.0-32-g37aa1b3</jitsi.utils.version>
+    <jitsi.utils.version>1.0-33-g2ed4090</jitsi.utils.version>
     <jicoco.version>1.1-17-g0f9a752</jicoco.version>
   </properties>
   <dependencyManagement>

--- a/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -116,11 +116,8 @@ public abstract class AbstractEndpoint extends PropertyChangeNotifier
         {
             this.pinnedEndpoints = newPinnedEndpoints;
 
-            if (logger.isDebugEnabled())
-            {
-                logger.debug("Pinned "
-                    + Arrays.toString(pinnedEndpoints.toArray()));
-            }
+            logger.debug(() -> "Pinned "
+                + Arrays.toString(pinnedEndpoints.toArray()));
 
             firePropertyChange(PINNED_ENDPOINTS_PROPERTY_NAME,
                 oldPinnedEndpoints, pinnedEndpoints);
@@ -142,11 +139,8 @@ public abstract class AbstractEndpoint extends PropertyChangeNotifier
         {
             this.selectedEndpoints = newSelectedEndpoints;
 
-            if (logger.isDebugEnabled())
-            {
-                logger.debug("Selected "
-                    + Arrays.toString(selectedEndpoints.toArray()));
-            }
+            logger.debug(() -> "Selected "
+                + Arrays.toString(selectedEndpoints.toArray()));
 
             firePropertyChange(SELECTED_ENDPOINTS_PROPERTY_NAME,
                 oldSelectedEndpoints, selectedEndpoints);

--- a/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -268,10 +268,6 @@ public abstract class AbstractEndpoint extends PropertyChangeNotifier
     public void setDisplayName(String displayName)
     {
         this.displayName = displayName;
-        if (displayName != null)
-        {
-            logger.addContext("display_name", displayName);
-        }
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -268,6 +268,10 @@ public abstract class AbstractEndpoint extends PropertyChangeNotifier
     public void setDisplayName(String displayName)
     {
         this.displayName = displayName;
+        if (displayName != null)
+        {
+            logger.addContext("display_name", displayName);
+        }
     }
 
     /**
@@ -278,6 +282,10 @@ public abstract class AbstractEndpoint extends PropertyChangeNotifier
     public void setStatsId(String value)
     {
         this.statsId = value;
+        if (value != null)
+        {
+            logger.addContext("stats_id", value);
+        }
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -227,7 +227,7 @@ public class Conference
         }
         if (name != null)
         {
-            context.put("name", name.toString());
+            context.put("conf_name", name.toString());
         }
         logger = new LoggerImpl(Conference.class.getName(), minLevel, new LogContext(context));
         this.shim = new ConferenceShim(this, logger);

--- a/src/main/java/org/jitsi/videobridge/DtlsTransport.java
+++ b/src/main/java/org/jitsi/videobridge/DtlsTransport.java
@@ -127,8 +127,7 @@ public class DtlsTransport extends IceTransport
 
         dtlsStack.onHandshakeComplete((chosenSrtpProfile, tlsRole, keyingMaterial) -> {
             dtlsHandshakeComplete = true;
-            logger.info(logPrefix +
-                    "DTLS handshake complete. Got SRTP profile " +
+            logger.info("DTLS handshake complete. Got SRTP profile " +
                     chosenSrtpProfile);
             endpoint.setSrtpInformation(chosenSrtpProfile, tlsRole, keyingMaterial);
             dtlsConnectedSubscribers.forEach(Runnable::run);
@@ -164,8 +163,7 @@ public class DtlsTransport extends IceTransport
             }
             else
             {
-                logger.info(logPrefix +
-                        "Ignoring empty DtlsFingerprint extension: "
+                logger.info("Ignoring empty DtlsFingerprint extension: "
                                 + transportPacketExtension.toXML());
             }
         });
@@ -174,20 +172,17 @@ public class DtlsTransport extends IceTransport
             String setup = fingerprintExtensions.get(0).getSetup();
             if ("active".equalsIgnoreCase(setup))
             {
-                logger.info(logPrefix +
-                    "The remote side is acting as DTLS client, we'll act as server");
+                logger.info("The remote side is acting as DTLS client, we'll act as server");
                 dtlsStack.actAsServer();
             }
             else if ("passive".equalsIgnoreCase(setup))
             {
-                logger.info(logPrefix +
-                    "The remote side is acting as DTLS server, we'll act as client");
+                logger.info("The remote side is acting as DTLS server, we'll act as client");
                 dtlsStack.actAsClient();
             }
             else if (!StringUtils.isNullOrEmpty(setup))
             {
-                logger.error(logPrefix +
-                    "The remote side sent an unrecognized DTLS setup value: " +
+                logger.error("The remote side sent an unrecognized DTLS setup value: " +
                         setup);
             }
         }
@@ -209,8 +204,7 @@ public class DtlsTransport extends IceTransport
                 // hack(george) Jigasi sends a sha-1 dtls fingerprint without a
                 // setup attribute and it assumes a server role for the bridge.
 
-                logger.info(logPrefix +
-                    "Assume that the remote side is Jigasi, we'll act as server");
+                logger.info("Assume that the remote side is Jigasi, we'll act as server");
                 dtlsStack.actAsServer();
             }
         }
@@ -423,12 +417,12 @@ public class DtlsTransport extends IceTransport
                 }
                 catch (SocketClosedException e)
                 {
-                    logger.info(logPrefix + "Socket closed, stopping reader.");
+                    logger.info("Socket closed, stopping reader.");
                     break;
                 }
                 catch (IOException e)
                 {
-                    logger.warn(logPrefix + "Stopping reader: ", e);
+                    logger.warn("Stopping reader: ", e);
                     break;
                 }
             }
@@ -448,21 +442,19 @@ public class DtlsTransport extends IceTransport
         installIncomingPacketReader(socket);
 
         packetSender.socket = socket;
-        logger.info(logPrefix + "Starting DTLS.");
+        logger.info("Starting DTLS.");
         TaskPools.IO_POOL.submit(() -> {
             try
             {
                 if (dtlsStack.getRole() == null)
                 {
-                    logger.warn(logPrefix +
-                            "Starting the DTLS stack before it knows its role");
+                    logger.warn("Starting the DTLS stack before it knows its role");
                 }
                 dtlsStack.start();
             }
             catch (Throwable e)
             {
-                logger.error(logPrefix +
-                        "Error during DTLS negotiation: " + e.toString() +
+                logger.error("Error during DTLS negotiation: " + e.toString() +
                         ", closing this transport manager");
                 close();
             }
@@ -603,8 +595,7 @@ public class DtlsTransport extends IceTransport
                 }
                 catch (IOException e)
                 {
-                    logger.error(logPrefix +
-                            "Error sending packet: " + e.toString());
+                    logger.error("Error sending packet: " + e.toString());
                     throw new RuntimeException(e);
                 }
             }

--- a/src/main/java/org/jitsi/videobridge/ice/IceTransport.java
+++ b/src/main/java/org/jitsi/videobridge/ice/IceTransport.java
@@ -116,11 +116,6 @@ public class IceTransport
     protected final Logger logger;
 
     /**
-     * A string to add to log messages to identify the instance.
-     */
-    protected final String logPrefix;
-
-    /**
      * A flag which is raised if ICE has run and failed.
      */
     private boolean iceFailed = false;
@@ -163,13 +158,7 @@ public class IceTransport
         iceComponent = iceStream.getComponent(Component.RTP);
         iceStream.addPairChangeListener(iceStreamPairChangeListener);
 
-        //TODO(brian): this should be replaced by passing a log context
-        // when creating the child logger, but we don't have this
-        // value yet when creating the child logger, so we need to
-        // change the logger to allow adding context after creation,
-        // then we can get rid of the need for logPrefix here
-        this.logPrefix
-                = "[local_ufrag=" + iceAgent.getLocalUfrag() + "] ";
+        logger.addContext("local_ufrag", iceAgent.getLocalUfrag());
 
         EventAdmin eventAdmin = conference.getEventAdmin();
         if (eventAdmin != null)
@@ -359,7 +348,7 @@ public class IceTransport
         {
             if (logger.isDebugEnabled())
             {
-                logger.debug(logPrefix + "Connection already established.");
+                logger.debug("Connection already established.");
             }
             return;
         }
@@ -385,8 +374,7 @@ public class IceTransport
         if (iceAgentStateIsRunning && remoteCandidates.isEmpty()) {
             if (logger.isDebugEnabled())
             {
-                logger.debug(logPrefix +
-                        "Ignoring transport extension with no candidates, "
+                logger.debug("Ignoring transport extension with no candidates, "
                         + "the Agent is already running.");
             }
             return;
@@ -418,8 +406,7 @@ public class IceTransport
             // until we have at least one remote candidate per ICE Component.
             if (iceComponent.getRemoteCandidateCount() >= 1)
             {
-                logger.info(logPrefix +
-                        "Starting the agent with remote candidates.");
+                logger.info("Starting the agent with remote candidates.");
                 iceAgent.startConnectivityEstablishment();
             }
         }
@@ -428,16 +415,14 @@ public class IceTransport
         {
             // We don't have any remote candidates, but we already know the
             // remote ufrag and password, so we can start ICE.
-            logger.info(logPrefix +
-                    "Starting the Agent without remote candidates. ");
+            logger.info("Starting the Agent without remote candidates. ");
             iceAgent.startConnectivityEstablishment();
         }
         else
         {
             if (logger.isDebugEnabled())
             {
-                logger.debug(logPrefix +
-                        " Not starting ICE, no ufrag and pwd yet. " +
+                logger.debug(" Not starting ICE, no ufrag and pwd yet. " +
                         transportPacketExtension.toXML());
             }
         }
@@ -631,7 +616,7 @@ public class IceTransport
         IceProcessingState oldState = (IceProcessingState) ev.getOldValue();
         IceProcessingState newState = (IceProcessingState) ev.getNewValue();
 
-        logger.info(logPrefix + "ICE state changed old=" +
+        logger.info("ICE state changed old=" +
                 oldState + " new=" + newState);
 
         // We should be using newState.isEstablished() here, but we see
@@ -670,7 +655,7 @@ public class IceTransport
      */
     protected void onIceFailed()
     {
-        logger.warn(logPrefix + "ICE failed!");
+        logger.warn("ICE failed!");
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/ice/IceTransport.java
+++ b/src/main/java/org/jitsi/videobridge/ice/IceTransport.java
@@ -346,10 +346,7 @@ public class IceTransport
     {
         if (iceAgent.getState().isEstablished())
         {
-            if (logger.isDebugEnabled())
-            {
-                logger.debug("Connection already established.");
-            }
+            logger.debug(() -> "Connection already established.");
             return;
         }
 
@@ -372,11 +369,8 @@ public class IceTransport
                 = transportPacketExtension.getChildExtensionsOfType(
                         CandidatePacketExtension.class);
         if (iceAgentStateIsRunning && remoteCandidates.isEmpty()) {
-            if (logger.isDebugEnabled())
-            {
-                logger.debug("Ignoring transport extension with no candidates, "
-                        + "the Agent is already running.");
-            }
+            logger.debug(() -> "Ignoring transport extension with no candidates, "
+                    + "the Agent is already running.");
             return;
         }
 
@@ -420,11 +414,8 @@ public class IceTransport
         }
         else
         {
-            if (logger.isDebugEnabled())
-            {
-                logger.debug(" Not starting ICE, no ufrag and pwd yet. " +
-                        transportPacketExtension.toXML());
-            }
+            logger.debug(() -> " Not starting ICE, no ufrag and pwd yet. " +
+                    transportPacketExtension.toXML());
         }
 
     }

--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -280,11 +280,11 @@ public class ConferenceShim
         {
             for (ColibriConferenceIQ.Channel channel : content.getChannels())
             {
-                final String endpoint = channel.getEndpoint();
-                if (endpoint != null)
+                final String endpointId = channel.getEndpoint();
+                if (endpointId != null)
                 {
                     ensureEndpointCreated(
-                        channel.getEndpoint(),
+                        endpointId,
                         Boolean.TRUE.equals(channel.isInitiator()));
                 }
             }
@@ -292,11 +292,11 @@ public class ConferenceShim
             for (ColibriConferenceIQ.SctpConnection channel
                 : content.getSctpConnections())
             {
-                final String endpoint = channel.getEndpoint();
-                if (endpoint != null)
+                final String endpointId = channel.getEndpoint();
+                if (endpointId != null)
                 {
                     ensureEndpointCreated(
-                        channel.getEndpoint(),
+                        endpointId,
                         Boolean.TRUE.equals(channel.isInitiator()));
                 }
             }


### PR DESCRIPTION
This cleans up a couple things:
1) The 'manual' log prefix we had in IceTransport (which was needed because we previously couldn't add log context to a logger after it was created)
2) Replaces some usages of manual `isDebugEnabled` checks with the provider-based logger methods
3) Adds 'stats id' and 'display name' to an endpoint's log context (when non-null)

Depends on https://github.com/jitsi/jitsi-utils/pull/38