### PR TITLE
Optimize off-by-one in Vp8FrameMap.findAfter; plus minor tweaks.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveTrackProjectionContext.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveTrackProjectionContext.java
@@ -505,7 +505,7 @@ public class VP8AdaptiveTrackProjectionContext
                 f2 = prevFrame(f1);
                 if (f2 == null)
                 {
-                    throw new IllegalStateException("No next frame found before frame with picId " + f1.getPictureId() +
+                    throw new IllegalStateException("No previous frame found before frame with picId " + f1.getPictureId() +
                         ", even though refFrame " + refFrame.getPictureId() + " is after frame " + frame.getPictureId() + "!");
                 }
                 seqGap += -seqGap(f2, f1);

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
@@ -263,6 +263,7 @@ public class VP8FrameMap
             numCached--;
         }
 
+        @Nullable
         public VP8Frame findBefore(VP8Frame frame, Predicate<VP8Frame> pred)
         {
             int lastIndex = getLastIndex();
@@ -279,6 +280,7 @@ public class VP8FrameMap
             return doFind(pred, searchStartIndex, searchEndIndex, -1);
         }
 
+        @Nullable
         public VP8Frame findAfter(VP8Frame frame, Predicate<VP8Frame> pred)
         {
             int lastIndex = getLastIndex();
@@ -294,11 +296,12 @@ public class VP8FrameMap
                 return null;
             }
 
-            int searchStartIndex = max(index + 1, max(lastIndex - getSize(), firstIndex));
+            int searchStartIndex = max(index + 1, max(lastIndex - getSize() + 1, firstIndex));
 
             return doFind(pred, searchStartIndex, lastIndex + 1, 1);
         }
 
+        @Nullable
         private VP8Frame doFind(Predicate<VP8Frame> pred, int startIndex, int endIndex, int increment)
         {
             for (int index = startIndex; index != endIndex; index += increment)


### PR DESCRIPTION
`getIndex` of `getLastIndex() - getSize()` always returns `null`, so we can safely lower-bound `findAfter`'s search at `getLastIndex() - getSize() + 1`.

(The probably has pretty negligible performance impact, but it's nice for correctness.)

Also clean up a log message.