### PR TITLE
Dtls transport layer

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -1350,13 +1350,13 @@ public class Conference
         /**
          * Whether at least one endpoint in this conference failed ICE.
          */
-        boolean hasIceFailedEndpoint = false;
+        public boolean hasIceFailedEndpoint = false;
 
         /**
          * Whether at least one endpoint in this conference completed ICE
          * successfully.
          */
-        boolean hasIceSucceededEndpoint = false;
+        public boolean hasIceSucceededEndpoint = false;
 
         /**
          * Gets a snapshot of this object's state as JSON.

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -552,7 +552,7 @@ public class Endpoint
     @Override
     public boolean shouldExpire()
     {
-        if (dtlsTransport.dtlsHandshake.hasFailed)
+        if (dtlsTransport.dtlsHandshake.hasFailed())
         {
             logger.warn("Allowing to expire because connection failed.");
             return true;

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge;
 
+import kotlin.*;
 import org.jetbrains.annotations.*;
 import org.jitsi.nlj.*;
 import org.jitsi.nlj.format.*;
@@ -55,6 +56,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 import java.util.function.*;
+import java.util.function.Function;
 import java.util.stream.*;
 
 import static org.jitsi.videobridge.EndpointMessageBuilder.*;
@@ -550,10 +552,9 @@ public class Endpoint
     @Override
     public boolean shouldExpire()
     {
-        boolean iceFailed = dtlsTransport.hasIceFailed();
-        if (iceFailed)
+        if (dtlsTransport.dtlsHandshake.hasFailed)
         {
-            logger.warn("Allowing to expire because ICE failed.");
+            logger.warn("Allowing to expire because connection failed.");
             return true;
         }
 
@@ -760,7 +761,7 @@ public class Endpoint
         };
         socket.listen();
 
-        dtlsTransport.onDtlsHandshakeComplete(() -> {
+        dtlsTransport.dtlsHandshake.onSuccess(() -> {
             // We don't want to block the thread calling
             // onDtlsHandshakeComplete so run the socket acceptance in an IO
             // pool thread
@@ -794,6 +795,7 @@ public class Endpoint
                             " accepted connection.");
                 }
             });
+            return Unit.INSTANCE;
         });
     }
 

--- a/src/main/java/org/jitsi/videobridge/ice/IceTransport.java
+++ b/src/main/java/org/jitsi/videobridge/ice/IceTransport.java
@@ -504,7 +504,7 @@ public class IceTransport
     /**
      * Describes this {@link IceTransport} in a {@code transport} XML extension.
      */
-    protected void describe(IceUdpTransportPacketExtension pe)
+    public void describe(IceUdpTransportPacketExtension pe)
     {
         pe.setPassword(iceAgent.getLocalPassword());
         pe.setUfrag(iceAgent.getLocalUfrag());
@@ -679,6 +679,10 @@ public class IceTransport
         describe(pe);
     }
 
+    public boolean isClosed()
+    {
+        return closed;
+    }
     /**
      * Gets a JSON representation of the parts of this object's state that
      * are deemed useful for debugging.


### PR DESCRIPTION
Rather than having `DtlsTransport` extend `IceTransport`, it now wraps `IceTransport` instead.

When looking at endpoint queues for Octo I found myself wanting to make the Octo endpoints more like normal endpoints but with a shared transport, so I started poking around at that and felt this would be a good step in the right direction.

To me this better reflects the 'layers' of what is actually going on, and the plan would be to add some more fundamental 'Transport' interfaces as next steps and get to a place where `OctoRelay` can implement a form of transport and then just be shared amongst the OctoEndpoints in a way that looks the same as local endpoints having their own transports.

I think even `DtlsTransport` could be given an `IceTransport` (in the form of the generic `Transport` interface) and then become even further decoupled from it, which would make it feasible to add some tests for it, as well as do more fully functional 'test harnesses' (like we have in JMT) all the way down to this layer as well (since it would be easy to plug in a dummy transport).

I had originally started with something more drastic and was porting `IceTransport` and `DtlsTransport` to kotlin, but the inheritance actually made that a little difficult (as the classes are in different packages and kotlin treats the visibility keywords slightly differently), so this would be a good step towards that as well.