### PR TITLE
Record tcc timestamps when packets are sent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-media-transform</artifactId>
-      <version>1.0-137-gde1b071</version>
+      <version>1.0-139-g33e0a49</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/DtlsTransport.java
+++ b/src/main/java/org/jitsi/videobridge/DtlsTransport.java
@@ -641,6 +641,7 @@ public class DtlsTransport extends IceTransport
             {
                 try
                 {
+                    packetInfo.sent();
                     socket.send(
                         new DatagramPacket(
                                 packet.getBuffer(),

--- a/src/main/java/org/jitsi/videobridge/octo/OctoTentacle.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoTentacle.java
@@ -131,6 +131,7 @@ public class OctoTentacle extends PropertyChangeNotifier implements PotentialPac
                 @Override
                 protected void consume(@NotNull PacketInfo packetInfo)
                 {
+                    packetInfo.sent();
                     relay.sendPacket(packetInfo.getPacket(), targets,
                         conference.getGid(), packetInfo.getEndpointId());
                 }


### PR DESCRIPTION
This makes sure we don't treat internal packet queueing times as network congestion, causing us to reduce sending bandwidth.

Depends on https://github.com/jitsi/jitsi-media-transform/pull/245 .