### PR TITLE
call super.expire in OctoEndpoint#expire

### DIFF
--- a/src/main/kotlin/org/jitsi/videobridge/octo/OctoEndpoint.kt
+++ b/src/main/kotlin/org/jitsi/videobridge/octo/OctoEndpoint.kt
@@ -112,6 +112,7 @@ class OctoEndpoint(
         if (super.isExpired()) {
             return
         }
+        super.expire()
         transceiver.stop()
         logger.debug { transceiver.getNodeStats().prettyPrint() }
         conference.tentacle.removeHandler(id, this)


### PR DESCRIPTION
not doing this was causing leftover endpoints to 'pile up' in the
conference