### PR TITLE
Fixed prioritezation of TrackBitrateAllocation[] when endpoint has multiple tracks

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -956,7 +956,6 @@ public class BitrateController
                 for (MediaStreamTrackDesc track : tracks)
                 {
                     trackBitrateAllocations.add(
-                        endpointPriority,
                         new TrackBitrateAllocation(
                             sourceEndpoint,
                             track,
@@ -996,7 +995,7 @@ public class BitrateController
                     for (MediaStreamTrackDesc track : tracks)
                     {
                         trackBitrateAllocations.add(
-                            endpointPriority, new TrackBitrateAllocation(
+                            new TrackBitrateAllocation(
                                 sourceEndpoint,
                                 track,
                                 true /* fitsInLastN */,
@@ -1033,7 +1032,7 @@ public class BitrateController
                     for (MediaStreamTrackDesc track : tracks)
                     {
                         trackBitrateAllocations.add(
-                            endpointPriority, new TrackBitrateAllocation(
+                            new TrackBitrateAllocation(
                                 sourceEndpoint, track,
                                 forwarded, false /* selected */,
                                 maxRxFrameHeightPx));


### PR DESCRIPTION
This `PR` fixes prioritization of `TrackBitrateAllocation`s when single endpoint has multiple tracks. In my case endpoint has dedicated camera and screen sharing tracks.

**Steps to reproduce:**
1. Use conference with `LastN=1` across all peers joining conference;
2. User A joins the conference with `2` video tracks: `User-A-camera` and `User-A-screen`;
3. User B joins the conference with video track `User-B-video` and selects User A endpoint to observe it;
4. User B receives both video tracks of User A;
5. User C joins the conference with video track `User-C-video` and selects User A endpoint to observe it;

**Actual result:**
User B and User C stops receiving one of the video tracks of `User A` while another is being received fine;

**Expected result:**
Both tracks of User A received by User B and User C.

**Description:**

User B and User C stops receiving one of the tracks of User A because of incorrect ordering of tracks in `TrackBitrateAllocation[]` after `prioritize` execution:
https://github.com/jitsi/jitsi-videobridge/blob/5f9377b9b2c8201a02e047426e341874f43ca1ee/src/main/java/org/jitsi/videobridge/cc/BitrateController.java#L906-L1049

When `prioritize` executed on `BitrateController` of `User B` endpoint, it consider tracks of  `User A` and `User C` endpoints.

The first part of `prioritize` is picking tracks of selected endpoints:
https://github.com/jitsi/jitsi-videobridge/blob/5f9377b9b2c8201a02e047426e341874f43ca1ee/src/main/java/org/jitsi/videobridge/cc/BitrateController.java#L936-L973

When that part of `prioritize` finished, the state of `trackBitrateAllocations` and `endpointPriority` is the following:
```
trackBitrateAllocations: [
    0: (`User-A-screen`, fitsInLastN: true), 
    1: (`User-A-camera`, fitsInLastN: true)
]
endpointPriority = 1
```

Then `prioritize` is picking tracks of pinned endpoints:
https://github.com/jitsi/jitsi-videobridge/blob/5f9377b9b2c8201a02e047426e341874f43ca1ee/src/main/java/org/jitsi/videobridge/cc/BitrateController.java#L976-L1013

In my case the set of pinned endpoints is empty and the state of `trackBitrateAllocations` and `endpointPriority` has not changed since previous step:
```
trackBitrateAllocations: [
    0: (`User-A-screen`, fitsInLastN: true), 
    1: (`User-A-camera`, fitsInLastN: true)
]
endpointPriority = 1
```

Last part of `prioritize` is picking tracks from the rest of endpoints:
https://github.com/jitsi/jitsi-videobridge/blob/5f9377b9b2c8201a02e047426e341874f43ca1ee/src/main/java/org/jitsi/videobridge/cc/BitrateController.java#L1015-L1046

And at that moment the order of `trackBitrateAllocations` messed due `List.add(index, item)` which insert item in specific list position is used. When the track of `User C` is inspected it is NOT appended to the end of the `trackBitrateAllocations` list, but rather inserted at position `endpointPriority = 1`.
The state of `trackBitrateAllocations` and `endpointPriority` after`prioritize` finished execution is the following:

```
trackBitrateAllocations: [
    0: (`User-A-screen`, fitsInLastN: true), 
    1: (`User-C-video`, fitsInLastN: false), // <-- should not be here
    2: (`User-A-camera`, fitsInLastN: true)
]
endpointPriority = 2
```

The track of endpoint `User C` which is not selected was inserted in the middle of tracks of `User A` which is selected. As a consequence the track `User-A-camera` of selected endpoint `User A` is stopped being forwarded to `User B`.

This PR fixes population of `trackBitrateAllocations` list. Now new `TrackBitrateAllocation` items are always appended at the end of the `trackBitrateAllocations` list and not inserted somewhere in the middle. I believe this is an exactly what `prioritize` code was intended to to, but issue was never noticed, due widespread usage of single track per endpoint.