### PR TITLE
Move octo pipelines to individual OctoEndpoint instances

### DIFF
--- a/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -15,6 +15,8 @@
  */
 package org.jitsi.videobridge;
 
+import org.jitsi.nlj.format.*;
+import org.jitsi.nlj.rtp.*;
 import org.jitsi.nlj.util.*;
 import org.jitsi.utils.*;
 import org.jitsi.utils.event.*;
@@ -427,4 +429,14 @@ public abstract class AbstractEndpoint extends PropertyChangeNotifier
      * Whether the remote endpoint is currently sending video.
      */
     public abstract boolean isSendingVideo();
+
+    /**
+     * Adds a payload type to this endpoint.
+     */
+    public abstract void addPayloadType(PayloadType payloadType);
+
+    /**
+     * Adds an RTP extension to this endpoint
+     */
+    public abstract void addRtpExtension(RtpExtension rtpExtension);
 }

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -205,7 +205,7 @@ public class Conference
     /**
      * This {@link Conference}'s link to Octo.
      */
-    private OctoTentacle tentacle;
+    private ConfOctoTransport tentacle;
 
     /**
      * Initializes a new <tt>Conference</tt> instance which is to represent a
@@ -1221,13 +1221,13 @@ public class Conference
     }
 
     /**
-     * @return The {@link OctoTentacle} for this conference.
+     * @return The {@link ConfOctoTransport} for this conference.
      */
-    public OctoTentacle getTentacle()
+    public ConfOctoTransport getTentacle()
     {
         if (tentacle == null)
         {
-            tentacle = new OctoTentacle(this);
+            tentacle = new ConfOctoTransport(this);
             tentacle.addPropertyChangeListener(propertyChangeListener);
         }
         return tentacle;
@@ -1320,7 +1320,7 @@ public class Conference
             debugState.put("includeInStatistics", includeInStatistics);
             debugState.put("statistics", statistics.getJson());
             //debugState.put("encodingsManager", encodingsManager.getDebugState());
-            OctoTentacle tentacle = this.tentacle;
+            ConfOctoTransport tentacle = this.tentacle;
             debugState.put(
                     "tentacle",
                     tentacle == null ? null : tentacle.getDebugState());

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -676,10 +676,17 @@ public class Endpoint
     /**
      * Adds a payload type to this endpoint.
      */
+    @Override
     public void addPayloadType(PayloadType payloadType)
     {
         transceiver.addPayloadType(payloadType);
         bitrateController.addPayloadType(payloadType);
+    }
+
+    @Override
+    public void addRtpExtension(RtpExtension rtpExtension)
+    {
+        transceiver.addRtpExtension(rtpExtension);
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -31,7 +31,6 @@ import org.jitsi.service.configuration.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.utils.queue.*;
 import org.jitsi.utils.version.Version;
-import org.jitsi.videobridge.health.*;
 import org.jitsi.videobridge.ice.*;
 import org.jitsi.videobridge.octo.*;
 import org.jitsi.videobridge.octo.config.*;
@@ -1136,7 +1135,7 @@ public class Videobridge
                 getJsonFromQueueErrorHandler(Endpoint.queueErrorCounter));
         queueStats.put(
                 "octo_receive_queue",
-                getJsonFromQueueErrorHandler(OctoTentacle.queueErrorCounter));
+                getJsonFromQueueErrorHandler(ConfOctoTransport.queueErrorCounter));
         queueStats.put(
                 "octo_send_queue",
                 getJsonFromQueueErrorHandler(OctoRtpReceiver.queueErrorCounter));

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -1136,7 +1136,7 @@ public class Videobridge
                 getJsonFromQueueErrorHandler(Endpoint.queueErrorCounter));
         queueStats.put(
                 "octo_receive_queue",
-                getJsonFromQueueErrorHandler(OctoRtpSender.queueErrorCounter));
+                getJsonFromQueueErrorHandler(OctoTentacle.queueErrorCounter));
         queueStats.put(
                 "octo_send_queue",
                 getJsonFromQueueErrorHandler(OctoRtpReceiver.queueErrorCounter));

--- a/src/main/java/org/jitsi/videobridge/octo/ConfOctoTransport.java
+++ b/src/main/java/org/jitsi/videobridge/octo/ConfOctoTransport.java
@@ -224,7 +224,7 @@ public class ConfOctoTransport extends PropertyChangeNotifier
         }
         else
         {
-            // Packets without an endpoint ID originalted from within the bridge
+            // Packets without an endpoint ID originated from within the bridge
             // itself and, in practice, are things like keyframe requests.  We
             // send them out directly (without queueing).
             doSend(packet);
@@ -383,7 +383,7 @@ public class ConfOctoTransport extends PropertyChangeNotifier
     public void expire()
     {
         logger.info("Expiring");
-        setRelays(new LinkedList<>());
+        setRelays(Collections.emptyList());
         octoEndpoints.setEndpoints(Collections.emptySet());
         outgoingPacketQueues.values().forEach(PacketInfoQueue::close);
         outgoingPacketQueues.clear();

--- a/src/main/java/org/jitsi/videobridge/octo/ConfOctoTransport.java
+++ b/src/main/java/org/jitsi/videobridge/octo/ConfOctoTransport.java
@@ -549,7 +549,7 @@ public class ConfOctoTransport extends PropertyChangeNotifier
 
             debugState.put("packets_sent", packetsSent.sum());
             debugState.put("send_packet_rate_pps", sendPacketRate.getRate());
-            debugState.put("bytes_sent", bytesSent);
+            debugState.put("bytes_sent", bytesSent.sum());
             debugState.put("send_bitrate_bps", sendBitRate.getRate());
 
             return debugState;

--- a/src/main/java/org/jitsi/videobridge/octo/ConfOctoTransport.java
+++ b/src/main/java/org/jitsi/videobridge/octo/ConfOctoTransport.java
@@ -21,8 +21,6 @@ import org.jitsi.nlj.format.*;
 import org.jitsi.nlj.rtp.*;
 import org.jitsi.nlj.util.*;
 import org.jitsi.osgi.*;
-import org.jitsi.rtp.*;
-import org.jitsi.rtp.rtcp.*;
 import org.jitsi.utils.*;
 import org.jitsi.utils.event.*;
 import org.jitsi.utils.logging2.*;
@@ -36,7 +34,6 @@ import org.jitsi.videobridge.xmpp.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jitsi.xmpp.extensions.jingle.*;
 import org.jitsi_modified.impl.neomedia.rtp.*;
-import org.json.simple.*;
 import org.osgi.framework.*;
 
 import java.net.*;
@@ -57,17 +54,17 @@ import static org.jitsi.videobridge.transport.octo.OctoUtils.JVB_EP_ID;
  *
  * @author Boris Grozev
  */
-public class OctoTentacle extends PropertyChangeNotifier
+public class ConfOctoTransport extends PropertyChangeNotifier
     implements PotentialPacketHandler, BridgeOctoTransport.IncomingOctoPacketHandler
 {
     /**
-     * The {@link Logger} used by the {@link OctoTentacle} class and its
+     * The {@link Logger} used by the {@link ConfOctoTransport} class and its
      * instances to print debug information.
      */
     private final Logger logger;
 
     /**
-     * The conference for this {@link OctoTentacle}.
+     * The conference for this {@link ConfOctoTransport}.
      */
     private final Conference conference;
 
@@ -118,15 +115,15 @@ public class OctoTentacle extends PropertyChangeNotifier
     private final Clock clock;
 
     /**
-     * Initializes a new {@link OctoTentacle} instance.
+     * Initializes a new {@link ConfOctoTransport} instance.
      * @param conference the conference.
      */
-    public OctoTentacle(Conference conference)
+    public ConfOctoTransport(Conference conference)
     {
         this(conference, Clock.systemUTC());
     }
 
-    public OctoTentacle(Conference conference, Clock clock)
+    public ConfOctoTransport(Conference conference, Clock clock)
     {
         this.conference = conference;
         this.clock = clock;

--- a/src/main/java/org/jitsi/videobridge/octo/ConfOctoTransport.java
+++ b/src/main/java/org/jitsi/videobridge/octo/ConfOctoTransport.java
@@ -284,6 +284,7 @@ public class ConfOctoTransport extends PropertyChangeNotifier
         else
         {
             stats.incomingPacketDropped();
+            ByteBufferPool.returnBuffer(packetInfo.getPacket().getBuffer());
         }
     }
 

--- a/src/main/java/org/jitsi/videobridge/octo/OctoTentacle.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoTentacle.java
@@ -43,7 +43,7 @@ import java.util.stream.*;
  * @author Boris Grozev
  */
 public class OctoTentacle extends PropertyChangeNotifier
-    implements PotentialPacketHandler, OctoTransport.IncomingOctoPacketHandler
+    implements PotentialPacketHandler, BridgeOctoTransport.IncomingOctoPacketHandler
 {
     /**
      * The {@link Logger} used by the {@link OctoTentacle} class and its
@@ -68,9 +68,9 @@ public class OctoTentacle extends PropertyChangeNotifier
     private final OctoTransceiver transceiver;
 
     /**
-     * The {@link OctoTransport} used to actually send and receive Octo packets.
+     * The {@link BridgeOctoTransport} used to actually send and receive Octo packets.
      */
-    private final OctoTransport octoTransport;
+    private final BridgeOctoTransport bridgeOctoTransport;
 
     /**
      * The list of remote Octo targets.
@@ -96,8 +96,8 @@ public class OctoTentacle extends PropertyChangeNotifier
             throw new IllegalStateException("Couldn't get OctoRelayService");
         }
 
-        octoTransport = octoRelayService.getOctoTransport();
-        if (octoTransport == null)
+        bridgeOctoTransport = octoRelayService.getBridgeOctoTransport();
+        if (bridgeOctoTransport == null)
         {
             throw new IllegalStateException("Couldn't get OctoTransport");
         }
@@ -110,7 +110,7 @@ public class OctoTentacle extends PropertyChangeNotifier
         transceiver.setOutgoingPacketHandler(packetInfo ->
         {
             packetInfo.sent();
-            octoTransport.sendMediaData(
+            bridgeOctoTransport.sendMediaData(
                 packetInfo.getPacket().getBuffer(),
                 packetInfo.getPacket().getOffset(),
                 packetInfo.getPacket().getLength(),
@@ -137,7 +137,7 @@ public class OctoTentacle extends PropertyChangeNotifier
     public void setRelays(Collection<String> relays)
     {
         Objects.requireNonNull(
-                octoTransport,
+            bridgeOctoTransport,
                 "Octo requested but not configured");
 
         Set<SocketAddress> socketAddresses = new HashSet<>();
@@ -276,11 +276,11 @@ public class OctoTentacle extends PropertyChangeNotifier
 
             if (targets.isEmpty())
             {
-                octoTransport.removeHandler(conference.getGid(), this);
+                bridgeOctoTransport.removeHandler(conference.getGid(), this);
             }
             else
             {
-                octoTransport.addHandler(conference.getGid(), this);
+                bridgeOctoTransport.addHandler(conference.getGid(), this);
             }
         }
     }
@@ -311,7 +311,7 @@ public class OctoTentacle extends PropertyChangeNotifier
      */
     public void sendMessage(String message)
     {
-        octoTransport.sendString(
+        bridgeOctoTransport.sendString(
             message,
             targets,
             conference.getGid()
@@ -328,7 +328,7 @@ public class OctoTentacle extends PropertyChangeNotifier
         JSONObject debugState = new JSONObject();
         debugState.put("octoEndpoints", octoEndpoints.getDebugState());
         debugState.put("transceiver", transceiver.getDebugState());
-        debugState.put("octoTransport", octoTransport.getStatsJson());
+        debugState.put("bridgeOctoTransport", bridgeOctoTransport.getStatsJson());
         debugState.put("targets", targets.toString());
 
         return debugState;

--- a/src/main/java/org/jitsi/videobridge/octo/OctoTentacle.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoTentacle.java
@@ -88,6 +88,10 @@ public class OctoTentacle extends PropertyChangeNotifier
     private Set<SocketAddress> targets
             = Collections.unmodifiableSet(new HashSet<>());
 
+    /**
+     * Handlers for incoming Octo media packets, looked up by the
+     * source endpoint ID field in the Octo header.
+     */
     private final Map<String, IncomingOctoEpPacketHandler> incomingPacketHandlers =
         new ConcurrentHashMap<>();
 
@@ -98,7 +102,7 @@ public class OctoTentacle extends PropertyChangeNotifier
         = new CountingErrorHandler();
 
     /**
-     * The queues which pass packets to be sent.
+     * We queue up outgoing packets by their *source* endpoint ID.
      */
     private final Map<String, PacketInfoQueue> outgoingPacketQueues =
         new ConcurrentHashMap<>();

--- a/src/main/java/org/jitsi/videobridge/octo/OctoTransceiver.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoTransceiver.java
@@ -22,7 +22,6 @@ import org.jitsi.nlj.rtp.*;
 import org.jitsi.nlj.stats.*;
 import org.jitsi.nlj.transform.*;
 import org.jitsi.nlj.util.*;
-import org.jitsi.utils.collections.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.*;
 import org.jitsi.videobridge.octo.config.*;
@@ -31,7 +30,7 @@ import org.json.simple.*;
 
 /**
  * Parses and handles incoming RTP/RTCP packets from an Octo source for a
- * specific {@link Conference}/{@link OctoTentacle}.
+ * specific {@link Conference}/{@link ConfOctoTransport}.
  *
  * @author Boris Grozev
  */

--- a/src/main/java/org/jitsi/videobridge/octo/OctoTransceiver.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoTransceiver.java
@@ -22,11 +22,14 @@ import org.jitsi.nlj.rtp.*;
 import org.jitsi.nlj.stats.*;
 import org.jitsi.nlj.transform.*;
 import org.jitsi.nlj.util.*;
+import org.jitsi.utils.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.*;
 import org.jitsi.videobridge.octo.config.*;
 import org.jitsi_modified.impl.neomedia.rtp.*;
 import org.json.simple.*;
+
+import java.util.*;
 
 /**
  * Parses and handles incoming RTP/RTCP packets from an Octo source for a
@@ -80,6 +83,31 @@ public class OctoTransceiver implements Stoppable, NodeStatsProducer
     void requestKeyframe(long mediaSsrc)
     {
         octoSender.requestKeyframe(mediaSsrc);
+    }
+
+    void requestKeyframe()
+    {
+        octoSender.requestKeyframe(null);
+    }
+
+    boolean receivesSsrc(long ssrc)
+    {
+        return streamInformationStore.getReceiveSsrcs().contains(ssrc);
+    }
+
+    void setReceiveSsrcs(Map<MediaType, Set<Long>> ssrcsByMediaType)
+    {
+        streamInformationStore.getReceiveSsrcs().forEach(streamInformationStore::removeReceiveSsrc);
+        ssrcsByMediaType.forEach((mediaType, ssrcs) -> {
+            ssrcs.forEach(ssrc -> {
+                streamInformationStore.addReceiveSsrc(ssrc, mediaType);
+            });
+        });
+    }
+
+    boolean hasReceiveSsrcs()
+    {
+        return !streamInformationStore.getReceiveSsrcs().isEmpty();
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/octo/OctoTransceiver.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoTransceiver.java
@@ -122,14 +122,6 @@ public class OctoTransceiver {
     }
 
     /**
-     * Called when a local endpoint is expired.
-     */
-    public void endpointExpired(String endpointId)
-    {
-        octoSender.endpointExpired(endpointId);
-    }
-
-    /**
      * Adds a payload type to this transceiver.
      *
      * @param payloadType the payload type to add

--- a/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
@@ -363,7 +363,7 @@ public class ChannelShim
             RtpExtension rtpExtension = createRtpExtension(ext);
             if (rtpExtension != null)
             {
-                endpoint.getTransceiver().addRtpExtension(rtpExtension);
+                endpoint.addRtpExtension(rtpExtension);
             }
             else
             {

--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -210,7 +210,7 @@ public class ConferenceShim
                 @NotNull ColibriConferenceIQ.Channel audioChannel,
                 @NotNull ColibriConferenceIQ.Channel videoChannel)
     {
-        OctoTentacle tentacle = conference.getTentacle();
+        ConfOctoTransport tentacle = conference.getTentacle();
 
         int expire
                 = Math.min(audioChannel.getExpire(), videoChannel.getExpire());

--- a/src/main/kotlin/org/jitsi/videobridge/octo/OctoEndpoint.kt
+++ b/src/main/kotlin/org/jitsi/videobridge/octo/OctoEndpoint.kt
@@ -81,7 +81,6 @@ class OctoEndpoint(
     }
 
     override fun requestKeyframe(mediaSsrc: Long) {
-        // just making sure the tentacle hasn't expired
         transceiver.requestKeyframe(mediaSsrc)
     }
 

--- a/src/main/kotlin/org/jitsi/videobridge/octo/OctoEndpoint.kt
+++ b/src/main/kotlin/org/jitsi/videobridge/octo/OctoEndpoint.kt
@@ -16,6 +16,8 @@
 
 package org.jitsi.videobridge.octo
 
+import org.jitsi.nlj.format.PayloadType
+import org.jitsi.nlj.rtp.RtpExtension
 import org.jitsi.nlj.util.StreamInformationStore
 import org.jitsi.nlj.util.StreamInformationStoreImpl
 import org.jitsi.utils.MediaType
@@ -76,6 +78,12 @@ class OctoEndpoint(
 
     override fun addReceiveSsrc(ssrc: Long, mediaType: MediaType?) {
         // This is controlled through setReceiveSsrcs.
+    }
+
+    override fun addPayloadType(payloadType: PayloadType?) {
+    }
+
+    override fun addRtpExtension(rtpExtension: RtpExtension?) {
     }
 
     override fun expire() {

--- a/src/main/kotlin/org/jitsi/videobridge/octo/OctoEndpoint.kt
+++ b/src/main/kotlin/org/jitsi/videobridge/octo/OctoEndpoint.kt
@@ -41,7 +41,7 @@ class OctoEndpoint(
     id: String,
     private val octoEndpoints: OctoEndpoints,
     parentLogger: Logger
-) : AbstractEndpoint(conference, id, parentLogger), OctoTentacle.IncomingOctoEpPacketHandler {
+) : AbstractEndpoint(conference, id, parentLogger), ConfOctoTransport.IncomingOctoEpPacketHandler {
 
     /**
      * Information about the streams belonging to this [OctoEndpoint]

--- a/src/main/kotlin/org/jitsi/videobridge/transport/octo/BridgeOctoTransport.kt
+++ b/src/main/kotlin/org/jitsi/videobridge/transport/octo/BridgeOctoTransport.kt
@@ -39,7 +39,7 @@ import kotlin.math.floor
 import kotlin.math.log10
 
 /**
- * [OctoTransport] handles *all* incoming and outgoing Octo traffic for a
+ * [BridgeOctoTransport] handles *all* incoming and outgoing Octo traffic for a
  * given bridge.
  *
  * [relayId] is the Octo relay ID which will be advertised by this JVB.
@@ -47,7 +47,7 @@ import kotlin.math.log10
  * this bridge is accessible on.  With the current implementation the ID just
  * encodes a pre-configured IP address and port, e.g. "10.0.0.1:20000"
  */
-class OctoTransport(
+class BridgeOctoTransport(
     val relayId: String,
     parentLogger: Logger
 ) {
@@ -68,7 +68,7 @@ class OctoTransport(
     private val unknownConferences: MutableMap<String, AtomicLong> = ConcurrentHashMap()
 
     /**
-     * The handler which will be invoked when this [OctoTransport] wants to
+     * The handler which will be invoked when this [BridgeOctoTransport] wants to
      * send data.
      */
     var outgoingDataHandler: OutgoingOctoPacketHandler? = null

--- a/src/main/kotlin/org/jitsi/videobridge/transport/octo/BridgeOctoTransport.kt
+++ b/src/main/kotlin/org/jitsi/videobridge/transport/octo/BridgeOctoTransport.kt
@@ -28,6 +28,7 @@ import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.videobridge.octo.OctoPacket
 import org.jitsi.videobridge.octo.OctoPacket.OCTO_HEADER_LENGTH
 import org.jitsi.videobridge.octo.OctoPacketInfo
+import org.jitsi.videobridge.transport.octo.OctoUtils.Companion.JVB_EP_ID
 import org.jitsi.videobridge.util.ByteBufferPool
 import java.net.SocketAddress
 import java.nio.charset.StandardCharsets
@@ -182,7 +183,7 @@ class BridgeOctoTransport(
         val octoPacketLength = len + OCTO_HEADER_LENGTH
 
         // Not all packets originate from an endpoint (e.g. some come from the bridge)
-        val epId = sourceEpId ?: "ffffffff"
+        val epId = sourceEpId ?: JVB_EP_ID
 
         val (newBuf, newOff) = when {
             off >= OCTO_HEADER_LENGTH -> {

--- a/src/main/kotlin/org/jitsi/videobridge/transport/octo/OctoUtils.kt
+++ b/src/main/kotlin/org/jitsi/videobridge/transport/octo/OctoUtils.kt
@@ -22,6 +22,7 @@ import java.net.SocketAddress
 
 class OctoUtils {
     companion object {
+        const val JVB_EP_ID = "ffffffff"
         fun relayIdToSocketAddress(relayId: String): SocketAddress? {
             if (!relayId.contains(":")) {
                 return null

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -62,11 +62,8 @@ videobridge {
     # The address which controls the public address which
     # will be part of the Octo relayId
     #public-address=198.51.100.1
-    # The size of the incoming octo queue. This is a conference level queue and
-    # it's where we temporarily store packets from remote bridges.
-    #
-    # This queue is per-remote-endpoint, so it matches what we use for local
-    # endpoints
+    # The size of the incoming octo queue. This queue is per-remote-endpoint,
+    # so it matches what we use for local endpoints
     recv-queue-size=1024
     # The size of the outgoing octo queue.  This is a per-originating-endpoint
     # queue, so assuming all packets are routed (as they currently are for Octo)

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -65,9 +65,9 @@ videobridge {
     # The size of the incoming octo queue. This is a conference level queue and
     # it's where we temporarily store packets from remote bridges.
     #
-    # With 4096 we observe no drops in a 100-participant call with 
-    # 20 senders across 4 bridges (c5.xlarge)
-    recv-queue-size=4096
+    # This queue is per-remote-endpoint, so it matches what we use for local
+    # endpoints
+    recv-queue-size=1024
     # The size of the outgoing octo queue.  This is a per-originating-endpoint
     # queue, so assuming all packets are routed (as they currently are for Octo)
     # it should be the same size as the transceiver recv queue in


### PR DESCRIPTION
This is another step in making Octo/remote endpoints act more like local endpoints.  This change moves from a single `OctoTransceiver` instance per conference to one per `OctoEndpoint`, and the `OctoTentacle` demuxes incoming Octo packets to their appropriate `OctoEndpoint` for processing (note that a conference-level `OctoTransceiver` does still exist to process incoming Octo packets which originated from a remote bridge and have no source endpoint ID set).

This means that we no longer have a single incoming Octo packet queue per conference, but instead individual queues per remote endpoint, just like local endpoints.