### PR TITLE
Update the BitrateController any time the active speaker changes

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -447,10 +447,7 @@ public class Conference
             getVideobridge().getStatistics().totalDominantSpeakerChanges.increment();
         }
 
-        List<String> sortedEndpointIds = speechActivity.getEndpointIds();
-        endpointsCache.stream()
-            .filter(Objects::nonNull)
-            .forEach(ep -> ep.speechActivityEndpointsChanged(sortedEndpointIds));
+        speechActivityEndpointsChanged(speechActivity.getEndpointIds());
 
         if (dominantSpeaker != null)
         {
@@ -1067,11 +1064,10 @@ public class Conference
     /**
      * Notifies this instance that the list of ordered endpoints has changed
      */
-    void speechActivityEndpointsChanged()
+    void speechActivityEndpointsChanged(List<String> newEndpointIds)
     {
-        List<String> endpoints = speechActivity.getEndpointIds();
         endpointsCache.forEach(
-                e ->  e.speechActivityEndpointsChanged(endpoints));
+                e ->  e.speechActivityEndpointsChanged(newEndpointIds));
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -447,6 +447,12 @@ public class Conference
             getVideobridge().getStatistics().totalDominantSpeakerChanges.increment();
         }
 
+        List<String> sortedEndpointIds = speechActivity.getEndpointIds();
+        //TODO: submit to IO pool?
+        endpointsCache.stream()
+            .filter(Objects::nonNull)
+            .forEach(ep -> ep.speechActivityEndpointsChanged(sortedEndpointIds));
+
         if (dominantSpeaker != null)
         {
             broadcastMessage(

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -448,7 +448,6 @@ public class Conference
         }
 
         List<String> sortedEndpointIds = speechActivity.getEndpointIds();
-        //TODO: submit to IO pool?
         endpointsCache.stream()
             .filter(Objects::nonNull)
             .forEach(ep -> ep.speechActivityEndpointsChanged(sortedEndpointIds));

--- a/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
+++ b/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
@@ -418,6 +418,7 @@ public class ConferenceSpeechActivity
         {
             final boolean finalDominantSpeakerChanged = dominantSpeakerChanged;
             final boolean finalEndpointsChanged = endpointsListChanged;
+            final List<String> finalNewEndpointIds = getEndpointIds();
             TaskPools.IO_POOL.submit(() -> {
                 final Conference conference = this.conference;
                 if (conference == null)
@@ -428,9 +429,10 @@ public class ConferenceSpeechActivity
                 {
                     conference.dominantSpeakerChanged();
                 }
-                if (finalEndpointsChanged)
+                // Dominant speaker changed implies that the list changed.
+                if (finalEndpointsChanged && !finalDominantSpeakerChanged)
                 {
-                    conference.speechActivityEndpointsChanged();
+                    conference.speechActivityEndpointsChanged(finalNewEndpointIds);
                 }
 
             });

--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -922,6 +922,14 @@ public class BitrateController
             // of the conference.
             adjustedLastN = Math.min(lastN, conferenceEndpoints.size() - 1);
         }
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("Prioritizing endpoints, adjusted last-n: " + adjustedLastN +
+                ", sorted endpoint list: " +
+                conferenceEndpoints.stream().map(AbstractEndpoint::getID).collect(Collectors.joining(", ")) +
+                ". Selected endpoints: " + String.join(", ", selectedEndpointIds) +
+                ". Pinned endpoints: " + String.join(", ", pinnedEndpointIds));
+        }
 
         int endpointPriority = 0;
 
@@ -935,6 +943,8 @@ public class BitrateController
                     || sourceEndpoint.getID().equals(destinationEndpoint.getID())
                     || !selectedEndpointIds.contains(sourceEndpoint.getID()))
             {
+                logger.trace(() -> "Endpoint " + sourceEndpoint.getID() + " is expired, is this destination, or " +
+                    "is not selected; ignoring");
                 continue;
             }
 
@@ -954,6 +964,7 @@ public class BitrateController
                             true /* selected */,
                             maxRxFrameHeightPx));
                 }
+                logger.trace(() -> "Adding endpoint " + sourceEndpoint.getID() + " to allocations");
 
                 endpointPriority++;
             }
@@ -972,6 +983,8 @@ public class BitrateController
                     || sourceEndpoint.getID().equals(destinationEndpoint.getID())
                     || !pinnedEndpointIds.contains(sourceEndpoint.getID()))
                 {
+                    logger.trace(() -> "Endpoint " + sourceEndpoint.getID() + " is expired, is this destination, or " +
+                        "is not pinned; ignoring");
                     continue;
                 }
 
@@ -991,6 +1004,7 @@ public class BitrateController
                                 maxRxFrameHeightPx));
                     }
 
+                    logger.trace(() -> "Adding endpoint " + sourceEndpoint.getID() + " to allocations");
                     endpointPriority++;
                 }
 
@@ -1025,6 +1039,7 @@ public class BitrateController
                                 maxRxFrameHeightPx));
                     }
 
+                    logger.debug(() -> "Adding endpoint " + sourceEndpoint.getID() + " to allocations");
                     endpointPriority++;
                 }
             }

--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -964,7 +964,7 @@ public class BitrateController
                             true /* selected */,
                             maxRxFrameHeightPx));
                 }
-                logger.trace(() -> "Adding endpoint " + sourceEndpoint.getID() + " to allocations");
+                logger.trace(() -> "Adding selected endpoint " + sourceEndpoint.getID() + " to allocations");
 
                 endpointPriority++;
             }
@@ -1004,7 +1004,7 @@ public class BitrateController
                                 maxRxFrameHeightPx));
                     }
 
-                    logger.trace(() -> "Adding endpoint " + sourceEndpoint.getID() + " to allocations");
+                    logger.trace(() -> "Adding pinned endpoint " + sourceEndpoint.getID() + " to allocations");
                     endpointPriority++;
                 }
 
@@ -1039,7 +1039,7 @@ public class BitrateController
                                 maxRxFrameHeightPx));
                     }
 
-                    logger.debug(() -> "Adding endpoint " + sourceEndpoint.getID() + " to allocations");
+                    logger.trace(() -> "Adding endpoint " + sourceEndpoint.getID() + " to allocations");
                     endpointPriority++;
                 }
             }


### PR DESCRIPTION
`BitrateController` needs to be told any time the order of active speakers changes (and have the new, correct order) for last-n to work correctly.  This issue did not affect non-last-n calls, as a `dominantSpeakerChanged` message would be sent to the client which would respond with a `SelectedEndpointMessage`.  Since selected endpoints are always given priority, that client would always be prioritized.  With last-n enabled, though, the `BitrateController` must have an accurate, up-to-date ordering of active endpoints so that the proper ones make it into last-n.

Note: in debugging this, we found the flow around updating the interested parties when active-speaker-list changes happen (which can be driven by a few things) feels pretty messy and would be worth revisiting; so this fix feels more like a hack on top of hacks.