### PR TITLE
Reduce log level of 'unknown ssrc' log in BitrateController

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -601,6 +601,7 @@ public class Endpoint
             if (logger.isDebugEnabled() && getConference().includeInStatistics())
             {
                 logger.debug(transceiver.getNodeStats().prettyPrint(0));
+                logger.debug(bitrateController.getDebugState().toJSONString());
             }
 
             transceiver.teardown();

--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -30,6 +30,7 @@ import org.json.simple.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
 import static org.jitsi.videobridge.cc.config.BitrateControllerConfig.*;
 
@@ -209,6 +210,9 @@ public class BitrateController
 
     private final Map<Byte, PayloadType> payloadTypes = new HashMap<>();
 
+    private final AtomicInteger numDroppedPacketsUnknownSsrc =
+        new AtomicInteger(0);
+
     /**
      * Initializes a new {@link BitrateController} instance which is to
      * belong to a particular {@link Endpoint}.
@@ -286,9 +290,10 @@ public class BitrateController
 
         if (adaptiveTrackProjection == null)
         {
-            logger.warn(
+            logger.debug(() ->
                 "Dropping an RTP packet, because the SSRC has not " +
                     "been signaled:" + ssrc);
+            numDroppedPacketsUnknownSsrc.incrementAndGet();
             return false;
         }
 
@@ -366,6 +371,9 @@ public class BitrateController
         debugState.put(
                 "adaptiveTrackProjectionMap",
                 adaptiveTrackProjectionsJson);
+        debugState.put(
+            "numDroppedPacketsUnknownSsrc",
+            numDroppedPacketsUnknownSsrc.intValue());
         return debugState;
     }
 


### PR DESCRIPTION
This log isn't completely unexpected, and can happen for a brief period when an endpoint first joins (before it's updated about all other endpoints in the conference), so reduce the log level and track the number of occurrences in a stat.