### PR TITLE
Drop IOException from Endpoint constructor signature.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -670,7 +670,6 @@ public class Conference
      */
     @NotNull
     public Endpoint createLocalEndpoint(String id, boolean iceControlling)
-        throws IOException
     {
         final AbstractEndpoint existingEndpoint = getEndpoint(id);
         if (existingEndpoint instanceof OctoEndpoint)

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -266,7 +266,6 @@ public class Endpoint
         Logger parentLogger,
         boolean iceControlling,
         Clock clock)
-        throws IOException
     {
         super(conference, id, parentLogger);
 
@@ -353,7 +352,6 @@ public class Endpoint
         Conference conference,
         Logger parentLogger,
         boolean iceControlling)
-        throws IOException
     {
         this(id, conference, parentLogger, iceControlling, Clock.systemUTC());
     }

--- a/src/main/java/org/jitsi/videobridge/health/Health.java
+++ b/src/main/java/org/jitsi/videobridge/health/Health.java
@@ -60,17 +60,9 @@ public class Health
 
         for (int i = 0; i < numEndpoints; ++i)
         {
-            final Endpoint endpoint;
-            try
-            {
-                final boolean iceControlling = i % 2 == 0;
-                endpoint = conference.createLocalEndpoint(
-                    generateEndpointID(), iceControlling);
-            }
-            catch (IOException ioe)
-            {
-                throw new RuntimeException(ioe);
-            }
+            final boolean iceControlling = i % 2 == 0;
+            final Endpoint endpoint = conference.createLocalEndpoint(
+                generateEndpointID(), iceControlling);
 
             //endpoints.add(endpoint);
 

--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -314,26 +314,15 @@ public class ConferenceShim
      * @param endpointId identifier of endpoint to check and initialize
      * @param iceControlling ICE control role of transport of newly created
      * endpoint
-     * @throws VideobridgeShim.IqProcessingException
      */
     private void ensureEndpointCreated(String endpointId, boolean iceControlling)
-        throws VideobridgeShim.IqProcessingException
     {
         if (conference.getLocalEndpoint(endpointId) != null)
         {
             return;
         }
-        try
-        {
-            conference.createLocalEndpoint(endpointId, iceControlling);
-        }
-        catch (IOException ioe)
-        {
-            throw new VideobridgeShim.IqProcessingException(
-                XMPPError.Condition.internal_server_error,
-                "Error initializing endpoint " +
-                    endpointId);
-        }
+
+        conference.createLocalEndpoint(endpointId, iceControlling);
     }
 
     /**


### PR DESCRIPTION
As long as `Endpoint` no longer generate `IOException` it could be removed, what do you think? 