### PR TITLE
Octo header and GID update

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -61,6 +61,11 @@ public class Conference
         AbstractEndpointMessageTransport.EndpointMessageTransportEventHandler
 {
     /**
+     * The constant denoting that {@link #gid} is not specified.
+     */
+    public static final long GID_NOT_SET = -1;
+
+    /**
      * The endpoints participating in this {@link Conference}. Although it's a
      * {@link ConcurrentHashMap}, writing to it must be protected by
      * synchronizing on the map itself, because it must be kept in sync with
@@ -98,14 +103,28 @@ public class Conference
     private boolean expired = false;
 
     /**
-     * The (unique) identifier/ID of this instance.
+     * The locally unique identifier of this conference (i.e. unique across the
+     * conferences on this bridge). It is locally generated and exposed via
+     * colibri, and used by colibri clients to reference the conference.
+     *
+     * The current thinking is that we will phase out use of this ID (but keep
+     * it for backward compatibility) in favor of {@link #gid}.
      */
     private final String id;
 
     /**
-     * The "global" id of this conference, set by the controller (e.g. jicofo)
-     * as opposed to the bridge. This is a 32-bit unsigned integer, or {@code -1}
-     * if it is not set.
+     * The "global" id of this conference, selected by the controller of the
+     * bridge (e.g. jicofo). The set of controllers are responsible for making
+     * sure this ID is unique across all conferences in the system.
+     *
+     * This is not a required field unless Octo is used, and when it is not
+     * specified by the controller its value is {@link #GID_NOT_SET}.
+     *
+     * If specified, it must be a 32-bit unsigned integer (i.e. in the range
+     * [0, 0xffff_ffff]).
+     *
+     * This ID is shared between all bridges in an Octo conference, and included
+     * on-the-wire in Octo packets.
      */
     private final long gid;
 
@@ -190,7 +209,7 @@ public class Conference
                       boolean enableLogging,
                       long gid)
     {
-        if (gid < -1 || gid > 0xffff_ffffl)
+        if (gid != GID_NOT_SET && (gid < 0 || gid > 0xffff_ffffL))
         {
             throw new IllegalArgumentException("Invalid GID:" + gid);
         }
@@ -970,8 +989,9 @@ public class Conference
     }
 
     /**
-     * @return the global ID of the conference, or {@code -1} if none has been
-     * set.
+     * @return the global ID of the conference (see {@link #gid)}, or
+     * {@link #GID_NOT_SET} if none has been set.
+     * @see #gid
      */
     public long getGid()
     {
@@ -1071,10 +1091,10 @@ public class Conference
      */
     public ConfOctoTransport getTentacle()
     {
-        if (gid < 0)
+        if (gid == GID_NOT_SET)
         {
             throw new IllegalStateException(
-                    "Can not enable Octo without a valid GID.");
+                    "Can not enable Octo without the GID being set.");
         }
         if (tentacle == null)
         {

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -233,7 +233,7 @@ public class Videobridge
     public @NotNull Conference createConference(
             String name, boolean enableLogging)
     {
-        return createConference(name, enableLogging, -1);
+        return createConference(name, enableLogging, Conference.GID_NOT_SET);
     }
 
     /**
@@ -245,8 +245,8 @@ public class Videobridge
      * @param name world readable name of the conference to create.
      * @param enableLogging whether logging should be enabled or disabled for
      * the {@link Conference}.
-     * @param gid the "global" id of the conference (or {@code -1} if it is not
-     * specified.
+     * @param gid the "global" id of the conference (or
+     * {@link Conference#GID_NOT_SET} if it is not specified.
      * @return a new <tt>Conference</tt> instance with an ID unique to the
      * <tt>Conference</tt> instances listed by this <tt>Videobridge</tt>
      */

--- a/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -180,7 +180,7 @@ public class Videobridge
      * @return a new <tt>Conference</tt> instance with an ID unique to the
      * <tt>Conference</tt> instances listed by this <tt>Videobridge</tt>
      */
-    public @NotNull Conference createConference(Localpart name, String gid)
+    public @NotNull Conference createConference(Localpart name, long gid)
     {
         return this.createConference(name == null ? null : name.toString(), /* enableLogging */ true, gid);
     }
@@ -193,7 +193,7 @@ public class Videobridge
      * @param gid
      * @return
      */
-    private @NotNull Conference doCreateConference(String name, boolean enableLogging, String gid)
+    private @NotNull Conference doCreateConference(String name, boolean enableLogging, long gid)
     {
         Conference conference = null;
         do
@@ -229,11 +229,29 @@ public class Videobridge
      * @param name world readable name of the conference to create.
      * @param enableLogging whether logging should be enabled or disabled for
      * the {@link Conference}.
-     * @param gid the optional "global" id of the conference.
+     */
+    public @NotNull Conference createConference(
+            String name, boolean enableLogging)
+    {
+        return createConference(name, enableLogging, -1);
+    }
+
+    /**
+     * Initializes a new {@link Conference} instance with an ID unique to the
+     * <tt>Conference</tt> instances listed by this <tt>Videobridge</tt> and
+     * adds the new instance to the list of existing <tt>Conference</tt>
+     * instances.
+     *
+     * @param name world readable name of the conference to create.
+     * @param enableLogging whether logging should be enabled or disabled for
+     * the {@link Conference}.
+     * @param gid the "global" id of the conference (or {@code -1} if it is not
+     * specified.
      * @return a new <tt>Conference</tt> instance with an ID unique to the
      * <tt>Conference</tt> instances listed by this <tt>Videobridge</tt>
      */
-    public @NotNull Conference createConference(String name, boolean enableLogging, String gid)
+    public @NotNull Conference createConference(
+            String name, boolean enableLogging, long gid)
     {
         final Conference conference = doCreateConference(name, enableLogging, gid);
 

--- a/src/main/java/org/jitsi/videobridge/health/Health.java
+++ b/src/main/java/org/jitsi/videobridge/health/Health.java
@@ -163,7 +163,7 @@ public class Health
 
         // TODO: check if ClientConnectionImpl is configured and connected.
 
-        Conference conference = videobridge.createConference(null, false, null);
+        Conference conference = videobridge.createConference(null, false);
 
         try
         {

--- a/src/main/java/org/jitsi/videobridge/octo/ConfOctoTransport.java
+++ b/src/main/java/org/jitsi/videobridge/octo/ConfOctoTransport.java
@@ -67,6 +67,12 @@ public class ConfOctoTransport
     private final Conference conference;
 
     /**
+     * The ID of the conference to use for everything Octo-related. It is set
+     * to the GID of the conference (see {@link Conference#gid}).
+     */
+    private final long conferenceId;
+
+    /**
      * The {@link OctoEndpoints} instance which maintains the list of Octo
      * endpoints in the conference.
      */
@@ -129,6 +135,7 @@ public class ConfOctoTransport
     public ConfOctoTransport(Conference conference, Clock clock)
     {
         this.conference = conference;
+        this.conferenceId = conference.getGid();
         this.clock = clock;
         this.logger = conference.getLogger().createChildLogger(this.getClass().getName());
         BundleContext bundleContext = conference.getBundleContext();
@@ -148,7 +155,7 @@ public class ConfOctoTransport
         }
 
         octoEndpoints = new OctoEndpoints(conference);
-        octoTransceiver = new OctoTransceiver("tentacle-" + conference.getGid(), logger);
+        octoTransceiver = new OctoTransceiver("tentacle-" + conferenceId, logger);
         octoTransceiver.setIncomingPacketHandler(conference::handleIncomingPacket);
         octoTransceiver.setOutgoingPacketHandler(packetInfo ->
         {
@@ -258,7 +265,7 @@ public class ConfOctoTransport
             packetInfo.getPacket().getOffset(),
             packetInfo.getPacket().getLength(),
             targets,
-            conference.getGid(),
+            conferenceId,
             packetInfo.getEndpointId()
         );
 
@@ -391,11 +398,11 @@ public class ConfOctoTransport
 
             if (targets.isEmpty())
             {
-                bridgeOctoTransport.removeHandler(conference.getGid(), this);
+                bridgeOctoTransport.removeHandler(conferenceId, this);
             }
             else
             {
-                bridgeOctoTransport.addHandler(conference.getGid(), this);
+                bridgeOctoTransport.addHandler(conferenceId, this);
             }
         }
     }
@@ -443,7 +450,7 @@ public class ConfOctoTransport
         bridgeOctoTransport.sendString(
             message,
             targets,
-            conference.getGid()
+            conferenceId
         );
     }
 

--- a/src/main/java/org/jitsi/videobridge/octo/OctoPacket.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoPacket.java
@@ -239,6 +239,6 @@ public class OctoPacket
             byte[] buf, int off, int len, int minLen)
     {
         return buf != null && off >= 0 && len >= minLen && minLen >= 0
-            && off + len < buf.length;
+            && off + len <= buf.length;
     }
 }

--- a/src/main/java/org/jitsi/videobridge/octo/OctoPacket.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoPacket.java
@@ -30,7 +30,7 @@ import static org.jitsi.utils.ByteArrayUtils.*;
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * |                         Endpoint ID                           |
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- * |MT|                      Reserved                              |
+ * | M |                     Reserved                              |
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * }</pre>
  * <p/>
@@ -39,7 +39,7 @@ import static org.jitsi.utils.ByteArrayUtils.*;
  * Endpoint ID: An identifier of the endpoint that is the original source of
  * the packet.
  * <p/>
- * MT: media type (audio, video, or data).
+ * M: media type (audio, video, or data).
  *
  * @author Boris Grozev
  */

--- a/src/main/java/org/jitsi/videobridge/octo/OctoPacket.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoPacket.java
@@ -21,22 +21,25 @@ import static org.jitsi.utils.ByteArrayUtils.*;
 
 /**
  * A utility class which handles the on-the-wire Octo format. Octo encapsulates
- * its payload (RTP, RTCP, or anything else) in an 8-byte header:
+ * its payload (RTP, RTCP, or anything else) in an 12-byte header:
  * <pre>{@code
  *  0                   1                   2                   3
  *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- * |R| M | S | res |              Conference ID                    |
+ * |                         Conference ID                         |
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * |                         Endpoint ID                           |
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |MT|                      Reserved                              |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * }</pre>
- * R: Source-is-a-relay flag. 1 if the source of the packet is a relay, and
- * 0 if it is an endpoint (bridge).
  * <p/>
- * M: media type (audio, video, or data).
+ * Conference ID: An identifier of the conference.
  * <p/>
- * S: Simulcast layer ID.
+ * Endpoint ID: An identifier of the endpoint that is the original source of
+ * the packet.
+ * <p/>
+ * MT: media type (audio, video, or data).
  *
  * @author Boris Grozev
  */
@@ -45,7 +48,7 @@ public class OctoPacket
     /**
      * The fixed length of the Octo header.
      */
-    public static final int OCTO_HEADER_LENGTH = 8;
+    public static final int OCTO_HEADER_LENGTH = 12;
 
     /**
      * The integer which identifies the "audio" media type in Octo.
@@ -85,28 +88,23 @@ public class OctoPacket
      * Writes an Octo header to the specified buffer at the specified offset.
      * @param buf the buffer to write to.
      * @param off the offset to write at.
-     * @param r the value of the {@code r} flag.
      * @param mediaType the media type.
-     * @param s the value of the {@code s} flag.
      * @param conferenceId the Octo ID of the conference.
      * @param endpointId the Octo ID of the endpoint.
      */
     public static void writeHeaders(
             byte[] buf, int off,
-            boolean r, MediaType mediaType, int s,
-            String conferenceId,
+            MediaType mediaType,
+            long conferenceId,
             String endpointId)
     {
-        buf[off] = 0;
-        if (r)
-        {
-            buf[off] |= 0x80;
-        }
-        buf[off] |= (getMediaTypeId(mediaType) & 0x03) << 5;
-        buf[off] |= (s & 0x03) << 3;
-
-        writeConferenceId(conferenceId, buf, off, OCTO_HEADER_LENGTH);
-        writeEndpointId(endpointId, buf, off, OCTO_HEADER_LENGTH);
+        assertMinLen(buf, off, buf.length);
+        off += writeConferenceId(conferenceId, buf, off);
+        off += writeEndpointId(endpointId, buf, off);
+        buf[off] = (byte) (getMediaTypeId(mediaType) << 6);
+        buf[off+1] = 0;
+        buf[off+2] = 0;
+        buf[off+3] = 0;
     }
 
     /**
@@ -116,12 +114,11 @@ public class OctoPacket
      * @param len the length of the buffer.
      * @return the Octo conference ID read from the buffer.
      */
-    public static String readConferenceId(byte[] buf, int off, int len)
+    public static long readConferenceId(byte[] buf, int off, int len)
     {
         assertMinLen(buf, off, len);
 
-        int cid = readUint24(buf, off + 1);
-        return Integer.toHexString(cid);
+        return readUint32(buf, off);
     }
 
     /**
@@ -135,7 +132,7 @@ public class OctoPacket
     {
         assertMinLen(buf, off, len);
 
-        int mediaType = (buf[off] & 0x60) >> 5;
+        int mediaType = (buf[off + 8] & 0xc0) >> 6;
         switch (mediaType)
         {
         case OCTO_MEDIA_TYPE_AUDIO:
@@ -147,20 +144,6 @@ public class OctoPacket
         default:
             throw new IllegalArgumentException("Invalid media type value: " + mediaType);
         }
-    }
-
-    /**
-     * Reads the {@code r} flag from an Octo header.
-     * @param buf the buffer which contains the Octo header.
-     * @param off the offset in {@code buf} at which the Octo header begins.
-     * @param len the length of the buffer.
-     * @return the {@code r} flag from the given Octo header.
-     */
-    private static boolean readRflag(byte[] buf, int off, int len)
-    {
-        assertMinLen(buf, off, len);
-
-        return (buf[off] & 0x80) != 0;
     }
 
     /**
@@ -185,13 +168,11 @@ public class OctoPacket
      * @param off the offset in {@code buf} at which the Octo header begins.
      * @param len the length of the buffer.
      */
-    private static void writeConferenceId(
-            String conferenceId, byte[] buf, int off, int len)
+    private static int writeConferenceId(
+            long conferenceId, byte[] buf, int off)
     {
-        assertMinLen(buf, off, len);
-
-        int cid = Integer.parseInt(conferenceId, 16);
-        writeUint24(buf, off + 1, cid);
+        writeInt(buf, off, (int) conferenceId);
+        return 4;
     }
 
     /**
@@ -199,15 +180,13 @@ public class OctoPacket
      * @param endpointId the Octo endpoint ID represented as a hex string.
      * @param buf the buffer which contains the Octo header.
      * @param off the offset in {@code buf} at which the Octo header begins.
-     * @param len the length of the buffer.
      */
-    private static void writeEndpointId(
-            String endpointId, byte[] buf, int off, int len)
+    private static int writeEndpointId(String endpointId, byte[] buf, int off)
     {
-        assertMinLen(buf, off, len);
-
         long eid = Long.parseLong(endpointId, 16);
-        writeInt(buf, off + 4, (int) eid);
+        writeInt(buf, off, (int) eid);
+
+        return 4;
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -25,6 +25,7 @@ import org.jitsi.videobridge.octo.*;
 import org.jitsi.videobridge.util.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jitsi.xmpp.extensions.jingle.*;
+import org.jitsi.xmpp.util.*;
 import org.jivesoftware.smack.packet.*;
 
 import java.io.*;

--- a/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
+++ b/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
@@ -25,6 +25,8 @@ import org.jivesoftware.smack.packet.*;
 
 import java.util.*;
 
+import static org.jitsi.videobridge.Conference.GID_NOT_SET;
+
 /**
  * Handles Colibri-related logic for a {@link Videobridge}, e.g. handles
  * incoming Colibri requests.
@@ -377,7 +379,7 @@ public class VideobridgeShim
 
         if (octoAudioChannel != null && octoVideoChannel != null)
         {
-            if (conference.getGid() < 0)
+            if (conference.getGid() == GID_NOT_SET)
             {
                 return IQUtils.createError(
                         conferenceIQ,
@@ -453,11 +455,12 @@ public class VideobridgeShim
 
     /**
      * Parses the "gid" field encoded in {@link ColibriConferenceIQ#getGID()}.
-     * It is a 32-bit unsigned integer encoded in hex. Returns {@code -1} if
-     * parsing fails.
+     * It is a 32-bit unsigned integer encoded in hex. Returns
+     * {@link Conference#GID_NOT_SET} if parsing fails.
      *
      * @param gidStr the string to parse
-     * @return the GID parsed as a {@code long}, or {@code -1} on failrue.
+     * @return the GID parsed as a {@code long}, or
+     * {@link Conference#GID_NOT_SET -1} on failure.
      */
     private static long parseGid(String gidStr)
     {
@@ -465,7 +468,7 @@ public class VideobridgeShim
 
         if (gidStr == null)
         {
-            gid = -1;
+            gid = GID_NOT_SET;
         }
         else
         {
@@ -477,7 +480,7 @@ public class VideobridgeShim
             {
                 logger.warn(
                     "Invalid GID: " + gidStr + ". Assuming it's unset.");
-                gid = -1;
+                gid = GID_NOT_SET;
             }
 
             if (gid < 0 || gid > 0xffff_ffffL)
@@ -485,7 +488,7 @@ public class VideobridgeShim
                 logger.warn(
                     "Invalid GID (not a 32-bit unsigned): " + gidStr
                             + ". Assuming it's unset");
-                gid = -1;
+                gid = GID_NOT_SET;
             }
         }
 

--- a/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayService.kt
+++ b/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayService.kt
@@ -124,7 +124,7 @@ class OctoRelayService : BundleActivator {
         /**
          * The version of the octo protocol.
          */
-        const val OCTO_VERSION = 0
+        const val OCTO_VERSION = 1
     }
 
     data class Stats(

--- a/src/main/kotlin/org/jitsi/videobridge/transport/octo/BridgeOctoTransport.kt
+++ b/src/main/kotlin/org/jitsi/videobridge/transport/octo/BridgeOctoTransport.kt
@@ -58,7 +58,7 @@ class BridgeOctoTransport(
 
     /**
      * Handlers for incoming Octo packets.  Packets will be routed to a handler based on the conference
-     * ID in the Octo packet
+     * ID in the Octo packet.
      */
     private val incomingPacketHandlers: MutableMap<Long, IncomingOctoPacketHandler> = ConcurrentHashMap()
 

--- a/src/main/kotlin/org/jitsi/videobridge/transport/octo/BridgeOctoTransport.kt
+++ b/src/main/kotlin/org/jitsi/videobridge/transport/octo/BridgeOctoTransport.kt
@@ -60,13 +60,13 @@ class BridgeOctoTransport(
      * Handlers for incoming Octo packets.  Packets will be routed to a handler based on the conference
      * ID in the Octo packet
      */
-    private val incomingPacketHandlers: MutableMap<String, IncomingOctoPacketHandler> = ConcurrentHashMap()
+    private val incomingPacketHandlers: MutableMap<Long, IncomingOctoPacketHandler> = ConcurrentHashMap()
 
     /**
      * Maps how many Octo packets have been received for unknown conference IDs, to avoid
      * spamming the error logs
      */
-    private val unknownConferences: MutableMap<String, AtomicLong> = ConcurrentHashMap()
+    private val unknownConferences: MutableMap<Long, AtomicLong> = ConcurrentHashMap()
 
     /**
      * The handler which will be invoked when this [BridgeOctoTransport] wants to
@@ -81,7 +81,10 @@ class BridgeOctoTransport(
     /**
      * Registers a [PacketHandler] for the given [conferenceId]
      */
-    fun addHandler(conferenceId: String, handler: IncomingOctoPacketHandler) {
+    fun addHandler(conferenceId: Long, handler: IncomingOctoPacketHandler) {
+        if (conferenceId < 0 || conferenceId > 0xffff_ffff) {
+            throw IllegalArgumentException("Invalid conference ID: $conferenceId")
+        }
         logger.info("Adding handler for conference $conferenceId")
 
         synchronized(incomingPacketHandlers) {
@@ -96,7 +99,7 @@ class BridgeOctoTransport(
      * Removes the [PacketHandler] for the given [conferenceId] IFF the one
      * in the map is the same as [handler].
      */
-    fun removeHandler(conferenceId: String, handler: IncomingOctoPacketHandler) = synchronized(incomingPacketHandlers) {
+    fun removeHandler(conferenceId: Long, handler: IncomingOctoPacketHandler) = synchronized(incomingPacketHandlers) {
         // If the Colibri conference for this GID was re-created, and the
         // original Conference object is expired after a new packet handler
         // was registered, the new packet handler should not be removed (as
@@ -116,7 +119,7 @@ class BridgeOctoTransport(
 
     @Suppress("DEPRECATION")
     fun dataReceived(buf: ByteArray, off: Int, len: Int, receivedTime: Instant) {
-        var conferenceId: String
+        var conferenceId: Long
         var mediaType: MediaType
         var sourceEpId: String
 
@@ -163,12 +166,12 @@ class BridgeOctoTransport(
         }
     }
 
-    fun sendMediaData(buf: ByteArray, off: Int, len: Int, targets: Set<SocketAddress>, confId: String, sourceEpId: String? = null) {
+    fun sendMediaData(buf: ByteArray, off: Int, len: Int, targets: Set<SocketAddress>, confId: Long, sourceEpId: String? = null) {
         sendData(buf, off, len, targets, confId, MediaType.VIDEO, sourceEpId)
     }
 
     @Suppress("DEPRECATION")
-    fun sendString(msg: String, targets: Set<SocketAddress>, confId: String) {
+    fun sendString(msg: String, targets: Set<SocketAddress>, confId: Long) {
         val msgData = msg.toByteArray(StandardCharsets.UTF_8)
         sendData(msgData, 0, msgData.size, targets, confId, MediaType.DATA, null)
     }
@@ -178,7 +181,7 @@ class BridgeOctoTransport(
         off: Int,
         len: Int,
         targets: Set<SocketAddress>,
-        confId: String,
+        confId: Long,
         mediaType: MediaType,
         sourceEpId: String? = null
     ) {

--- a/src/main/kotlin/org/jitsi/videobridge/transport/octo/BridgeOctoTransport.kt
+++ b/src/main/kotlin/org/jitsi/videobridge/transport/octo/BridgeOctoTransport.kt
@@ -208,9 +208,7 @@ class BridgeOctoTransport(
         }
         OctoPacket.writeHeaders(
             newBuf, newOff,
-            true /* source is a relay */,
             mediaType,
-            0 /* simulcast layers info */,
             confId,
             epId
         )

--- a/src/test/kotlin/org/jitsi/videobridge/octo/OctoPacketTest.kt
+++ b/src/test/kotlin/org/jitsi/videobridge/octo/OctoPacketTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.octo
+
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.ShouldSpec
+import org.jitsi.utils.MediaType
+import org.jitsi.rtp.extensions.bytearray.byteArrayOf
+import java.lang.IllegalArgumentException
+
+class OctoPacketTest : ShouldSpec() {
+    init {
+        "parsing an OctoPacket" {
+            should("parse a valid packet correctly") {
+                OctoPacket.readConferenceId(octoHeader, 0, octoHeader.size) shouldBe 1234
+                OctoPacket.readEndpointId(octoHeader, 0, octoHeader.size) shouldBe "abcdabcd"
+                OctoPacket.readMediaType(octoHeader, 0, octoHeader.size) shouldBe MediaType.VIDEO
+            }
+            should("fail when the length is insufficient") {
+                shouldThrow<IllegalArgumentException> {
+                    OctoPacket.readEndpointId(byteArrayOf(0, 0, 0, 0, 0), 0, 0)
+                }
+            }
+        }
+        "creating Octo headers" {
+            should("create a valid packet correctly") {
+                val octoHeader = ByteArray(12)
+                OctoPacket.writeHeaders(octoHeader, 0, MediaType.AUDIO, 111222, "1234abcd")
+                OctoPacket.readConferenceId(octoHeader, 0, octoHeader.size) shouldBe 111222
+                OctoPacket.readEndpointId(octoHeader, 0, octoHeader.size) shouldBe "1234abcd"
+                OctoPacket.readMediaType(octoHeader, 0, octoHeader.size) shouldBe MediaType.AUDIO
+            }
+            should("fail when the length is insufficient") {
+                val octoHeader = ByteArray(11)
+                shouldThrow<IllegalArgumentException> {
+                    OctoPacket.writeHeaders(octoHeader, 0, MediaType.AUDIO, 111222, "1234abcd")
+                }
+            }
+        }
+    }
+
+    companion object {
+        val octoHeader: ByteArray = byteArrayOf(
+            // Conference ID = 1234 (0x4d2)
+            0x00, 0x00, 0x04, 0xd2,
+            // Endpoint ID = "abcdabcd"
+            0xab, 0xcd, 0xab, 0xcd,
+            // MediaType = Video (1)
+            0x40, 0x00, 0x00, 0x00)
+    }
+}


### PR DESCRIPTION
This is a draft, because we need to have jicofo `>= b848a9fa19` running on meet.jit.si before merging.