### PR TITLE
fix: The on-stage participants becomes suspended when last-n equals 1.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -332,19 +332,27 @@ public class BitrateController
         @Override
         public int compare(EndpointMultiRank o1, EndpointMultiRank o2)
         {
-            int preferredHeightDiff = o1.videoConstraints.getPreferredHeight() - o2.videoConstraints.getPreferredHeight();
+            // We want "o1 has higher preferred height than o2" to imply "o1 is
+            // smaller than o2" as this is equivalent to "o1 needs to be
+            // prioritized first".
+            int preferredHeightDiff = o2.videoConstraints.getPreferredHeight() - o1.videoConstraints.getPreferredHeight();
             if (preferredHeightDiff != 0)
             {
                 return preferredHeightDiff;
             }
             else
             {
-                int idealHeightDiff = o1.videoConstraints.getIdealHeight() - o2.videoConstraints.getIdealHeight();
+                // We want "o1 has higher ideal height than o2" to imply "o1 is
+                // smaller than o2" as this is equivalent to "o1 needs to be
+                // prioritized first".
+                int idealHeightDiff = o2.videoConstraints.getIdealHeight() - o1.videoConstraints.getIdealHeight();
                 if (idealHeightDiff != 0)
                 {
                     return idealHeightDiff;
                 }
-                return o2.speakerRank - o1.speakerRank;
+
+                // Everything else being equal, we rely on the speaker order.
+                return o1.speakerRank - o2.speakerRank;
             }
         }
     }

--- a/src/test/java/org/jitsi/videobridge/cc/EndpointMultiRankerTest.java
+++ b/src/test/java/org/jitsi/videobridge/cc/EndpointMultiRankerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright @ 2015 - Present, 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.cc;
+
+import org.jitsi.videobridge.*;
+import org.junit.*;
+
+import java.util.*;
+import org.jitsi.videobridge.cc.BitrateController.*;
+
+import static org.junit.Assert.*;
+
+public class EndpointMultiRankerTest
+{
+    final List<EndpointMultiRank> endpointMultiRanks = new ArrayList<>();
+    final VideoConstraints stageVideoConstraints
+        = new VideoConstraints(/* idealHeight */ 720);
+    final VideoConstraints thumbnailVideoConstraints
+        = new VideoConstraints(/* idealHeight */ 180);
+
+    @Test
+    public void followActiveSpeaker()
+    {
+        EndpointMultiRank activeSpeakerMultiRank
+            = makeNextSpeakerWithVideoConstraints(stageVideoConstraints);
+        endpointMultiRanks.add(activeSpeakerMultiRank);
+
+        EndpointMultiRank speaker2MultiRank
+            = makeNextSpeakerWithVideoConstraints(thumbnailVideoConstraints);
+        endpointMultiRanks.add(speaker2MultiRank);
+
+        EndpointMultiRank speaker3MultiRank
+            = makeNextSpeakerWithVideoConstraints(thumbnailVideoConstraints);
+        endpointMultiRanks.add(speaker3MultiRank);
+
+        endpointMultiRanks.sort(new EndpointMultiRanker());
+
+        // Whoever's on-stage needs to be prioritized first, then by speaker. In
+        // this particular test case, the on-stage speaker coincides with the
+        // active speaker.
+        assertEquals(endpointMultiRanks.get(0), activeSpeakerMultiRank);
+        assertEquals(endpointMultiRanks.get(1), speaker2MultiRank);
+        assertEquals(endpointMultiRanks.get(2), speaker3MultiRank);
+    }
+
+    @Test
+    public void followArbitrarySpeaker()
+    {
+        EndpointMultiRank activeSpeakerMultiRank
+            = makeNextSpeakerWithVideoConstraints(thumbnailVideoConstraints);
+        endpointMultiRanks.add(activeSpeakerMultiRank);
+
+        EndpointMultiRank speaker2MultiRank
+            = makeNextSpeakerWithVideoConstraints(thumbnailVideoConstraints);
+        endpointMultiRanks.add(speaker2MultiRank);
+
+        EndpointMultiRank speaker3MultiRank
+            = makeNextSpeakerWithVideoConstraints(stageVideoConstraints);
+        endpointMultiRanks.add(speaker3MultiRank);
+
+        endpointMultiRanks.sort(new EndpointMultiRanker());
+
+        // Whoever's on-stage needs to be prioritized first, then by speaker. In
+        // this particular test case, the on-stage speaker is the least recent
+        // active speaker.
+        assertEquals(endpointMultiRanks.get(0), speaker3MultiRank);
+        assertEquals(endpointMultiRanks.get(1), activeSpeakerMultiRank);
+        assertEquals(endpointMultiRanks.get(2), speaker2MultiRank);
+    }
+
+    private EndpointMultiRank makeNextSpeakerWithVideoConstraints(VideoConstraints videoConstraints)
+    {
+        return new EndpointMultiRank(endpointMultiRanks.size(), videoConstraints, null);
+    }
+}

--- a/src/test/java/org/jitsi/videobridge/cc/EndpointMultiRankerTest.java
+++ b/src/test/java/org/jitsi/videobridge/cc/EndpointMultiRankerTest.java
@@ -48,6 +48,12 @@ public class EndpointMultiRankerTest
 
         endpointMultiRanks.sort(new EndpointMultiRanker());
 
+        // NOTE that the active speaker rank is the tie breaker if both the
+        // ideal and preferred height is equal and the order in which the
+        // endpoints are added to the list determines their speaker rank (for
+        // more information on how the ranking works, see the EndpointMultiRanker
+        // class documentation).
+        //
         // Whoever's on-stage needs to be prioritized first, then by speaker. In
         // this particular test case, the on-stage speaker coincides with the
         // active speaker.
@@ -73,6 +79,12 @@ public class EndpointMultiRankerTest
 
         endpointMultiRanks.sort(new EndpointMultiRanker());
 
+        // NOTE that the active speaker rank is the tie breaker if both the
+        // ideal and preferred height is equal and the order in which the
+        // endpoints are added to the list determines their speaker rank (for
+        // more information on how the ranking works, see the EndpointMultiRanker
+        // class documentation).
+        //
         // Whoever's on-stage needs to be prioritized first, then by speaker. In
         // this particular test case, the on-stage speaker is the least recent
         // active speaker.


### PR DESCRIPTION
@paweldomas discovered this issue where the prioritization order that the EndpointMultiRanker implements is inversed, leading to the wrong endpoints being allocated bandwidth first. The comments in the patch provide further information.