### PR TITLE
Combine reference conf correctly when building a fat jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,33 @@
     <smack.version>4.2.4-47d17fc</smack.version>
     <jitsi.utils.version>1.0-33-g2ed4090</jitsi.utils.version>
     <jicoco.version>1.1-17-g0f9a752</jicoco.version>
+    <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
   </properties>
+
+  <profiles>
+    <profile>
+      <!-- Building a fat jar is disabled by default. To build it
+           pass '-P buildFarJar
+      -->
+      <id>buildFatJar</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>${maven-shade-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>build-fat-jar</id>
+                <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <dependencyManagement>
     <dependencies>
     </dependencies>
@@ -284,12 +310,17 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>${maven-shade-plugin.version}</version>
         <executions>
           <execution>
+            <id>build-fat-jar</id>
             <goals>
               <goal>shade</goal>
             </goals>
+            <!-- Building a fat jar is disabled by default.  See the note
+                 on the buildFatJar profile at the top of this file
+            -->
+            <phase>none</phase>
             <configuration>
               <finalName>${project.name}-${project.version}-jar-with-dependencies</finalName>
               <transformers>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <profiles>
     <profile>
       <!-- Building a fat jar is disabled by default. To build it
-           pass '-P buildFarJar
+           pass '-P buildFatJar
       -->
       <id>buildFatJar</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <profiles>
     <profile>
       <!-- Building a fat jar is disabled by default. To build it
-           pass '-P buildFatJar
+           pass '-P buildFatJar'
       -->
       <id>buildFatJar</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -260,31 +260,60 @@
   </dependencies>
   <build>
     <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.2.0</version>
-          <executions>
-            <execution>
-              <id>assemble-archive</id>
-              <phase>package</phase>
-              <goals>
-                <goal>single</goal>
-              </goals>
-              <configuration>
-                <appendAssemblyId>true</appendAssemblyId>
-                <descriptors>
-                  <descriptor>src/assembly/archive.xml</descriptor>
-                </descriptors>
-                <skipAssembly>${assembly.skipAssembly}</skipAssembly>
-                <descriptorRefs>
-                  <descriptorRef>jar-with-dependencies</descriptorRef>
-                </descriptorRefs>
-              </configuration>
-            </execution>
-          </executions>
-
-        </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+         <version>3.2.0</version>
+         <executions>
+           <execution>
+             <id>assemble-archive</id>
+             <phase>package</phase>
+             <goals>
+               <goal>single</goal>
+             </goals>
+             <configuration>
+               <appendAssemblyId>true</appendAssemblyId>
+               <descriptors>
+                 <descriptor>src/assembly/archive.xml</descriptor>
+               </descriptors>
+               <skipAssembly>${assembly.skipAssembly}</skipAssembly>
+             </configuration>
+           </execution>
+         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${project.name}-${project.version}-jar-with-dependencies</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>reference.conf</resource>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <!-- Exclude signatures as they don't work correctly with a
+                       fat jar.
+                  -->
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>


### PR DESCRIPTION
This adds a new method for building a fat jar which correctly concatenates `reference.conf` files if there are multiple (which is the case since JVB and JMT have them).

Although building the fat jar only took ~3 seconds longer on my machine, I made it off by default.  It can be built by passing `-P buildFatJar` to maven.

`maven-assembly-plugin` had some support for this, but it didn't support concatenating the files for the final jar, so we no longer use it for building the fat jar, and use `maven-shade-plugin` instead which is recommended in the `maven-assembly-docs`:
```
Note that jar-with-dependencies provides only basic support for uber-jars. For more control, use the Maven Shade Plugin.
```
[here](https://maven.apache.org/plugins/maven-assembly-plugin/descriptor-refs.html#jar-with-dependencies)