### PR TITLE
Synchronize access to inactiveEndpoints list.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/EndpointConnectionStatus.java
+++ b/src/main/java/org/jitsi/videobridge/EndpointConnectionStatus.java
@@ -71,7 +71,7 @@ public class EndpointConnectionStatus
      * The list of <tt>Endpoint</tt>s which have current their connection status
      * classified as inactive.
      */
-    private final List<Endpoint> inactiveEndpoints = new LinkedList<>();
+    private final Set<Endpoint> inactiveEndpoints = new HashSet<>();
 
     /**
      * The timer which runs the periodical connection status probing operation.


### PR DESCRIPTION
I suspect this was the cause of the otherwise-inexplicable NPE in `EndpointConnectionStatus.handleEvent`.

Note the addition of `synchronized` blocks changed indentation, so you may wish to review the version of the diff ignoring whitespace changes.