### PR TITLE
Fix for Resource

### DIFF
--- a/src/main/java/org/jitsi/videobridge/rest/ssi/SSIResourceHandler.java
+++ b/src/main/java/org/jitsi/videobridge/rest/ssi/SSIResourceHandler.java
@@ -301,12 +301,11 @@ public class SSIResourceHandler
                     fileToInclude = aliasValue;
             }
 
-            Resource r = Resource.newResource(fileToInclude);
-
-            if (r.exists())
-            {
-                r.writeTo(out, 0, r.length());
-                return true;
+            try (Resource r = Resource.newResource(fileToInclude)) {
+                if (r.exists()) {
+                    r.writeTo(out, 0, r.length());
+                    return true;
+                }
             }
         }
         else


### PR DESCRIPTION
Closeable interface or its super-interface, AutoCloseable, needs to be closed after use.