### PR TITLE
Fail to project (and log packet contents) for VP8 packets without picture IDs.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveTrackProjectionContext.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveTrackProjectionContext.java
@@ -676,6 +676,13 @@ public class VP8AdaptiveTrackProjectionContext
         }
         Vp8Packet vp8Packet = packetInfo.packetAs();
 
+        if (vp8Packet.getPictureId() == -1)
+        {
+            /* Should have been rejected in accept(). */
+            logger.info("VP8 packet does not have picture ID, cannot track in frame map.");
+            throw new RewriteException("VP8 packet without picture ID in VP8 track projeciton");
+        }
+
         VP8Frame vp8Frame = lookupVP8Frame(vp8Packet);
         if (vp8Frame == null)
         {

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.*;
 import org.jitsi.nlj.codec.vp8.*;
 import org.jitsi.nlj.rtp.codec.vp8.*;
 import org.jitsi.nlj.util.*;
+import org.jitsi.rtp.extensions.*;
 import org.jitsi.rtp.extensions.bytearray.*;
 import org.jitsi.rtp.util.*;
 import org.jitsi.utils.logging2.*;
@@ -131,8 +132,7 @@ public class VP8FrameMap
         if (pictureId == -1)
         {
             /* Frame map indexes by picture ID.  All supported browsers should currently be setting it. */
-            logger.info("VP8 packet does not have picture ID, cannot track in frame map.  Packet data is: " +
-                ByteArrayExtensionsKt.toHex(packet.buffer, packet.offset, Math.min(packet.length, 80)));
+            /* Log message will have been logged by Vp8Parser in jmt. */
             return null;
         }
 

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.*;
 import org.jitsi.nlj.codec.vp8.*;
 import org.jitsi.nlj.rtp.codec.vp8.*;
 import org.jitsi.nlj.util.*;
+import org.jitsi.rtp.extensions.bytearray.*;
 import org.jitsi.rtp.util.*;
 import org.jitsi.utils.logging2.*;
 
@@ -126,6 +127,14 @@ public class VP8FrameMap
     public synchronized FrameInsertionResult insertPacket(@NotNull Vp8Packet packet)
     {
         int pictureId = packet.getPictureId();
+
+        if (pictureId == -1)
+        {
+            /* Frame map indexes by picture ID.  All supported browsers should currently be setting it. */
+            logger.info("VP8 packet does not have picture ID, cannot track in frame map.  Packet data is: " +
+                ByteArrayExtensionsKt.toHex(packet.buffer, packet.offset, Math.min(packet.length, 80)));
+            return null;
+        }
 
         if (isLargeJump(packet))
         {


### PR DESCRIPTION
The frame map indexes by picture ID.