### PR TITLE
ref: Make a message name shorter as per @bgrozev's suggestion

### DIFF
--- a/src/main/java/org/jitsi/videobridge/EndpointMessageBuilder.java
+++ b/src/main/java/org/jitsi/videobridge/EndpointMessageBuilder.java
@@ -138,7 +138,7 @@ public class EndpointMessageBuilder
      * {@code SenderVideoConstraintsChanged} message.
      */
     public static final String COLIBRI_CLASS_SENDER_VIDEO_CONSTRAINTS_CHANGED
-        = "SenderVideoConstraintsChangedEvent";
+        = "SenderVideoConstraints";
 
     /**
      * The {@link Videobridge#COLIBRI_CLASS} value indicating a


### PR DESCRIPTION
Adjusts the colibri class name according to https://github.com/jitsi/lib-jitsi-meet/pull/1227/commits/d0b19451e8cf6ed1f00b882387afa28efe3d502f