### PR TITLE
don't use mvn dependency:resolve to cache deps

### DIFF
--- a/resources/build_deb_package.sh
+++ b/resources/build_deb_package.sh
@@ -38,12 +38,12 @@ REV=$(git log --pretty=format:'%h' -n 1)
 dch -v "$VERSION-1" "Build from git. $REV"
 dch -D unstable -r ""
 
-# We need to make sure all dependencies are downloaded before start building
-# the debian package
-mvn dependency:resolve
-
 # sets the version in the pom file so it will propagate to resulting jar
 mvn versions:set -DnewVersion="${VERSION}"
+
+# We need to make sure all dependencies are downloaded before start building
+# the debian package
+mvn package
 
 # now build the deb
 dpkg-buildpackage -tc -us -uc -A


### PR DESCRIPTION
mvn dependency:resolve expects all packages to be in a remote repo, but
with the jvb api we have the packages locally.  since this call was only
made to make sure everything was downloaded, use mvn package instead
which doesn't expect everything to be remote.