### PR TITLE
WIP: Use usrsctp only from dedicated single thread.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/sctp/SctpManager.java
+++ b/src/main/java/org/jitsi/videobridge/sctp/SctpManager.java
@@ -22,6 +22,8 @@ import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.util.*;
 import org.jitsi_modified.sctp4j.*;
 
+import java.util.concurrent.*;
+
 /**
  * Manages the SCTP connection and handles incoming and outgoing SCTP packets.
  *
@@ -51,7 +53,10 @@ public class SctpManager {
     private static int DEFAULT_SCTP_PORT = 5000;
     static
     {
-        Sctp4j.init(DEFAULT_SCTP_PORT);
+        TaskPools.SCTP_POOL.submit(() -> 
+        {
+            Sctp4j.init(DEFAULT_SCTP_PORT);
+        });
     }
 
     /**
@@ -71,60 +76,75 @@ public class SctpManager {
      *                   application packet
      */
     public void handleIncomingSctp(PacketInfo sctpPacket) {
-        logger.debug(() -> "SCTP Socket " + socket.hashCode() + " receiving incoming SCTP data");
-        //NOTE(brian): from what I can tell in usrsctp, we can assume that it will make a copy
-        // of the buffer we pass it here (this ends up hitting usrsctp_conninput, and the sample
-        // program for usrsctp re-uses the buffer that's passed here, and the code does appear
-        // to make a copy).
-        socket.onConnIn(sctpPacket.getPacket().getBuffer(), sctpPacket.getPacket().getOffset(), sctpPacket.getPacket().getLength());
-        ByteBufferPool.returnBuffer(sctpPacket.getPacket().getBuffer());
+        TaskPools.SCTP_POOL.submit(() -> 
+        {
+            logger.debug(() -> "SCTP Socket " + socket.hashCode() + " receiving incoming SCTP data");
+            //NOTE(brian): from what I can tell in usrsctp, we can assume that it will make a copy
+            // of the buffer we pass it here (this ends up hitting usrsctp_conninput, and the sample
+            // program for usrsctp re-uses the buffer that's passed here, and the code does appear
+            // to make a copy).
+            socket.onConnIn(sctpPacket.getPacket().getBuffer(), sctpPacket.getPacket().getOffset(), sctpPacket.getPacket().getLength());
+            ByteBufferPool.returnBuffer(sctpPacket.getPacket().getBuffer());
+        });
     }
 
     /**
      * Create an {@link SctpServerSocket} to be used to wait for incoming SCTP connections
      * @return an {@link SctpServerSocket}
      */
-    public SctpServerSocket createServerSocket()
+    public CompletableFuture<SctpServerSocket> createServerSocket()
     {
-        socket = Sctp4j.createServerSocket(DEFAULT_SCTP_PORT);
-        socket.outgoingDataSender = this.dataSender;
-        logger.debug(() -> "Created SCTP server socket " + socket.hashCode());
-        return (SctpServerSocket)socket;
+        return CompletableFuture.supplyAsync(() -> 
+        {
+            socket = Sctp4j.createServerSocket(DEFAULT_SCTP_PORT);
+            socket.outgoingDataSender = this.dataSender;
+            logger.debug(() -> "Created SCTP server socket " + socket.hashCode());
+            return (SctpServerSocket)socket;
+        }, TaskPools.SCTP_POOL);
     }
 
     /**
      * Create an {@link SctpClientSocket} to be used to open an SCTP connection
      * @return an {@link SctpClientSocket}
      */
-    public SctpClientSocket createClientSocket() {
-        socket = Sctp4j.createClientSocket(DEFAULT_SCTP_PORT);
-        socket.outgoingDataSender = this.dataSender;
-        if (logger.isDebugEnabled())
+    public CompletableFuture<SctpClientSocket> createClientSocket()
+    {
+        return CompletableFuture.supplyAsync(() -> 
         {
-            logger.debug("Created SCTP client socket " + socket.hashCode());
-        }
-        return (SctpClientSocket)socket;
+            socket = Sctp4j.createClientSocket(DEFAULT_SCTP_PORT);
+            socket.outgoingDataSender = this.dataSender;
+            if (logger.isDebugEnabled())
+            {
+                logger.debug("Created SCTP client socket " + socket.hashCode());
+            }
+            return (SctpClientSocket)socket;
+        }, TaskPools.SCTP_POOL);
     }
 
     /**
      * Close the active {@link SctpSocket}, if there is one
      */
-    public void closeConnection() {
-        if (socket != null) {
-            if (logger.isDebugEnabled())
-            {
-                logger.debug("Closing SCTP socket " + socket.hashCode());
-            }
-            socket.close();
-            socket = null;
-        }
-        else
+    public CompletableFuture<Void> closeConnection() 
+    {
+        return CompletableFuture.runAsync(() -> 
         {
-            if (logger.isDebugEnabled())
+            if (socket != null)
             {
-                logger.debug("No SCTP socket to close");
+                if (logger.isDebugEnabled())
+                {
+                    logger.debug("Closing SCTP socket " + socket.hashCode());
+                }
+                socket.close();
+                socket = null;
             }
-        }
+            else
+            {
+                if (logger.isDebugEnabled())
+                {
+                    logger.debug("No SCTP socket to close");
+                }
+            }
+        }, TaskPools.SCTP_POOL);
     }
 
     /**
@@ -144,7 +164,13 @@ public class SctpManager {
         {
             byte[] newBuf = ByteBufferPool.getBuffer(length);
             System.arraycopy(data, offset, newBuf, 0, length);
-            return innerSctpDataSender.send(newBuf, 0, length);
+
+            // Leave SCTP thread ASAP
+            TaskPools.IO_POOL.submit(() -> 
+            {
+                innerSctpDataSender.send(newBuf, 0, length);
+            });
+            return 0;
         }
     }
 }


### PR DESCRIPTION
This PR moves calling usrsctp API into dedicated single thread to reduce chances of multi-threading issues.
When `usrsctp` is itself updated to the version which has support of disabling internal `SCTP Timer` thread then `usrsctp` will not be used concurrently at all.  