### PR TITLE
Add optional sentry error tracking

### DIFF
--- a/lib/logging.properties
+++ b/lib/logging.properties
@@ -1,5 +1,6 @@
 handlers= java.util.logging.ConsoleHandler
 #handlers= java.util.logging.ConsoleHandler, com.agafua.syslog.SyslogHandler
+#handlers= java.util.logging.ConsoleHandler, io.sentry.jul.SentryHandler
 
 java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = org.jitsi.utils.logging2.JitsiLogFormatter
@@ -13,13 +14,16 @@ org.jitsi.videobridge.xmpp.ComponentImpl.level=FINE
 # All of the INFO level logs from MediaStreamImpl are unnecessary in the context of jitsi-videobridge.
 org.jitsi.impl.neomedia.MediaStreamImpl.level=WARNING
 
-# Syslog(uncomment handler to use)
+# Syslog (uncomment handler to use)
 com.agafua.syslog.SyslogHandler.transport = udp
 com.agafua.syslog.SyslogHandler.facility = local0
 com.agafua.syslog.SyslogHandler.port = 514
 com.agafua.syslog.SyslogHandler.hostname = localhost
 com.agafua.syslog.SyslogHandler.formatter = org.jitsi.utils.logging2.JitsiLogFormatter
 com.agafua.syslog.SyslogHandler.escapeNewlines = false
+
+# Sentry (uncomment handler to use)
+io.sentry.jul.SentryHandler.level=WARNING
 
 # to disable double timestamps in syslog uncomment next line
 #net.java.sip.communicator.util.ScLogFormatter.disableTimestamp=true

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,12 @@
       <version>0.4</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>io.sentry</groupId>
+      <artifactId>sentry</artifactId>
+      <version>1.7.30</version>
+      <scope>runtime</scope>
+    </dependency>
     <!-- test -->
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
Because Jitsi is using `java.util.logging` it is quite easy to implement:
https://docs.sentry.io/clients/java/integrations/#javautillogging

To configure the Sentry client the SENTRY_DSN environment variable has to be set. But there are also some other possibilities.

The same changes for the other jitsi repositories can be found here:
- https://github.com/jitsi/jigasi/pull/247
- https://github.com/jitsi/jicofo/pull/449