### PR TITLE
Adds a query param to the main debug call in the colibri http api.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -1098,7 +1098,7 @@ public class Videobridge
      * to include. If not specified, all of the conference's endpoints will be
      * included.
      */
-    public OrderedJsonObject getDebugState(String conferenceId, String endpointId)
+    public OrderedJsonObject getDebugState(String conferenceId, String endpointId, boolean full)
     {
         OrderedJsonObject debugState = new OrderedJsonObject();
         debugState.put("shutdownInProgress", shutdownInProgress);
@@ -1125,7 +1125,7 @@ public class Videobridge
             {
                 conferences.put(
                         conference.getID(),
-                        conference.getDebugState(false, null));
+                        conference.getDebugState(full, null));
             }
         }
         else
@@ -1140,7 +1140,7 @@ public class Videobridge
             conferences.put(
                     conferenceId,
                     conference == null
-                            ? "null" : conference.getDebugState(true, endpointId));
+                            ? "null" : conference.getDebugState(full, endpointId));
         }
 
         return debugState;

--- a/src/main/java/org/jitsi/videobridge/rest/root/colibri/debug/Debug.java
+++ b/src/main/java/org/jitsi/videobridge/rest/root/colibri/debug/Debug.java
@@ -49,9 +49,9 @@ public class Debug extends ColibriResource
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String bridgeDebug()
+    public String bridgeDebug(@DefaultValue("false") @QueryParam("full") boolean full)
     {
-        OrderedJsonObject confJson = videobridgeProvider.get().getDebugState(null, null);
+        OrderedJsonObject confJson = videobridgeProvider.get().getDebugState(null, null, full);
         return confJson.toJSONString();
     }
 
@@ -153,7 +153,7 @@ public class Debug extends ColibriResource
     @Produces(MediaType.APPLICATION_JSON)
     public String confDebug(@PathParam("confId") String confId)
     {
-        OrderedJsonObject confJson = videobridgeProvider.get().getDebugState(confId, null);
+        OrderedJsonObject confJson = videobridgeProvider.get().getDebugState(confId, null, true);
         return confJson.toJSONString();
     }
 
@@ -162,7 +162,7 @@ public class Debug extends ColibriResource
     @Produces(MediaType.APPLICATION_JSON)
     public String epDebug(@PathParam("confId") String confId, @PathParam("epId") String epId)
     {
-        OrderedJsonObject confJson = videobridgeProvider.get().getDebugState(confId, epId);
+        OrderedJsonObject confJson = videobridgeProvider.get().getDebugState(confId, epId, true);
         return confJson.toJSONString();
     }
 


### PR DESCRIPTION
This avoids having to do 2 API calls during testing, first get the conference id and then get the full description of the call.