### PR TITLE
Bump RTP version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>rtp</artifactId>
-      <version>1.0-41-ge1846ad</version>
+      <version>1.0-42-gc2cd0a2</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
(I don't think we need a corresponding JMT bump for https://github.com/jitsi/jitsi-media-transform/pull/223; it just has a comment update and a RTP version update, and this Maven RTP version wins.)