### PR TITLE
Do not describe expired channels or channels of expired endpoint.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -183,6 +183,10 @@ public class ConferenceShim
 
             for (ChannelShim channelShim : contentShim.getChannelShims())
             {
+                if (channelShim.isExpired() || channelShim.getEndpoint().isExpired())
+                {
+                    continue;
+                }
                 if (channelShim instanceof SctpConnectionShim)
                 {
                     ColibriConferenceIQ.SctpConnection sctpConnectionIQ


### PR DESCRIPTION
In some scenarios when endpoint is expired, the corresponding channel shims are not removed. Generation of IQ with expired channels via:
```java
final ColibriConferenceIQ iq = new ColibriConferenceIQ();
final ConferenceShim confShim = conference.getShim();
confShim.describeDeep(iq);
```

The fix for channel shims outliving owning endpoint will be done separately.