### PR TITLE
Fail to project VP8 packets without picture IDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>rtp</artifactId>
-      <version>1.0-42-gc2cd0a2</version>
+      <version>1.0-43-g1ee1a7c</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-media-transform</artifactId>
-      <version>1.0-128-gdc66434</version>
+      <version>1.0-133-g9c6e608</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
@@ -271,10 +271,6 @@ public class AdaptiveTrackProjection
             // scalability, conversely if temporal scalability is disabled
             // then simulcast is disabled.
 
-            byte[] buf = rtpPacket.getBuffer();
-            int payloadOffset = rtpPacket.getPayloadOffset(),
-                payloadLen = rtpPacket.getPayloadLength();
-
             /* Check whether this stream is projectable by the VP8AdaptiveTrackProjectionContext. */
             boolean projectable = rtpPacket instanceof Vp8Packet &&
                 ((Vp8Packet)rtpPacket).getHasTemporalLayerIndex() &&

--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
@@ -19,12 +19,12 @@ import org.jetbrains.annotations.*;
 import org.jitsi.nlj.*;
 import org.jitsi.nlj.format.*;
 import org.jitsi.nlj.rtp.*;
+import org.jitsi.nlj.rtp.codec.vp8.*;
 import org.jitsi.rtp.rtcp.*;
 import org.jitsi.utils.collections.*;
 import org.jitsi.utils.logging.*;
 import org.jitsi.utils.logging2.Logger;
 import org.jitsi.videobridge.cc.vp8.*;
-import org.jitsi_modified.impl.neomedia.codec.video.vp8.*;
 import org.jitsi_modified.impl.neomedia.rtp.*;
 import org.json.simple.*;
 
@@ -275,10 +275,12 @@ public class AdaptiveTrackProjection
             int payloadOffset = rtpPacket.getPayloadOffset(),
                 payloadLen = rtpPacket.getPayloadLength();
 
-            boolean hasTemporalLayerIndex = DePacketizer.VP8PayloadDescriptor
-                .getTemporalLayerIndex(buf, payloadOffset, payloadLen) > -1;
+            /* Check whether this stream is projectable by the VP8AdaptiveTrackProjectionContext. */
+            boolean projectable = rtpPacket instanceof Vp8Packet &&
+                ((Vp8Packet)rtpPacket).getHasTemporalLayerIndex() &&
+                ((Vp8Packet)rtpPacket).getHasPictureId();
 
-            if (hasTemporalLayerIndex
+            if (projectable
                 && !(context instanceof VP8AdaptiveTrackProjectionContext))
             {
                 // context switch
@@ -290,7 +292,7 @@ public class AdaptiveTrackProjection
                     diagnosticContext, payloadTypeObject, rtpState, parentLogger);
                 contextPayloadType = payloadType;
             }
-            else if (!hasTemporalLayerIndex
+            else if (!projectable
                 && !(context instanceof GenericAdaptiveTrackProjectionContext))
             {
                 RtpState rtpState = getRtpState();

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveTrackProjectionContext.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveTrackProjectionContext.java
@@ -676,6 +676,13 @@ public class VP8AdaptiveTrackProjectionContext
         }
         Vp8Packet vp8Packet = packetInfo.packetAs();
 
+        if (vp8Packet.getPictureId() == -1)
+        {
+            /* Should have been rejected in accept(). */
+            logger.info("VP8 packet does not have picture ID, cannot track in frame map.");
+            throw new RewriteException("VP8 packet without picture ID in VP8 track projeciton");
+        }
+
         VP8Frame vp8Frame = lookupVP8Frame(vp8Packet);
         if (vp8Frame == null)
         {

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.*;
 import org.jitsi.nlj.codec.vp8.*;
 import org.jitsi.nlj.rtp.codec.vp8.*;
 import org.jitsi.nlj.util.*;
+import org.jitsi.rtp.extensions.*;
 import org.jitsi.rtp.extensions.bytearray.*;
 import org.jitsi.rtp.util.*;
 import org.jitsi.utils.logging2.*;
@@ -131,8 +132,7 @@ public class VP8FrameMap
         if (pictureId == -1)
         {
             /* Frame map indexes by picture ID.  All supported browsers should currently be setting it. */
-            logger.info("VP8 packet does not have picture ID, cannot track in frame map.  Packet data is: " +
-                ByteArrayExtensionsKt.toHex(packet.buffer, packet.offset, Math.min(packet.length, 80)));
+            /* Log message will have been logged by Vp8Parser in jmt. */
             return null;
         }
 

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
@@ -19,8 +19,6 @@ import org.jetbrains.annotations.*;
 import org.jitsi.nlj.codec.vp8.*;
 import org.jitsi.nlj.rtp.codec.vp8.*;
 import org.jitsi.nlj.util.*;
-import org.jitsi.rtp.extensions.*;
-import org.jitsi.rtp.extensions.bytearray.*;
 import org.jitsi.rtp.util.*;
 import org.jitsi.utils.logging2.*;
 
@@ -282,7 +280,7 @@ public class VP8FrameMap
         PictureIdIndexTracker indexTracker = new PictureIdIndexTracker();
 
         /**
-         * Gets a packet with a given VP8 picture ID from the cache.
+         * Gets a frame with a given VP8 picture ID from the cache.
          */
         public VP8Frame get(int pictureId)
         {
@@ -291,7 +289,7 @@ public class VP8FrameMap
         }
 
         /**
-         * Gets a packet with a given VP8 picture ID index from the cache.
+         * Gets a frame with a given VP8 picture ID index from the cache.
          */
         private VP8Frame getIndex(int index)
         {

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.*;
 import org.jitsi.nlj.codec.vp8.*;
 import org.jitsi.nlj.rtp.codec.vp8.*;
 import org.jitsi.nlj.util.*;
+import org.jitsi.rtp.extensions.bytearray.*;
 import org.jitsi.rtp.util.*;
 import org.jitsi.utils.logging2.*;
 
@@ -126,6 +127,14 @@ public class VP8FrameMap
     public synchronized FrameInsertionResult insertPacket(@NotNull Vp8Packet packet)
     {
         int pictureId = packet.getPictureId();
+
+        if (pictureId == -1)
+        {
+            /* Frame map indexes by picture ID.  All supported browsers should currently be setting it. */
+            logger.info("VP8 packet does not have picture ID, cannot track in frame map.  Packet data is: " +
+                ByteArrayExtensionsKt.toHex(packet.buffer, packet.offset, Math.min(packet.length, 80)));
+            return null;
+        }
 
         if (isLargeJump(packet))
         {


### PR DESCRIPTION
This is https://github.com/jitsi/jitsi-videobridge/pull/1106 but with the branch name changed to match https://github.com/jitsi/jitsi-media-transform/pull/227, in hopes that the latter's PR tests pass.