### PR TITLE
Start jitsi-videobridge after nginx

### DIFF
--- a/debian/jitsi-videobridge2.service
+++ b/debian/jitsi-videobridge2.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Jitsi Videobridge
-After=network.target
+After=network.target nginx.service
 
 [Service]
 # allow bind to 80 and 443


### PR DESCRIPTION
`apt install jitsi-meet` results in an nginx that is unable to start because jitsi-videobridge has claimed port 443.

```
11396#11396: bind() to 0.0.0.0:443 failed (98: Address already in use)
11396#11396: bind() to 0.0.0.0:443 failed (98: Address already in use)
11396#11396: bind() to 0.0.0.0:443 failed (98: Address already in use)
11396#11396: bind() to 0.0.0.0:443 failed (98: Address already in use)
11396#11396: bind() to 0.0.0.0:443 failed (98: Address already in use)
11396#11396: still could not bind()
```

Making nginx start before jitsi-videobridge has solved this issue for me and can be done with the patch in this PR.

But why does the package `jitsi-meet` install two services that both want to bind on 443? (And why is jitsi-videobridge fine with not being able to bind on 443 because nginx has now claimed it?)