### PR TITLE
Log an error, and fail frame insertion, if a frame in the frame map doesn't match.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveTrackProjectionContext.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveTrackProjectionContext.java
@@ -284,7 +284,8 @@ public class VP8AdaptiveTrackProjectionContext
 
         if (result == null)
         {
-            /* Very old frame, more than Vp8FrameMap.FRAME_MAP_SIZE old. */
+            /* Very old frame, more than Vp8FrameMap.FRAME_MAP_SIZE old,
+               or something wrong with the stream. */
             return false;
         }
 

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
@@ -87,6 +87,26 @@ public class VP8FrameMap
         VP8Frame frame = frameHistory.get(pictureId);
         if (frame != null)
         {
+            if (!frame.matchesFrame(packet))
+            {
+                if (frame.getPictureId() != pictureId)
+                {
+                    throw new IllegalStateException("Frame map returned frame with picture ID " +
+                        frame.getPictureId() +
+                        " when asked for frame with picture ID " + pictureId);
+                }
+                logger.warn("Cannot insert packet in frame map: " +
+                    "frame with ssrc " + frame.getSsrc() +
+                    ", timestamp " + frame.getTemporalLayer() +
+                    ", and sequence numnber range " + frame.getEarliestKnownSequenceNumber() +
+                    "-" + frame.getLatestKnownSequenceNumber() +
+                    ", and packet " + packet.getSequenceNumber() +
+                    " with ssrc " + packet.getSsrc() +
+                    ", timestamp " + packet.getTimestamp() +
+                    ", and sequence number " + packet.getTimestamp() +
+                    " both have picture ID " + pictureId);
+                return null;
+            }
             return doFrameInsert(frame, packet);
         }
 


### PR DESCRIPTION
Rather than throwing an exception.

This is necessary because we now index frames in the map by picture ID rather than by timestamp.

Note this is *not* the same as https://github.com/jitsi/jitsi-videobridge/pull/1077; it's addressing a different (though related) problem.