### PR TITLE
Some small cleanup - mainly removing Localpart from Conference.java

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -430,7 +430,14 @@ public class Conference
         iq.setID(getID());
         try
         {
-            iq.setName(Localpart.from(getName()));
+            if (conferenceName == null)
+            {
+                iq.setName(null);
+            }
+            else
+            {
+                iq.setName(Localpart.from(conferenceName));
+            }
         } catch (XmppStringprepException e)
         {
             logger.error("Error converting conference name to a localpart ", e);

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -1322,7 +1322,7 @@ public class Conference
     {
         JSONObject debugState = new JSONObject();
         debugState.put("id", id);
-        debugState.put("name", conferenceName == null ? null : conferenceName);
+        debugState.put("name", conferenceName);
 
         if (full)
         {

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -36,6 +36,7 @@ import org.jitsi.xmpp.extensions.colibri.*;
 import org.json.simple.*;
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.parts.*;
+import org.jxmpp.stringprep.*;
 import org.osgi.framework.*;
 
 import java.beans.*;
@@ -124,7 +125,7 @@ public class Conference
     /**
      * The world readable name of this instance if any.
      */
-    private Localpart name;
+    private String conferenceName;
 
     /**
      * The time in milliseconds of the last activity related to this
@@ -208,6 +209,20 @@ public class Conference
     private ConfOctoTransport tentacle;
 
     /**
+     * Deprecated, see {@link Conference#Conference(Videobridge, String, Jid, String, boolean, String)}
+     */
+    @Deprecated
+    public Conference(Videobridge videobridge,
+                      String id,
+                      Jid focus,
+                      Localpart name,
+                      boolean enableLogging,
+                      String gid)
+    {
+        this(videobridge, id, focus, name.toString(), enableLogging, gid);
+    }
+
+    /**
      * Initializes a new <tt>Conference</tt> instance which is to represent a
      * conference in the terms of Jitsi Videobridge which has a specific
      * (unique) ID and is managed by a conference focus with a specific JID.
@@ -219,7 +234,7 @@ public class Conference
      * initialization of the new instance and from whom further/future requests
      * to manage the new instance must come or they will be ignored.
      * Pass <tt>null</tt> to override this safety check.
-     * @param name world readable name of this instance if any.
+     * @param conferenceName world readable name of this conference
      * @param enableLogging whether logging should be enabled for this
      * {@link Conference} and its sub-components, and whether this conference
      * should be considered when generating statistics.
@@ -228,7 +243,7 @@ public class Conference
     public Conference(Videobridge videobridge,
                       String id,
                       Jid focus,
-                      Localpart name,
+                      String conferenceName,
                       boolean enableLogging,
                       String gid)
     {
@@ -241,9 +256,9 @@ public class Conference
         {
             context.put("gid", gid);
         }
-        if (name != null)
+        if (conferenceName != null)
         {
-            context.put("conf_name", name.toString());
+            context.put("conf_name", conferenceName);
         }
         logger = new LoggerImpl(Conference.class.getName(), minLevel, new LogContext(context));
         this.shim = new ConferenceShim(this, logger);
@@ -252,7 +267,7 @@ public class Conference
         this.focus = focus;
         this.eventAdmin = enableLogging ? videobridge.getEventAdmin() : null;
         this.includeInStatistics = enableLogging;
-        this.name = name;
+        this.conferenceName = conferenceName;
 
         lastKnownFocus = focus;
 
@@ -288,10 +303,10 @@ public class Conference
     {
 
 
-        if (name != null)
+        if (conferenceName != null)
         {
             DiagnosticContext diagnosticContext = new DiagnosticContext();
-            diagnosticContext.put("conf_name", name.toString());
+            diagnosticContext.put("conf_name", conferenceName);
             diagnosticContext.put("conf_creation_time_ms", creationTime);
             return diagnosticContext;
         }
@@ -427,7 +442,14 @@ public class Conference
     public void describeShallow(ColibriConferenceIQ iq)
     {
         iq.setID(getID());
-        iq.setName(getName());
+        try
+        {
+            iq.setName(Localpart.from(getName()));
+        } catch (XmppStringprepException e)
+        {
+            logger.error("Error converting conference name to a localpart ", e);
+            iq.setName(null);
+        }
     }
 
     /**
@@ -1097,9 +1119,9 @@ public class Conference
      *
      * @return the conference name
      */
-    public Localpart getName()
+    public String getName()
     {
-        return name;
+        return conferenceName;
     }
 
     /**
@@ -1307,7 +1329,7 @@ public class Conference
     {
         JSONObject debugState = new JSONObject();
         debugState.put("id", id);
-        debugState.put("name", name == null ? null : name.toString());
+        debugState.put("name", conferenceName == null ? null : conferenceName);
 
         if (full)
         {

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -209,20 +209,6 @@ public class Conference
     private ConfOctoTransport tentacle;
 
     /**
-     * Deprecated, see {@link Conference#Conference(Videobridge, String, Jid, String, boolean, String)}
-     */
-    @Deprecated
-    public Conference(Videobridge videobridge,
-                      String id,
-                      Jid focus,
-                      Localpart name,
-                      boolean enableLogging,
-                      String gid)
-    {
-        this(videobridge, id, focus, name.toString(), enableLogging, gid);
-    }
-
-    /**
      * Initializes a new <tt>Conference</tt> instance which is to represent a
      * conference in the terms of Jitsi Videobridge which has a specific
      * (unique) ID and is managed by a conference focus with a specific JID.

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -219,7 +219,7 @@ public class Videobridge
      */
     public @NotNull Conference createConference(Jid focus, Localpart name, String gid)
     {
-        return this.createConference(focus, name, /* enableLogging */ true, gid);
+        return this.createConference(focus, name.toString(), /* enableLogging */ true, gid);
     }
 
     /**
@@ -231,7 +231,7 @@ public class Videobridge
      * @param gid
      * @return
      */
-    private @NotNull Conference doCreateConference(Jid focus, Localpart name, boolean enableLogging, String gid)
+    private @NotNull Conference doCreateConference(Jid focus, String name, boolean enableLogging, String gid)
     {
         Conference conference = null;
         do
@@ -280,7 +280,7 @@ public class Videobridge
      * <tt>Conference</tt> instances listed by this <tt>Videobridge</tt>
      */
     public @NotNull Conference createConference(
-            Jid focus, Localpart name, boolean enableLogging, String gid)
+            Jid focus, String name, boolean enableLogging, String gid)
     {
         final Conference conference = doCreateConference(focus, name, enableLogging, gid);
 

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -219,7 +219,7 @@ public class Videobridge
      */
     public @NotNull Conference createConference(Jid focus, Localpart name, String gid)
     {
-        return this.createConference(focus, name.toString(), /* enableLogging */ true, gid);
+        return this.createConference(focus, name == null ? null : name.toString(), /* enableLogging */ true, gid);
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/eventadmin/callstats/ConferencePeriodicRunnable.java
+++ b/src/main/java/org/jitsi/videobridge/eventadmin/callstats/ConferencePeriodicRunnable.java
@@ -51,7 +51,7 @@ public class ConferencePeriodicRunnable
             period,
             statsService,
             conference.getName() == null
-                  ? "null" : conference.getName().toString(),
+                  ? "null" : conference.getName(),
             conferenceIDPrefix,
             initiatorID);
     }

--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -146,8 +146,7 @@ public class ConferenceShim
      */
     public void describeShallow(ColibriConferenceIQ iq)
     {
-        iq.setID(conference.getID());
-        iq.setName(conference.getName());
+        conference.describeShallow(iq);
     }
 
     /**


### PR DESCRIPTION
Pass a`String` instead of a `Localpart` for the conference name.  This is something I came across when doing JVB API investigation, since we won't have a `Localpart` in the future.