### PR TITLE
Fixed Endpoint leak caused by ChannelShims not being removed from ConerenceShim.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -604,6 +604,15 @@ public class Endpoint
 
         try
         {
+            for (ChannelShim channelShim : channelShims)
+            {
+                if (!channelShim.isExpired())
+                {
+                    // Last expired channel will also trigger Endpoint.expire()
+                    // causing recursive call. But it will be stopped by `super.isExpired` check
+                    channelShim.setExpire(0);
+                }
+            }
             updateStatsOnExpire();
             this.transceiver.stop();
             if (logger.isDebugEnabled() && getConference().includeInStatistics())

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -604,15 +604,17 @@ public class Endpoint
 
         try
         {
+            final ChannelShim[] channelShims = this.channelShims.toArray(new ChannelShim[0]);
+            this.channelShims.clear();
+
             for (ChannelShim channelShim : channelShims)
             {
                 if (!channelShim.isExpired())
                 {
-                    // Last expired channel will also trigger Endpoint.expire()
-                    // causing recursive call. But it will be stopped by `super.isExpired` check
                     channelShim.setExpire(0);
                 }
             }
+
             updateStatsOnExpire();
             this.transceiver.stop();
             if (logger.isDebugEnabled() && getConference().includeInStatistics())


### PR DESCRIPTION
When endpoint A in a conference permanently looses connection with JVB it is eventually expired by this code due to lack of network activity: 
https://github.com/jitsi/jitsi-videobridge/blob/c5b5f463cae3ad1e8548678d4fa7ff16e9918cad/src/main/java/org/jitsi/videobridge/VideobridgeExpireThread.java#L157-L164

But all the ChannelShims which were corresponded to Endpoint A are not expired and not removed from [`ConferenceShim.contents`](https://github.com/jitsi/jitsi-videobridge/blob/c5b5f463cae3ad1e8548678d4fa7ff16e9918cad/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java#L55-L58)/[`ContentShim.channels`](https://github.com/jitsi/jitsi-videobridge/blob/c5b5f463cae3ad1e8548678d4fa7ff16e9918cad/src/main/java/org/jitsi/videobridge/shim/ContentShim.java#L66-L69).

[`ChannelShim.endpoint`](https://github.com/jitsi/jitsi-videobridge/blob/c5b5f463cae3ad1e8548678d4fa7ff16e9918cad/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java#L95-L98) still storing reference to `Endpoint` causing leak.

It also causes [`ConferenceChim.describeDeep`](https://github.com/jitsi/jitsi-videobridge/blob/c5b5f463cae3ad1e8548678d4fa7ff16e9918cad/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java#L175) to describe channels of expired endpoint.