### PR TITLE
Enforce sequential processing of incoming data channel messages.

### DIFF
--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -310,8 +310,8 @@ public class Endpoint
 
         incomingDataChannelMessagesQueue = new PacketInfoQueue(
             getClass().getSimpleName() + "-incoming-data-channel-queue",
-            TaskPools.IO_POOL, 
-            packetInfo -> 
+            TaskPools.IO_POOL,
+            packetInfo ->
             {
                 dataChannelHandler.consume(packetInfo);
                 return true;


### PR DESCRIPTION
I completely agree that issue with ordering raised in https://github.com/jitsi/jitsi-videobridge/pull/1309 need to be fixed.
Here is another possible fix to consider to ensure sequential processing of incoming data channel messages.