### PR TITLE
Move SR relay log to trace

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -469,9 +469,9 @@ public class Endpoint
             RtcpSrPacket rtcpSrPacket = (RtcpSrPacket) packet;
             bitrateController.transformRtcp(rtcpSrPacket);
 
-            if (logger.isDebugEnabled())
+            if (logger.isTraceEnabled())
             {
-                logger.debug(
+                logger.trace(
                     "relaying an sr from ssrc="
                         + rtcpSrPacket.getSenderSsrc()
                         + ", timestamp="


### PR DESCRIPTION
Setting the log level to FINE on Endpoint is basically filled with this log, currently.