### PR TITLE
make the version strings used consistent across all poms

### DIFF
--- a/jvb-api/jvb-api-client/pom.xml
+++ b/jvb-api/jvb-api-client/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.jitsi</groupId>
         <artifactId>jvb-api-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jvb-api-client</artifactId>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.jitsi</groupId>
             <artifactId>jvb-api-common</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>2.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.ktor</groupId>

--- a/jvb-api/jvb-api-common/pom.xml
+++ b/jvb-api/jvb-api-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.jitsi</groupId>
         <artifactId>jvb-api-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jvb-api-common</artifactId>

--- a/jvb-api/jvb-api-server/pom.xml
+++ b/jvb-api/jvb-api-server/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.jitsi</groupId>
         <artifactId>jvb-api-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jvb-api-server</artifactId>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.jitsi</groupId>
             <artifactId>jvb-api-common</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>2.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.kotest</groupId>

--- a/jvb-api/pom.xml
+++ b/jvb-api/pom.xml
@@ -17,9 +17,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.jitsi</groupId>
+        <artifactId>jvb-parent</artifactId>
+        <version>2.1-SNAPSHOT</version>
+    </parent>
+
     <groupId>org.jitsi</groupId>
     <artifactId>jvb-api-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>jvb-api-parent</name>


### PR DESCRIPTION
I think this must have not gotten caught due to some cached versions (from before the pom hierarchy change) as part of https://github.com/jitsi/jitsi-videobridge/pull/1268