### PR TITLE
Order last-n endpoints by video availability.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-media-transform</artifactId>
-                <version>1.0-161-gc1b49ff</version>
+                <version>1.0-164-g031788f</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/src/main/java/org/jitsi/videobridge/Conference.java
@@ -158,7 +158,6 @@ public class Conference
      */
     private final Logger logger;
 
-
     /**
      * Whether this conference should be considered when generating statistics.
      */

--- a/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
+++ b/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
@@ -341,19 +341,7 @@ public class ConferenceSpeechActivity
     {
         synchronized (syncRoot)
         {
-            //TODO(brian): make a copy?
-            return endpoints;
-        }
-    }
-
-    public List<String> getEndpointIds()
-    {
-
-        synchronized (syncRoot)
-        {
-           return endpoints.stream()
-                .map(AbstractEndpoint::getID)
-                .collect(Collectors.toList());
+            return new LinkedList<>(endpoints);
         }
     }
 
@@ -418,7 +406,6 @@ public class ConferenceSpeechActivity
         {
             final boolean finalDominantSpeakerChanged = dominantSpeakerChanged;
             final boolean finalEndpointsChanged = endpointsListChanged;
-            final List<String> finalNewEndpointIds = getEndpointIds();
             TaskPools.IO_POOL.submit(() -> {
                 final Conference conference = this.conference;
                 if (conference == null)
@@ -432,7 +419,7 @@ public class ConferenceSpeechActivity
                 // Dominant speaker changed implies that the list changed.
                 if (finalEndpointsChanged && !finalDominantSpeakerChanged)
                 {
-                    conference.speechActivityEndpointsChanged(finalNewEndpointIds);
+                    conference.speechActivityEndpointsChanged();
                 }
 
             });

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1009,7 +1009,16 @@ public class Endpoint
                     endpointsEnteringLastN,
                     conferenceEndpoints);
 
-        sendMessage(msg);
+        TaskPools.IO_POOL.submit(() -> {
+            try
+            {
+                sendMessage(msg);
+            }
+            catch (Exception e)
+            {
+                logger.warn("Failed to send a message: ", e);
+            }
+        });
     }
 
     /**

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1531,16 +1531,14 @@ public class Endpoint
     @Override
     public boolean isSendingAudio()
     {
-        // The endpoint is sending audio if we (the transceiver) are receiving
-        // audio.
+        // The endpoint is sending audio if we (the transceiver) are receiving audio.
         return transceiver.isReceivingAudio();
     }
 
     @Override
     public boolean isSendingVideo()
     {
-        // The endpoint is sending video if we (the transceiver) are receiving
-        // video.
+        // The endpoint is sending video if we (the transceiver) are receiving video.
         return transceiver.isReceivingVideo();
     }
 

--- a/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -236,6 +236,9 @@ public class Endpoint
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private Optional<SctpServerSocket> sctpSocket = Optional.empty();
 
+    @NotNull
+    private final TransceiverEventHandler transceiverEventHandler = new TransceiverEventHandlerImpl();
+
     /**
      * Initializes a new <tt>Endpoint</tt> instance with a specific (unique)
      * identifier/ID of the endpoint of a participant in a <tt>Conference</tt>.
@@ -267,6 +270,7 @@ public class Endpoint
             TaskPools.SCHEDULED_POOL,
             diagnosticContext,
             logger,
+            transceiverEventHandler,
             clock
         );
         transceiver.setIncomingPacketHandler(
@@ -305,13 +309,6 @@ public class Endpoint
         bandwidthProbing = new BandwidthProbing(Endpoint.this.transceiver::sendProbing);
         bandwidthProbing.setDiagnosticContext(diagnosticContext);
         bandwidthProbing.setBitrateController(bitrateController);
-        transceiver.setAudioLevelListener(conference.getAudioLevelListener());
-        transceiver.onBandwidthEstimateChanged(newValueBps ->
-        {
-            logger.debug(() -> "Estimated bandwidth is now " + newValueBps + " bps.");
-            bitrateController.bandwidthChanged((long)newValueBps.getBps());
-        });
-        transceiver.onBandwidthEstimateChanged(bandwidthProbing);
         conference.encodingsManager.subscribe(this);
 
         bandwidthProbing.enabled = true;
@@ -1536,5 +1533,31 @@ public class Endpoint
         // The endpoint is sending video if we (the transceiver) are receiving
         // video.
         return transceiver.isReceivingVideo();
+    }
+
+    private class TransceiverEventHandlerImpl implements TransceiverEventHandler
+    {
+        /**
+         * Forward audio level events from the Transceiver to the conference. We use the same thread, because this fires
+         * for every packet and we want to avoid the switch. The conference audio level code must not block.
+         * @param sourceSsrc
+         * @param level
+         */
+        @Override
+        public void audioLevelReceived(long sourceSsrc, long level)
+        {
+            getConference().getAudioLevelListener().onLevelReceived(sourceSsrc, level);
+        }
+
+        /**
+         * Forward bwe events from the Transceiver.
+         */
+        @Override
+        public void bandwidthEstimationChanged(@NotNull Bandwidth newValue)
+        {
+            logger.debug(() -> "Estimated bandwidth is now " + newValue);
+            bitrateController.bandwidthChanged((long)newValue.getBps());
+            bandwidthProbing.bandwidthEstimationChanged(newValue);
+        }
     }
 }

--- a/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -696,6 +696,9 @@ public class BitrateController
 
         Set<String> newForwardedEndpointIds = new HashSet<>();
         Set<String> endpointsEnteringLastNIds = new HashSet<>();
+        // TODO: The only use of conferenceEndpointIds is sending it to the client. Since it is just a set of all
+        // endpoints in the conference (not ordered by anything specific), it carries no useful information to the
+        // client. Check if we can remove its use from the client and subsequently from this code.
         Set<String> conferenceEndpointIds = new HashSet<>();
 
         // Accumulators used for tracing purposes.

--- a/src/main/java/org/jitsi/videobridge/octo/OctoTransceiver.java
+++ b/src/main/java/org/jitsi/videobridge/octo/OctoTransceiver.java
@@ -54,18 +54,23 @@ public class OctoTransceiver implements Stoppable, NodeStatsProducer
     private final StreamInformationStore streamInformationStore
             = new StreamInformationStoreImpl();
 
-    private final OctoRtpReceiver octoReceiver;
+    final OctoRtpReceiver octoReceiver;
 
     private final OctoRtpSender octoSender;
+
+    OctoTransceiver(String id, Logger parentLogger)
+    {
+        this(id, null, parentLogger);
+    }
 
     /**
      * Initializes a new {@link OctoTransceiver} instance.
      */
-    OctoTransceiver(String id, Logger parentLogger)
+    OctoTransceiver(String id, TransceiverEventHandler eventHandler, Logger parentLogger)
     {
         this.logger = parentLogger.createChildLogger(this.getClass().getName());
         this.id = id;
-        this.octoReceiver = new OctoRtpReceiver(streamInformationStore, logger);
+        this.octoReceiver = new OctoRtpReceiver(streamInformationStore, eventHandler, logger);
         this.octoSender = new OctoRtpSender(streamInformationStore, logger);
     }
 
@@ -173,13 +178,9 @@ public class OctoTransceiver implements Stoppable, NodeStatsProducer
         streamInformationStore.addRtpExtensionMapping(rtpExtension);
     }
 
-    void setAudioLevelListener(AudioLevelListener audioLevelListener)
-    {
-        octoReceiver.setAudioLevelListener(audioLevelListener);
-    }
-
     @Override
-    public void stop() {
+    public void stop()
+    {
         octoReceiver.stop();
         octoReceiver.tearDown();
         octoSender.stop();
@@ -199,17 +200,13 @@ public class OctoTransceiver implements Stoppable, NodeStatsProducer
         return nodeStats;
     }
 
-    /**
-     * Gets a JSON representation of the parts of this object's state that
-     * are deemed useful for debugging.
-     */
-    @SuppressWarnings("unchecked")
-    JSONObject getDebugState()
+    boolean isReceivingAudio()
     {
-        JSONObject debugState = new JSONObject();
-        debugState.put("octoReceiver", octoReceiver.getDebugState());
-        debugState.put("octoSender", octoSender.getDebugState());
-        debugState.put("mediaSources", mediaSources.getNodeStats().toJson());
-        return debugState;
+        return octoReceiver.isReceivingAudio();
+    }
+
+    boolean isReceivingVideo()
+    {
+        return octoReceiver.isReceivingVideo();
     }
 }

--- a/src/main/java/org/jitsi/videobridge/rest/root/colibri/conferences/Conferences.java
+++ b/src/main/java/org/jitsi/videobridge/rest/root/colibri/conferences/Conferences.java
@@ -98,8 +98,7 @@ public class Conferences extends ColibriResource
             throw new NotFoundException();
         }
 
-        ConferenceSpeechActivity conferenceSpeechActivity
-                = conference.getSpeechActivity();
+        ConferenceSpeechActivity conferenceSpeechActivity = conference.getSpeechActivity();
 
         return conferenceSpeechActivity.doGetDominantSpeakerIdentificationJSON().toJSONString();
     }


### PR DESCRIPTION
When ordering the endpoints to forward, order not only by speech activity, but also whether endpoints are sending video (those sending video are put on the top of the list).