### PR TITLE
AdaptiveTrackProjection log: null value check for srcEpId

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
@@ -139,7 +139,7 @@ public class AdaptiveTrackProjection
         this.parentLogger = parentLogger;
         this.logger = parentLogger.createChildLogger(AdaptiveTrackProjection.class.getName(),
             JMap.of("targetSsrc", Long.toString(targetSsrc),
-                "srcEpId", source.getOwner()));
+                "srcEpId", Objects.toString(source.getOwner(), "")));
         this.keyframeRequester = keyframeRequester;
     }
 


### PR DESCRIPTION
possible exception in LogContext  when use ImmutableMap.copyOf(context), if source.getOwner() is null