### PR TITLE
Fixing link for setting up stats

### DIFF
--- a/doc/rest-colibri.md
+++ b/doc/rest-colibri.md
@@ -134,7 +134,7 @@ The respective response could look like:
     "threads":17,
     "videochannels":0
 }</pre>
-		(Make sure <a href="rest.md#introduction">statistics are enabled</a>.)
+		(Make sure <a href="statistics.md#implementation">statistics are enabled</a>.)
 		</td>
 	</tr>
 </table>

--- a/doc/rest-colibri.md
+++ b/doc/rest-colibri.md
@@ -134,7 +134,7 @@ The respective response could look like:
     "threads":17,
     "videochannels":0
 }</pre>
-		(Make sure <a href="https://github.com/jitsi/jitsi-videobridge/blob/master/doc/rest.md#introduction">statistics are enabled</a>.)
+		(Make sure <a href="rest.md#introduction">statistics are enabled</a>.)
 		</td>
 	</tr>
 </table>

--- a/doc/rest-colibri.md
+++ b/doc/rest-colibri.md
@@ -134,7 +134,7 @@ The respective response could look like:
     "threads":17,
     "videochannels":0
 }</pre>
-		(Make sure <a href="using_statistics.md#configuration">statistics are enabled</a>.)
+		(Make sure <a href="https://github.com/jitsi/jitsi-videobridge/blob/master/doc/rest.md#introduction">statistics are enabled</a>.)
 		</td>
 	</tr>
 </table>


### PR DESCRIPTION
Link "using_statistics.md#configuration" is not valid anymore, it is replaced by https://github.com/jitsi/jitsi-videobridge/blob/master/doc/rest.md#introduction