### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/resources/timeseries-cli.py
+++ b/resources/timeseries-cli.py
@@ -103,7 +103,7 @@ def plot_endpoint(df, series, endpoint_id, remote_endpoint_id):
     if 'in_pkt' in series and 'in_pkt' in df_series:
         df_pkt = df[df['series'] == 'in_pkt']
 
-        if len(df_pkt['rbe_id'].unique()) is not 1:
+        if len(df_pkt['rbe_id'].unique()) != 1:
             raise Exception('There cannot be multiple remote bitrate estimators')
 
         df_sz = pd.DataFrame(


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. In Python >= 3.8, these instances will raise SyntaxWarnings so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

% python3.8
```
>>> 1 is 1
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```