### PR TITLE
debian: don't depend on a specific JRE version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: extra
 Maintainer: Jitsi Team <dev@jitsi.org>
 Uploaders: Emil Ivov <emcho@jitsi.org>, Damian Minkov <damencho@jitsi.org>
-Build-Depends: debhelper (>= 9), dh-systemd, openjdk-8-jre-headless | openjdk-11-jre-headless, maven
+Build-Depends: debhelper (>= 9), dh-systemd, java8-runtime-headless | java8-runtime | java11-runtime-headless | java11-runtime, maven
 Standards-Version: 3.9.3
 Homepage: https://jitsi.org/videobridge
 
@@ -11,7 +11,7 @@ Package: jitsi-videobridge2
 Replaces: jitsi-videobridge
 Conflicts: jitsi-videobridge (<= 1400-1)
 Architecture: all
-Pre-Depends: openjdk-8-jre-headless | openjdk-11-jre-headless
+Pre-Depends: java8-runtime-headless | java8-runtime | java11-runtime-headless | java11-runtime
 Depends: ${misc:Depends}, procps, uuid-runtime
 Description: WebRTC compatible Selective Forwarding Unit (SFU)
  Jitsi Videobridge is a WebRTC compatible Selective Forwarding Unit


### PR DESCRIPTION
This makes it possible to use AdoptOpenJDK builds. This is useful for
running Java 8 on Debian Buster, for example.