### PR TITLE
Replace deprecated usage of Stringutils with plain java calls

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -16,6 +16,7 @@
 package org.jitsi.videobridge;
 
 import kotlin.*;
+import org.apache.commons.lang3.StringUtils;
 import org.ice4j.ice.harvest.*;
 import org.ice4j.stack.*;
 import org.jetbrains.annotations.*;
@@ -26,7 +27,6 @@ import org.jitsi.nlj.*;
 import org.jitsi.nlj.util.*;
 import org.jitsi.osgi.*;
 import org.jitsi.service.configuration.*;
-import org.jitsi.utils.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.utils.queue.*;
 import org.jitsi.utils.version.Version;
@@ -820,7 +820,7 @@ public class Videobridge
      */
     public void setAuthorizedSourceRegExp(String authorizedSourceRegExp)
     {
-        if (!StringUtils.isNullOrEmpty(authorizedSourceRegExp))
+        if (!StringUtils.isBlank(authorizedSourceRegExp))
         {
             authorizedSourcePattern
                 = Pattern.compile(authorizedSourceRegExp);
@@ -871,7 +871,7 @@ public class Videobridge
                 ? null
                 : cfg.getString(SHUTDOWN_ALLOWED_SOURCE_REGEXP_PNAME);
 
-        if (!StringUtils.isNullOrEmpty(shutdownSourcesRegexp))
+        if (!StringUtils.isBlank(shutdownSourcesRegexp))
         {
             try
             {
@@ -888,7 +888,7 @@ public class Videobridge
         String authorizedSourceRegexp
             = (cfg == null)
                     ? null : cfg.getString(AUTHORIZED_SOURCE_REGEXP_PNAME);
-        if (!StringUtils.isNullOrEmpty(authorizedSourceRegexp))
+        if (!StringUtils.isBlank(authorizedSourceRegexp))
         {
             try
             {
@@ -1105,7 +1105,7 @@ public class Videobridge
 
         JSONObject conferences = new JSONObject();
         debugState.put("conferences", conferences);
-        if (StringUtils.isNullOrEmpty(conferenceId))
+        if (StringUtils.isBlank(conferenceId))
         {
             for (Conference conference : getConferences())
             {

--- a/src/main/java/org/jitsi/videobridge/rest/JSONDeserializer.java
+++ b/src/main/java/org/jitsi/videobridge/rest/JSONDeserializer.java
@@ -19,7 +19,7 @@ import java.lang.reflect.*;
 import java.net.*;
 import java.util.*;
 
-import org.jitsi.utils.*;
+import org.apache.commons.lang3.StringUtils;
 import org.jitsi.xmpp.extensions.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jitsi.xmpp.extensions.jingle.*;
@@ -477,7 +477,7 @@ public final class JSONDeserializer
                         .RTCPTerminationStrategy.NAME_ATTR_NAME);
 
             String name = Objects.toString(attrName, null);
-            if (StringUtils.isNullOrEmpty(name))
+            if (StringUtils.isBlank(name))
             {
                 return;
             }


### PR DESCRIPTION
This PR replaces the usage of the deprecated  `StringUtils.isNullorEmpty` with plain java calls.

Currently, there are a few more deprecated references in the codebase, but idk what the replacement for those instances is.
If someone can point me in the right direction I'll create PRs for those as well.

```
[WARNING] /jitsi-videobridge/src/main/java/org/jitsi/videobridge/octo/OctoPacket.java:[146,29] DATA in org.jitsi.utils.MediaType has been deprecated
[WARNING] /jitsi-videobridge/src/main/java/org/jitsi/videobridge/octo/OctoRelay.java:[409,26] DATA in org.jitsi.utils.MediaType has been deprecated
[WARNING] /jitsi-videobridge/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java:[112,25] RTP_LOSS in org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension has been deprecated
[WARNING] /jitsi-videobridge/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java:[413,21] RTP_LOSS in org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension has been deprecated
```