### PR TITLE
have adaptivetrackprojection refer to the same map of payload types used

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
@@ -113,26 +113,29 @@ public class AdaptiveTrackProjection
      */
     private int targetIndex = RTPEncodingDesc.SUSPENDED_INDEX;
 
-    //TODO(brian): we need this to know which frameprojectioncontext to make
-    // based on the payload type of a packet.  is there a better way?
-    private final Map<Byte, PayloadType> payloadTypes = new HashMap<>();
+    private final Map<Byte, PayloadType> payloadTypes;
 
     /**
      * Ctor.
      *
      * @param source the {@link MediaStreamTrackDesc} that owns the packets
      * that this instance filters.
+     *
+     * @param payloadTypes a reference to a map of payload types.  This map
+     *                     should be updated as the payload types change.
      */
     AdaptiveTrackProjection(
         @NotNull DiagnosticContext diagnosticContext,
         @NotNull MediaStreamTrackDesc source,
         Runnable keyframeRequester,
+        Map<Byte, PayloadType> payloadTypes,
         Logger parentLogger
     )
     {
         weakSource = new WeakReference<>(source);
         targetSsrc = source.getRTPEncodings()[0].getPrimarySSRC();
         this.diagnosticContext = diagnosticContext;
+        this.payloadTypes = payloadTypes;
         this.parentLogger = parentLogger;
         this.logger = parentLogger.createChildLogger(AdaptiveTrackProjection.class.getName(),
             JMap.of("targetSsrc", Long.toString(targetSsrc),
@@ -415,14 +418,6 @@ public class AdaptiveTrackProjection
     public long getTargetSsrc()
     {
         return targetSsrc;
-    }
-
-    /**
-     * Adds a payload type.
-     */
-    public void addPayloadType(PayloadType payloadType)
-    {
-        payloadTypes.put(payloadType.getPt(), payloadType);
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -207,7 +207,8 @@ public class BitrateController
     // is the main use case for wanting to disable adaptivity).
     private boolean supportsRtx = false;
 
-    private final Map<Byte, PayloadType> payloadTypes = new HashMap<>();
+    private final Map<Byte, PayloadType> payloadTypes =
+        new ConcurrentHashMap<>();
 
     /**
      * Initializes a new {@link BitrateController} instance which is to
@@ -750,12 +751,8 @@ public class BitrateController
                     trackBitrateAllocation.track, () ->
                         destinationEndpoint.getConference().requestKeyframe(
                             endpointID, targetSSRC),
+                    payloadTypes,
                     logger);
-
-            for (PayloadType payloadType : payloadTypes.values())
-            {
-                adaptiveTrackProjection.addPayloadType(payloadType);
-            }
 
             logger.debug(() -> "new track projection for " + trackBitrateAllocation.track);
 
@@ -1092,7 +1089,6 @@ public class BitrateController
     public void addPayloadType(PayloadType payloadType)
     {
         payloadTypes.put(payloadType.getPt(), payloadType);
-        adaptiveTrackProjections.forEach(atp -> atp.addPayloadType(payloadType));
 
         if (payloadType.getEncoding() == PayloadTypeEncoding.RTX)
         {


### PR DESCRIPTION
by the bitratecontroller to avoid any out-of-sync issues.

There existed a race between creating an `AdaptiveTrackProjection` and being notified of a new payload type that resulted in the `AdaptiveTrackProjection` not knowing of a payload type and logging `AdaptiveTrackProjection.getContext#278: No payload type object signaled for payload type...`.  This change removes the chance for the two payload type maps (one in `BitrateController`, one in `AdaptiveTrackProjection`) getting out of sync by using only a single map.