### PR TITLE
Fix DataChannel SCTP packets arriving out-of-order

### DIFF
--- a/src/main/java/org/jitsi/videobridge/util/SequentialExecutor.java
+++ b/src/main/java/org/jitsi/videobridge/util/SequentialExecutor.java
@@ -1,0 +1,66 @@
+package org.jitsi.videobridge.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Executes submitted commands asynchronously through an Executor, while ensuring
+ * that the commands are executed in the exact order that they were submitted in.
+ * <p>
+ * All methods in this class are thread-safe.
+ */
+public final class SequentialExecutor implements Executor {
+
+    private final AtomicBoolean running = new AtomicBoolean();
+    private final Queue<Runnable> queue = new ConcurrentLinkedQueue<>();
+    private final Executor executor;
+
+    public SequentialExecutor(Executor executor) {
+        this.executor = executor;
+    }
+
+    /**
+     * Submit a command for asynchronous execution. The submitted command will
+     * run after all previously submitted commands have completed.
+     *
+     * @param command The command to execute.
+     */
+    @Override
+    public void execute(@NotNull Runnable command) {
+        queue.add(command);
+        triggerRun();
+    }
+
+    private void doRun() {
+        try {
+            Runnable runnable;
+            while ((runnable = queue.poll()) != null) {
+                // if run() throws, a new run will be triggered for the
+                // remainder of the queue if it is not yet emptied
+                runnable.run();
+            }
+        } finally {
+            afterRun();
+        }
+    }
+
+    private void afterRun() {
+        running.set(false);
+        if (!queue.isEmpty()) {
+            triggerRun();
+        }
+    }
+
+    /**
+     * Atomically trigger a new run if none is running.
+     */
+    private void triggerRun() {
+        if (running.compareAndSet(false, true)) {
+            executor.execute(this::doRun);
+        }
+    }
+}

--- a/src/test/java/org/jitsi/videobridge/util/SequentialExecutorTest.java
+++ b/src/test/java/org/jitsi/videobridge/util/SequentialExecutorTest.java
@@ -1,0 +1,100 @@
+package org.jitsi.videobridge.util;
+
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SequentialExecutorTest {
+
+    private final Queue<Runnable> runnables = new ArrayDeque<>();
+    private final SequentialExecutor sequentialExecutor = new SequentialExecutor(runnables::add);
+
+    @Test
+    public void shouldRunCommandInExecutor() {
+        AtomicInteger commandInvocations = new AtomicInteger();
+        sequentialExecutor.execute(commandInvocations::incrementAndGet);
+        assertEquals(0, commandInvocations.get());
+        assertEquals(1, runnables.size());
+        runNextRunnable();
+        assertEquals(1, commandInvocations.get());
+        assertEquals(0, runnables.size());
+    }
+
+    @Test
+    public void shouldRunCommandsSequentially() {
+        List<Integer> expectedInvocations = Arrays.asList(1, 2, 3);
+        List<Integer> actualInvocations = new ArrayList<>();
+        expectedInvocations.forEach(i ->
+                sequentialExecutor.execute(() -> actualInvocations.add(i))
+        );
+        assertEquals(0, actualInvocations.size());
+        assertEquals(1, runnables.size());
+        runNextRunnable();
+        assertEquals(expectedInvocations, actualInvocations);
+        assertEquals(0, runnables.size());
+    }
+
+    @Test
+    public void shouldTriggerNextRun() {
+        sequentialExecutor.execute(() -> {
+        });
+        runNextRunnable();
+        shouldRunCommandInExecutor();
+    }
+
+    @Test
+    public void shouldTriggerRunForRemainingCommands() {
+        AtomicInteger commandInvocations = new AtomicInteger();
+
+        sequentialExecutor.execute(() -> {
+            throw new ExpectedTestException();
+        });
+        sequentialExecutor.execute(commandInvocations::incrementAndGet);
+        assertEquals(1, runnables.size());
+
+        assertThrows(ExpectedTestException.class, this::runNextRunnable);
+        assertEquals(0, commandInvocations.get());
+        assertEquals(1, runnables.size());
+
+        runNextRunnable();
+        assertEquals(1, commandInvocations.get());
+        assertEquals(0, runnables.size());
+    }
+
+    @Test
+    public void shouldAcceptCommandsWhileRunning() {
+        List<Integer> expectedInvocations = Arrays.asList(1, 2, 3, 4);
+        ArrayList<Integer> actualInvocations = new ArrayList<>();
+
+        sequentialExecutor.execute(() -> {
+            sequentialExecutor.execute(() -> {
+                sequentialExecutor.execute(() -> {
+                    actualInvocations.add(3);
+                });
+                sequentialExecutor.execute(() -> {
+                    actualInvocations.add(4);
+                });
+                actualInvocations.add(2);
+            });
+            actualInvocations.add(1);
+        });
+        assertEquals(1, runnables.size());
+        assertEquals(0, actualInvocations.size());
+
+        runNextRunnable();
+
+        assertEquals(expectedInvocations, actualInvocations);
+        assertEquals(0, runnables.size());
+    }
+
+    private void runNextRunnable() {
+        assertFalse(runnables.isEmpty());
+        runnables.remove().run();
+    }
+
+    private static class ExpectedTestException extends RuntimeException {
+    }
+}


### PR DESCRIPTION
When opening a DataChannel SCTP connection on a heavily loaded machine, the logs often indicate:
> SEVERE: Could not find data channel for sid <sid>

This indicates that data packets arrived before the OpenChannelMessage was processed.

The cause of this issue is that incoming packet processing was scheduled on independent IO threads.
As such, they would be handled in any particular order on a loaded machine.
While JVB could recover from this condition for future packets, initial packets would get lost.
I have observed examples where this impacted initial Last-N selection, for which the command is sent from Jitsi Meet upon connection opened.

This change ensures that incoming SCTP packets are processed in the exact order that they arrived in.