### PR TITLE
Allow VP8 layers without temporal scalability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-media-transform</artifactId>
-      <version>1.0-142-g94e1c26</version>
+      <version>1.0-146-g0a3489f</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
@@ -246,8 +246,6 @@ public class AdaptiveTrackProjection
 
         if (context == null || contextPayloadType != payloadType)
         {
-            logger.debug(() -> " adaptive track projection " +
-                    " creating context for payload type " + payloadType);
             payloadTypeObject = payloadTypes.get((byte)payloadType);
             if (payloadTypeObject == null)
             {
@@ -284,6 +282,11 @@ public class AdaptiveTrackProjection
                 if (rtpState == null) {
                     return null;
                 }
+                logger.debug(() -> "adaptive track projection " +
+                    (context == null ? "creating new" : "changing to") +
+                    " VP8 context for payload type "
+                    + payloadType +
+                    ", source packet ssrc " + rtpPacket.getSsrc());
                 context = new VP8AdaptiveTrackProjectionContext(
                     diagnosticContext, payloadTypeObject, rtpState, parentLogger);
                 contextPayloadType = payloadType;
@@ -296,6 +299,19 @@ public class AdaptiveTrackProjection
                     return null;
                 }
                 // context switch
+                logger.debug(() -> {
+                    boolean hasTemporalLayer = rtpPacket instanceof Vp8Packet &&
+                        ((Vp8Packet)rtpPacket).getHasTemporalLayerIndex();
+                    boolean hasPictureId = rtpPacket instanceof Vp8Packet &&
+                        ((Vp8Packet)rtpPacket).getHasPictureId();
+                    return "adaptive track projection " +
+                        (context == null ? "creating new" : "changing to") +
+                        " generic context for non-scalable VP8 payload type "
+                        + payloadType +
+                        " (packet is " + rtpPacket.getClass().getSimpleName() +
+                        ", ssrc " + rtpPacket.getSsrc() +
+                        ", hasTL=" + hasTemporalLayer + ", hasPID=" + hasPictureId + ")";
+                });
                 context = new GenericAdaptiveTrackProjectionContext(payloadTypeObject, rtpState, parentLogger);
                 contextPayloadType = payloadType;
             }
@@ -309,6 +325,9 @@ public class AdaptiveTrackProjection
             if (rtpState == null) {
                 return null;
             }
+            logger.debug(() -> "adaptive track projection "  +
+                (context == null ? "creating new" : "changing to") +
+                " generic context for payload type " + payloadType);
             context = new GenericAdaptiveTrackProjectionContext(payloadTypeObject, rtpState, parentLogger);
             contextPayloadType = payloadType;
             return context;

--- a/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/AdaptiveTrackProjection.java
@@ -271,7 +271,8 @@ public class AdaptiveTrackProjection
 
             /* Check whether this stream is projectable by the VP8AdaptiveTrackProjectionContext. */
             boolean projectable = rtpPacket instanceof Vp8Packet &&
-                ((Vp8Packet)rtpPacket).getHasTemporalLayerIndex() &&
+                /* Work around Firefox 75 bug - https://bugzilla.mozilla.org/show_bug.cgi?id=1628851 */
+                /* ((Vp8Packet)rtpPacket).getHasTemporalLayerIndex() && */
                 ((Vp8Packet)rtpPacket).getHasPictureId();
 
             if (projectable

--- a/src/main/java/org/jitsi/videobridge/cc/GenericAdaptiveTrackProjectionContext.java
+++ b/src/main/java/org/jitsi/videobridge/cc/GenericAdaptiveTrackProjectionContext.java
@@ -178,7 +178,7 @@ class GenericAdaptiveTrackProjectionContext
                             destinationSequenceNumber,
                             sourceSequenceNumber);
 
-                logger.debug(() -> "delta ssrc=" + rtpPacket.getSsrc()
+                logger.trace(() -> "delta ssrc=" + rtpPacket.getSsrc()
                     + ",src_sequence=" + sourceSequenceNumber
                     + ",dst_sequence=" + destinationSequenceNumber
                     + ",max_sequence=" + maxDestinationSequenceNumber
@@ -220,14 +220,14 @@ class GenericAdaptiveTrackProjectionContext
                 maxDestinationTimestamp = destinationTimestamp;
             }
 
-                logger.debug(() -> "accept ssrc=" + rtpPacket.getSsrc()
+                logger.trace(() -> "accept ssrc=" + rtpPacket.getSsrc()
                 + ",src_sequence=" + sourceSequenceNumber
                 + ",dst_sequence=" + destinationSequenceNumber
                 + ",max_sequence=" + maxDestinationSequenceNumber);
         }
         else
         {
-            logger.debug(() -> "reject ssrc=" + rtpPacket.getSsrc()
+            logger.trace(() -> "reject ssrc=" + rtpPacket.getSsrc()
                 + ",src_sequence=" + sourceSequenceNumber);
         }
 

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveTrackProjectionContext.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveTrackProjectionContext.java
@@ -347,9 +347,9 @@ public class VP8AdaptiveTrackProjectionContext
      */
     private boolean checkDecodability(@NotNull VP8Frame frame)
     {
-        if (frame.isKeyframe() || frame.getTemporalLayer() == 0)
+        if (frame.isKeyframe() || frame.getTemporalLayer() <= 0)
         {
-            /* We'll always project all TL0 frames, and TL0PICIDX lets the
+            /* We'll always project all TL0 or unknown-TL frames, and TL0PICIDX lets the
              * decoder know if it's missed something, so no need to check.
              */
             return true;

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8Frame.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8Frame.java
@@ -184,10 +184,11 @@ class VP8Frame
 
     /**
      * @return true if this is a base temporal layer frame, false otherwise
+     * @note We treat unknown temporal layer frames as TL0.
      */
     boolean isTL0()
     {
-        return temporalLayer == 0;
+        return temporalLayer <= 0;
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameProjection.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameProjection.java
@@ -168,7 +168,10 @@ public class VP8FrameProjection
 
         pkt.setSequenceNumber(sequenceNumber);
 
-        pkt.setTL0PICIDX(tl0PICIDX);
+        if (pkt.getTL0PICIDX() != -1)
+        {
+            pkt.setTL0PICIDX(tl0PICIDX);
+        }
         pkt.setPictureId(extendedPictureId);
 
     }

--- a/src/main/java/org/jitsi/videobridge/cc/vp8/VP8QualityFilter.java
+++ b/src/main/java/org/jitsi/videobridge/cc/vp8/VP8QualityFilter.java
@@ -147,10 +147,7 @@ class VP8QualityFilter
 
         if (temporalLayerIdOfFrame < 0)
         {
-            // This is strange; If temporal scalability is enabled the TID is
-            // included in every packet (keyframe, interframe, continuation). So
-            // it seems like the encoder has disabled (or maybe it has never
-            // enabled?) temporal scalability.. For now we will pretend that
+            // temporal scalability is not enabled. Pretend that
             // this is the base temporal layer.
             temporalLayerIdOfFrame = 0;
         }


### PR DESCRIPTION
This works around a FF 75 bug https://bugzilla.mozilla.org/show_bug.cgi?id=1628851 .

Also improve some logging.