### PR TITLE
Msg transport handler interfaces

### DIFF
--- a/src/main/java/org/jitsi/videobridge/AbstractEndpointMessageTransport.java
+++ b/src/main/java/org/jitsi/videobridge/AbstractEndpointMessageTransport.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.octo.*;
 import org.jitsi.videobridge.util.*;
+import org.jitsi.videobridge.websocket.*;
 import org.json.simple.*;
 import org.json.simple.parser.*;
 
@@ -33,6 +34,7 @@ import static org.jitsi.videobridge.EndpointMessageBuilder.*;
  * @author Boris Grozev
  */
 public abstract class AbstractEndpointMessageTransport
+    implements ColibriWebSocket.EventHandler
 {
     /**
      * The name of the JSON property that indicates the target Octo endpoint id

--- a/src/main/java/org/jitsi/videobridge/AbstractEndpointMessageTransport.java
+++ b/src/main/java/org/jitsi/videobridge/AbstractEndpointMessageTransport.java
@@ -34,7 +34,6 @@ import static org.jitsi.videobridge.EndpointMessageBuilder.*;
  * @author Boris Grozev
  */
 public abstract class AbstractEndpointMessageTransport
-    implements ColibriWebSocket.EventHandler
 {
     /**
      * The name of the JSON property that indicates the target Octo endpoint id

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -79,8 +79,7 @@ import static org.jitsi.videobridge.EndpointMessageBuilder.*;
 public class Endpoint
     extends AbstractEndpoint implements PotentialPacketHandler,
         PropertyChangeListener,
-        EncodingsManager.EncodingsUpdateListener,
-        ColibriWebSocket.EventHandler
+        EncodingsManager.EncodingsUpdateListener
 {
     /**
      * Track how long it takes for all RTP and RTCP packets to make their way through the bridge.
@@ -158,6 +157,7 @@ public class Endpoint
      * The instance which manages the Colibri messaging (over a data channel
      * or web sockets).
      */
+    @NotNull
     private final EndpointMessageTransport messageTransport;
 
     /**
@@ -1002,48 +1002,6 @@ public class Endpoint
         }
 
         return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void webSocketConnected(ColibriWebSocket ws)
-    {
-        EndpointMessageTransport messageTransport
-            = getMessageTransport();
-        if (messageTransport != null)
-        {
-            messageTransport.onWebSocketConnect(ws);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void webSocketClosed(ColibriWebSocket ws, int statusCode, String reason)
-    {
-        EndpointMessageTransport messageTransport
-            = getMessageTransport();
-        if (messageTransport != null)
-        {
-            messageTransport.onWebSocketClose(ws, statusCode, reason);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void webSocketTextReceived(ColibriWebSocket ws, String message)
-    {
-        EndpointMessageTransport messageTransport
-            = getMessageTransport();
-        if (messageTransport != null)
-        {
-            messageTransport.onWebSocketText(ws, message);
-        }
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -79,7 +79,8 @@ import static org.jitsi.videobridge.EndpointMessageBuilder.*;
 public class Endpoint
     extends AbstractEndpoint implements PotentialPacketHandler,
         PropertyChangeListener,
-        EncodingsManager.EncodingsUpdateListener
+        EncodingsManager.EncodingsUpdateListener,
+        ColibriWebSocket.EventHandler
 {
     /**
      * Track how long it takes for all RTP and RTCP packets to make their way through the bridge.
@@ -1004,11 +1005,10 @@ public class Endpoint
     }
 
     /**
-     * Notifies this {@link Endpoint} that a specific {@link ColibriWebSocket}
-     * instance associated with it has connected.
-     * @param ws the {@link ColibriWebSocket} which has connected.
+     * {@inheritDoc}
      */
-    public void onWebSocketConnect(ColibriWebSocket ws)
+    @Override
+    public void webSocketConnected(ColibriWebSocket ws)
     {
         EndpointMessageTransport messageTransport
             = getMessageTransport();
@@ -1019,12 +1019,10 @@ public class Endpoint
     }
 
     /**
-     * Notifies this {@link Endpoint} that a specific {@link ColibriWebSocket}
-     * instance associated with it has been closed.
-     * @param ws the {@link ColibriWebSocket} which has been closed.
+     * {@inheritDoc}
      */
-    public void onWebSocketClose(
-            ColibriWebSocket ws, int statusCode, String reason)
+    @Override
+    public void webSocketClosed(ColibriWebSocket ws, int statusCode, String reason)
     {
         EndpointMessageTransport messageTransport
             = getMessageTransport();
@@ -1035,11 +1033,10 @@ public class Endpoint
     }
 
     /**
-     * Notifies this {@link Endpoint} that a message has been received from a
-     * specific {@link ColibriWebSocket} instance associated with it.
-     * @param ws the {@link ColibriWebSocket} from which a message was received.
+     * {@inheritDoc}
      */
-    public void onWebSocketText(ColibriWebSocket ws, String message)
+    @Override
+    public void webSocketTextReceived(ColibriWebSocket ws, String message)
     {
         EndpointMessageTransport messageTransport
             = getMessageTransport();

--- a/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
+++ b/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
@@ -38,7 +38,8 @@ import static org.jitsi.videobridge.EndpointMessageBuilder.*;
  */
 class EndpointMessageTransport
     extends AbstractEndpointMessageTransport
-    implements DataChannelStack.DataChannelMessageListener
+    implements DataChannelStack.DataChannelMessageListener,
+        ColibriWebSocket.EventHandler
 {
     /**
      * The last accepted web-socket by this instance, if any.

--- a/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
+++ b/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
@@ -298,13 +298,12 @@ class EndpointMessageTransport
         return getActiveTransportChannel() != null;
     }
 
+
     /**
-     * Notifies this {@link EndpointMessageTransport} that a specific
-     * {@link ColibriWebSocket} instance associated with its {@link Endpoint}
-     * has connected.
-     * @param ws the {@link ColibriWebSocket} which has connected.
+     * {@inheritDoc}
      */
-    void onWebSocketConnect(ColibriWebSocket ws)
+    @Override
+    public void webSocketConnected(ColibriWebSocket ws)
     {
         synchronized (webSocketSyncRoot)
         {
@@ -323,13 +322,10 @@ class EndpointMessageTransport
     }
 
     /**
-     * Notifies this {@link EndpointMessageTransport} that a specific
-     * {@link ColibriWebSocket} instance associated with its {@link Endpoint}
-     * has been closed.
-     * @param ws the {@link ColibriWebSocket} which has been closed.
+     * {@inheritDoc}
      */
-    public void onWebSocketClose(
-            ColibriWebSocket ws, int statusCode, String reason)
+    @Override
+    public void webSocketClosed(ColibriWebSocket ws, int statusCode, String reason)
     {
         synchronized (webSocketSyncRoot)
         {
@@ -370,12 +366,10 @@ class EndpointMessageTransport
     }
 
     /**
-     * Notifies this {@link EndpointMessageTransport} that a message has been
-     * received from a specific {@link ColibriWebSocket} instance associated
-     * with its {@link Endpoint}.
-     * @param ws the {@link ColibriWebSocket} from which a message was received.
+     * {@inheritDoc}
      */
-    public void onWebSocketText(ColibriWebSocket ws, String message)
+    @Override
+    public void webSocketTextReceived(ColibriWebSocket ws, String message)
     {
         if (ws == null || !ws.equals(webSocket))
         {

--- a/src/main/java/org/jitsi/videobridge/octo/OctoEndpointMessageTransport.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoEndpointMessageTransport.java
@@ -149,24 +149,6 @@ class OctoEndpointMessageTransport
     }
 
     @Override
-    public void webSocketConnected(ColibriWebSocket ws)
-    {
-
-    }
-
-    @Override
-    public void webSocketClosed(ColibriWebSocket ws, int statusCode, String reason)
-    {
-
-    }
-
-    @Override
-    public void webSocketTextReceived(ColibriWebSocket ws, String message)
-    {
-
-    }
-
-    @Override
     public boolean isConnected()
     {
         return true;

--- a/src/main/java/org/jitsi/videobridge/octo/OctoEndpointMessageTransport.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoEndpointMessageTransport.java
@@ -17,6 +17,7 @@ package org.jitsi.videobridge.octo;
 
 import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.*;
+import org.jitsi.videobridge.websocket.*;
 import org.json.simple.*;
 
 import java.util.*;
@@ -145,6 +146,24 @@ class OctoEndpointMessageTransport
             JSONObject jsonObject)
     {
         logUnexpectedMessage(jsonObject.toJSONString());
+    }
+
+    @Override
+    public void webSocketConnected(ColibriWebSocket ws)
+    {
+
+    }
+
+    @Override
+    public void webSocketClosed(ColibriWebSocket ws, int statusCode, String reason)
+    {
+
+    }
+
+    @Override
+    public void webSocketTextReceived(ColibriWebSocket ws, String message)
+    {
+
     }
 
     @Override

--- a/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocketServlet.java
+++ b/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocketServlet.java
@@ -165,7 +165,7 @@ class ColibriWebSocketServlet
             return null;
         }
 
-        return new ColibriWebSocket(ids[2], this, endpoint);
+        return new ColibriWebSocket(ids[2], this, endpoint.getMessageTransport());
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocketServlet.java
+++ b/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocketServlet.java
@@ -165,7 +165,7 @@ class ColibriWebSocketServlet
             return null;
         }
 
-        return new ColibriWebSocket(this, endpoint);
+        return new ColibriWebSocket(ids[2], this, endpoint);
     }
 
     /**


### PR DESCRIPTION
This decouples websocket code from the endpoint, and instead defines an event handler in `ColibriWebSocket` which can be implemented.  It also skips passing websocket messages through the Endpoint and sends them directly to the endpoint message transport (the code in endpoint was just passthrough logic anyway).  

This is some refactoring I bumped into when doing work to make Octo endpoints more similar to local endpoints.