### PR TITLE
ref: Extracts the VideoPolicy from the VideoConstraints.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -17,7 +17,6 @@ package org.jitsi.videobridge;
 
 import org.jetbrains.annotations.*;
 import org.jitsi.nlj.*;
-import com.google.common.collect.*;
 import org.jitsi.nlj.format.*;
 import org.jitsi.nlj.rtp.*;
 import org.jitsi.nlj.util.*;
@@ -33,7 +32,7 @@ import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 
-import static org.jitsi.videobridge.VideoConstraints.thumbnailVideoConstraints;
+import static org.jitsi.videobridge.VideoConstraints.thumbnail;
 
 /**
  * Represents an endpoint in a conference (i.e. the entity associated with
@@ -50,7 +49,7 @@ public abstract class AbstractEndpoint
     /**
      * The default video constraints to assume when nothing is signaled.
      */
-    private static final VideoConstraints defaultMaxReceiverVideoConstraints = thumbnailVideoConstraints;
+    private static final VideoConstraints defaultMaxReceiverVideoConstraints = thumbnail;
 
     /**
      * The (unique) identifier/ID of the endpoint of a participant in a
@@ -376,25 +375,6 @@ public abstract class AbstractEndpoint
      * Adds an RTP extension to this endpoint
      */
     public abstract void addRtpExtension(RtpExtension rtpExtension);
-
-    /**
-     * Sets the video constraints for the streams that this endpoint wishes to
-     * receive expressed as a map of endpoint id to {@link VideoConstraints}.
-     *
-     * NOTE that the map specifies all the constraints that need to be respected
-     * and therefore it resets any previous settings. In other words the map
-     * is not a diff/delta to be applied on top of the existing settings.
-     *
-     * NOTE that if there are no {@link VideoConstraints} specified for an
-     * endpoint, then its {@link VideoConstraints} are assumed to be
-     * {@link org.jitsi.videobridge.cc.BitrateController.defaultVideoConstraints}
-     *
-     * @param videoConstraints the map of endpoint id to {@link VideoConstraints}
-     * that contains the {@link VideoConstraints} to respect when allocating
-     * bandwidth for a specific endpoint.
-     */
-    public abstract void setSenderVideoConstraints(
-        ImmutableMap<String, VideoConstraints> videoConstraints);
 
     /**
      * Notifies this instance that the max video constraints that the bridge

--- a/jvb/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
@@ -18,6 +18,7 @@ package org.jitsi.videobridge;
 import com.google.common.collect.*;
 import org.jetbrains.annotations.*;
 import org.jitsi.utils.logging2.*;
+import org.jitsi.videobridge.cc.*;
 import org.jitsi.videobridge.datachannel.*;
 import org.jitsi.videobridge.datachannel.protocol.*;
 import org.jitsi.videobridge.message.*;
@@ -429,7 +430,7 @@ class EndpointMessageTransport
         }
 
         videoConstraintsCompatibility.setPinnedEndpoints(newPinnedEndpoints);
-        setSenderVideoConstraints(videoConstraintsCompatibility.computeVideoConstraints());
+        setSenderVideoSetupMap(videoConstraintsCompatibility.computeVideoSetupMap());
 
         return null;
     }
@@ -467,25 +468,25 @@ class EndpointMessageTransport
 
         logger.debug(() -> "Selected " + newSelectedEndpoints);
         videoConstraintsCompatibility.setSelectedEndpoints(newSelectedEndpoints);
-        setSenderVideoConstraints(videoConstraintsCompatibility.computeVideoConstraints());
+        setSenderVideoSetupMap(videoConstraintsCompatibility.computeVideoSetupMap());
         return null;
     }
 
     /**
      * Sets the sender video constraints of this {@link #endpoint}.
      *
-     * @param videoConstraintsMap the sender video constraints of this
+     * @param videoSetupMap the sender video constraints of this
      * {@link #endpoint}.
      */
-    public void setSenderVideoConstraints(Map<String, VideoConstraints> videoConstraintsMap)
+    public void setSenderVideoSetupMap(Map<String, VideoSetup> videoSetupMap)
     {
         // Don't "pollute" the video constraints map with constraints for this
         // endpoint.
-        videoConstraintsMap.remove(endpoint.getID());
+        videoSetupMap.remove(endpoint.getID());
 
-        logger.debug(() -> "New video constraints map: " + videoConstraintsMap);
+        logger.debug(() -> "New video setup map: " + videoSetupMap);
 
-        endpoint.setSenderVideoConstraints(ImmutableMap.copyOf(videoConstraintsMap));
+        endpoint.setSenderVideoSetupMap(ImmutableMap.copyOf(videoSetupMap));
     }
 
     /**
@@ -502,7 +503,7 @@ class EndpointMessageTransport
                 () -> "Received a maxFrameHeight video constraint from " + endpoint.getID() + ": " + maxFrameHeight);
 
         videoConstraintsCompatibility.setMaxFrameHeight(maxFrameHeight);
-        setSenderVideoConstraints(videoConstraintsCompatibility.computeVideoConstraints());
+        setSenderVideoSetupMap(videoConstraintsCompatibility.computeVideoSetupMap());
 
         return null;
     }

--- a/jvb/src/main/java/org/jitsi/videobridge/VideoConstraints.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/VideoConstraints.java
@@ -28,7 +28,7 @@ public class VideoConstraints
     /**
      * Static instance for the default constraints for a thumbnail.
      */
-    public static final VideoConstraints thumbnailVideoConstraints =
+    public static final VideoConstraints thumbnail =
         new VideoConstraints(BitrateControllerConfig.thumbnailMaxHeightPx());
 
     /**
@@ -37,24 +37,6 @@ public class VideoConstraints
      * is available.
      */
     private final int idealHeight;
-
-    /**
-     * The "preferred" height of the constrained endpoint. When it's time to
-     * allocate bandwidth for the associated source or endpoint, the bridge
-     * tries to satisfy the preferred resolution before moving to the next
-     * endpoint or source.
-     *
-     * NOTE this this field along with {@link #preferredFps} is more of a
-     * per-endpoint policy than a constraint and eventually it should be moved
-     * out of this class.
-     */
-    private final int preferredHeight;
-
-    /**
-     * The "preferred" frame-rate of the constrained endpoint.
-     */
-    private final double preferredFps;
-
 
     /**
      * A default constructor to allow parsing with jackson.
@@ -68,13 +50,9 @@ public class VideoConstraints
      * Ctor.
      *
      * @param idealHeight The ideal height of the constrained endpoint.
-     * @param preferredHeight The "preferred" height of the constrained endpoint.
-     * @param preferredFps The "preferred" frame-rate of the constrained endpoint.
      */
     public VideoConstraints(int idealHeight, int preferredHeight, double preferredFps)
     {
-        this.preferredFps = preferredFps;
-        this.preferredHeight = preferredHeight;
         this.idealHeight = idealHeight;
     }
 
@@ -86,22 +64,6 @@ public class VideoConstraints
     public VideoConstraints(int idealHeight)
     {
         this(idealHeight, -1, -1);
-    }
-
-    /**
-     * @return The "preferred" height of the constrained endpoint source.
-     */
-    public int getPreferredHeight()
-    {
-        return preferredHeight;
-    }
-
-    /**
-     * @return The "preferred" framerate of the constrained endpoint or source.
-     */
-    public double getPreferredFps()
-    {
-        return preferredFps;
     }
 
     /**
@@ -118,15 +80,13 @@ public class VideoConstraints
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         VideoConstraints that = (VideoConstraints) o;
-        return idealHeight == that.idealHeight &&
-            preferredHeight == that.preferredHeight &&
-            Double.compare(that.preferredFps, preferredFps) == 0;
+        return idealHeight == that.idealHeight;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(idealHeight, preferredHeight, preferredFps);
+        return Objects.hash(idealHeight);
     }
 
     @Override
@@ -134,8 +94,6 @@ public class VideoConstraints
     {
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("idealHeight", idealHeight);
-        jsonObject.put("preferredHeight", preferredHeight);
-        jsonObject.put("preferredFps", preferredFps);
         return jsonObject.toJSONString();
     }
 }

--- a/jvb/src/main/java/org/jitsi/videobridge/VideoConstraintsCompatibility.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/VideoConstraintsCompatibility.java
@@ -17,6 +17,7 @@
 package org.jitsi.videobridge;
 
 import org.jitsi.nlj.util.*;
+import org.jitsi.videobridge.cc.*;
 import org.jitsi.videobridge.cc.config.*;
 import org.json.simple.*;
 
@@ -93,20 +94,20 @@ class VideoConstraintsCompatibility
      * controller that it needs to (evenly) distribute bandwidth across all
      * participants, up to X.
      */
-    Map<String, VideoConstraints> computeVideoConstraints()
+    Map<String, VideoSetup> computeVideoSetupMap()
     {
-        Map<String, VideoConstraints> newVideoConstraints = new HashMap<>();
+        Map<String, VideoSetup> newVideoConstraints = new HashMap<>();
 
         int maxFrameHeightCopy = maxFrameHeight;
 
         Set<String> pinnedEndpointsCopy = pinnedEndpoints;
         if (pinnedEndpointsCopy != null && !pinnedEndpointsCopy.isEmpty())
         {
-            final VideoConstraints pinnedEndpointConstraints
-                = new VideoConstraints(Math.min(
-                BitrateControllerConfig.thumbnailMaxHeightPx(), maxFrameHeightCopy));
+            final VideoSetup pinnedEndpointConstraints
+                = new VideoSetup(VideoPolicy.empty, new VideoConstraints(Math.min(
+                BitrateControllerConfig.thumbnailMaxHeightPx(), maxFrameHeightCopy)));
 
-            Map<String, VideoConstraints> pinnedVideoConstraintsMap
+            Map<String, VideoSetup> pinnedVideoConstraintsMap
                 = pinnedEndpointsCopy
                 .stream()
                 .collect(Collectors.toMap(e -> e, e -> pinnedEndpointConstraints));
@@ -117,7 +118,7 @@ class VideoConstraintsCompatibility
         Set<String> selectedEndpointsCopy = selectedEndpoints;
         if (selectedEndpointsCopy != null && !selectedEndpointsCopy.isEmpty())
         {
-            final VideoConstraints selectedEndpointConstraints;
+            final VideoSetup selectedEndpointConstraints;
 
             if (selectedEndpointsCopy.size() > 1)
             {
@@ -143,20 +144,18 @@ class VideoConstraintsCompatibility
                 // In tile view we set the ideal height but not the preferred height
                 // nor the preferred frame-rate because we want even even
                 // distribution of bandwidth among all the tiles to avoid ninjas.
-                selectedEndpointConstraints = new VideoConstraints(
+                selectedEndpointConstraints = new VideoSetup(VideoPolicy.empty, new VideoConstraints(
                     Math.min(BitrateControllerConfig.onstageIdealHeightPx(),
-                        maxFrameHeightCopy));
+                        maxFrameHeightCopy)));
             }
             else
             {
-                selectedEndpointConstraints = new VideoConstraints(
+                selectedEndpointConstraints = new VideoSetup(VideoPolicy.greedyTo360ThenFavorMotion, new VideoConstraints(
                     Math.min(BitrateControllerConfig.onstageIdealHeightPx(),
-                        maxFrameHeightCopy),
-                    BitrateControllerConfig.onstagePreferredHeightPx(),
-                    BitrateControllerConfig.onstagePreferredFramerate());
+                        maxFrameHeightCopy)));
             }
 
-            Map<String, VideoConstraints> selectedVideoConstraintsMap
+            Map<String, VideoSetup> selectedVideoConstraintsMap
                 = selectedEndpointsCopy
                 .stream()
                 .collect(Collectors.toMap(e -> e, e -> selectedEndpointConstraints));

--- a/jvb/src/main/java/org/jitsi/videobridge/VideoConstraintsCompatibility.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/VideoConstraintsCompatibility.java
@@ -150,9 +150,10 @@ class VideoConstraintsCompatibility
             }
             else
             {
-                selectedEndpointConstraints = new VideoSetup(VideoPolicy.greedyTo360ThenFavorMotion, new VideoConstraints(
-                    Math.min(BitrateControllerConfig.onstageIdealHeightPx(),
-                        maxFrameHeightCopy)));
+                selectedEndpointConstraints = new VideoSetup(
+                    VideoPolicy.greedyTo360ThenFavorMotion, new VideoConstraints(
+                        Math.min(BitrateControllerConfig.onstageIdealHeightPx(),
+                            maxFrameHeightCopy)));
             }
 
             Map<String, VideoSetup> selectedVideoConstraintsMap

--- a/jvb/src/main/java/org/jitsi/videobridge/VideoPolicy.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/VideoPolicy.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright @ 2017 - Present, 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge;
+
+import org.json.simple.*;
+
+import java.util.*;
+
+/**
+ *
+ */
+public class VideoPolicy
+{
+    /**
+     * The instance that expresses the lack of video preferences.
+     */
+    public static final VideoPolicy empty = new VideoPolicy(-1, -1);
+
+    /**
+     * The instance that expresses greedy allocation up to 360p and a preference of motion (frame rate) over quality
+     * (resolution/height) beyond that point.
+     *
+     * For the "selected" participant we favor frame rate over resolution. We include all temporal layers up to the
+     * preferred resolution, but only consider the preferred frame-rate with higher-than-preferred resolutions. In
+     * practice today this translates to 180p7.5fps, 180p15fps, 180p30fps, 360p30fps and 720p30fps.
+     */
+    public static final VideoPolicy greedyTo360ThenFavorMotion = new VideoPolicy(360, 30);
+
+    /**
+     * The "preferred" height of the constrained endpoint. When it's time to
+     * allocate bandwidth for the associated source or endpoint, the bridge
+     * tries to satisfy the preferred resolution before moving to the next
+     * endpoint or source.
+     *
+     * NOTE this this field along with {@link #minFpsBeyondGreedyHeight} is more of a
+     * per-endpoint policy than a constraint and eventually it should be moved
+     * out of this class.
+     */
+    private final int greedyHeightAllocationUpperBound;
+
+    /**
+     * The "preferred" frame-rate of the constrained endpoint.
+     */
+    private final double minFpsBeyondGreedyHeight;
+
+    /**
+     * Ctor.
+     *
+     * @param greedyHeightAllocationUpperBound The "preferred" height of the constrained endpoint.
+     * @param minFpsBeyondGreedyHeight The "preferred" frame-rate of the constrained endpoint.
+     */
+    public VideoPolicy(int greedyHeightAllocationUpperBound, double minFpsBeyondGreedyHeight)
+    {
+        this.minFpsBeyondGreedyHeight = minFpsBeyondGreedyHeight;
+        this.greedyHeightAllocationUpperBound = greedyHeightAllocationUpperBound;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VideoPolicy that = (VideoPolicy) o;
+        return greedyHeightAllocationUpperBound == that.greedyHeightAllocationUpperBound &&
+            Double.compare(that.minFpsBeyondGreedyHeight, minFpsBeyondGreedyHeight) == 0;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(minFpsBeyondGreedyHeight, greedyHeightAllocationUpperBound);
+    }
+
+    @Override
+    public String toString()
+    {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("greedyHeight", greedyHeightAllocationUpperBound);
+        jsonObject.put("minFpsBeyondGreedyHeight", minFpsBeyondGreedyHeight);
+        return jsonObject.toJSONString();
+    }
+
+    public double getMinFpsBeyondGreedyHeight()
+    {
+        return minFpsBeyondGreedyHeight;
+    }
+
+    public int getGreedyHeightAllocationUpperBound()
+    {
+        return greedyHeightAllocationUpperBound;
+    }
+}

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -346,8 +346,10 @@ public class BitrateController
             // We want "o1 has higher preferred height than o2" to imply "o1 is
             // smaller than o2" as this is equivalent to "o1 needs to be
             // prioritized first".
+            int greedyHeightAllocationUpperBound1 = o1.videoSetup.policy.getGreedyHeightAllocationUpperBound();
+            int greedyHeightAllocationUpperBound2 = o2.videoSetup.policy.getGreedyHeightAllocationUpperBound();
             int greedyHeightAllocationUpperBoundDiff =
-                o2.videoSetup.policy.getGreedyHeightAllocationUpperBound() - o1.videoSetup.policy.getGreedyHeightAllocationUpperBound();
+                greedyHeightAllocationUpperBound2 - greedyHeightAllocationUpperBound1;
 
             if (greedyHeightAllocationUpperBoundDiff != 0)
             {
@@ -358,7 +360,8 @@ public class BitrateController
                 // We want "o1 has higher ideal height than o2" to imply "o1 is
                 // smaller than o2" as this is equivalent to "o1 needs to be
                 // prioritized first".
-                int idealHeightDiff = o2.videoSetup.constraints.getIdealHeight() - o1.videoSetup.constraints.getIdealHeight();
+                int idealHeightDiff
+                    = o2.videoSetup.constraints.getIdealHeight() - o1.videoSetup.constraints.getIdealHeight();
                 if (idealHeightDiff != 0)
                 {
                     return idealHeightDiff;

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/VideoSetup.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/VideoSetup.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright @ 2015 - Present, 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.cc;
+
+import org.jetbrains.annotations.*;
+import org.jitsi.nlj.*;
+import org.jitsi.videobridge.*;
+
+import java.util.*;
+
+/**
+ * A pair of {@link VideoConstraints} and a {@link VideoPolicy} that forms the constraints sub-problem to solve when
+ * allocating bandwidth for a specific endpoint or a specific source.
+ */
+public class VideoSetup
+{
+    /**
+     * The instructions that describe how to chose the layers for a specific endpoint or a specific source.
+     */
+    public final VideoPolicy policy;
+
+    /**
+     * The constraints that limit the layer choices for a specific endpoint or a specific source.
+     */
+    public final VideoConstraints constraints;
+
+    /**
+     * Ctor.
+     *
+     * @param policy The instructions that describe how to chose the layers for a specific endpoint or a specific source.
+     * @param constraints The constraints that limit the layer choices for a specific endpoint or a specific source.
+     */
+    public VideoSetup(@NotNull VideoPolicy policy, @NotNull VideoConstraints constraints)
+    {
+        this.policy = policy;
+        this.constraints = constraints;
+    }
+
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VideoSetup that = (VideoSetup) o;
+        return constraints.equals(that.constraints) && policy.equals(that.policy);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(constraints.hashCode(), policy.hashCode());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "{policy: " + policy + ",constraints: " + constraints + "}";
+    }
+
+    public RtpLayerMatcher makeRtpLayerMatcher(RtpLayerDesc layer)
+    {
+        boolean lessThanOrEqualIdealResolution = layer.getHeight() <= constraints.getIdealHeight();
+        boolean lessThanPreferredResolution = layer.getHeight() < policy.getGreedyHeightAllocationUpperBound();
+        boolean atLeastPreferredFps = layer.getFrameRate() >= policy.getMinFpsBeyondGreedyHeight();
+
+        RtpLayerMatcher rtpLayerMatcher = new RtpLayerMatcher();
+        rtpLayerMatcher.isMatch = lessThanOrEqualIdealResolution && ((lessThanPreferredResolution || atLeastPreferredFps));
+        rtpLayerMatcher.withEagerAllocation = layer.getHeight() <= policy.getGreedyHeightAllocationUpperBound();
+
+        return rtpLayerMatcher;
+    }
+
+    static class RtpLayerMatcher
+    {
+        private boolean withEagerAllocation;
+        private boolean isMatch;
+
+        public boolean matches()
+        {
+            return isMatch;
+        }
+
+        public boolean shouldDoGreedyAllocation()
+        {
+            return withEagerAllocation;
+        }
+    }
+}

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/VideoSetup.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/VideoSetup.java
@@ -40,7 +40,8 @@ public class VideoSetup
     /**
      * Ctor.
      *
-     * @param policy The instructions that describe how to chose the layers for a specific endpoint or a specific source.
+     * @param policy The instructions that describe how to chose the layers for a specific endpoint or a specific
+     * source.
      * @param constraints The constraints that limit the layer choices for a specific endpoint or a specific source.
      */
     public VideoSetup(@NotNull VideoPolicy policy, @NotNull VideoConstraints constraints)
@@ -78,7 +79,8 @@ public class VideoSetup
         boolean atLeastPreferredFps = layer.getFrameRate() >= policy.getMinFpsBeyondGreedyHeight();
 
         RtpLayerMatcher rtpLayerMatcher = new RtpLayerMatcher();
-        rtpLayerMatcher.isMatch = lessThanOrEqualIdealResolution && ((lessThanPreferredResolution || atLeastPreferredFps));
+        rtpLayerMatcher.isMatch
+            = lessThanOrEqualIdealResolution && ((lessThanPreferredResolution || atLeastPreferredFps));
         rtpLayerMatcher.withEagerAllocation = layer.getHeight() <= policy.getGreedyHeightAllocationUpperBound();
 
         return rtpLayerMatcher;

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoEndpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoEndpoint.kt
@@ -16,7 +16,6 @@
 
 package org.jitsi.videobridge.octo
 
-import com.google.common.collect.ImmutableMap
 import org.jitsi.nlj.PacketHandler
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.format.PayloadType

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoEndpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoEndpoint.kt
@@ -83,10 +83,6 @@ class OctoEndpoint(
         // single OctoEndpoints instance.
     }
 
-    override fun setSenderVideoConstraints(newVideoConstraints: ImmutableMap<String, VideoConstraints>?) {
-        // NO-OP
-    }
-
     override fun requestKeyframe(mediaSsrc: Long) {
         transceiver.requestKeyframe(mediaSsrc)
     }

--- a/jvb/src/test/java/org/jitsi/videobridge/cc/EndpointMultiRankerTest.java
+++ b/jvb/src/test/java/org/jitsi/videobridge/cc/EndpointMultiRankerTest.java
@@ -26,10 +26,14 @@ import static org.junit.Assert.*;
 public class EndpointMultiRankerTest
 {
     final List<EndpointMultiRank> endpointMultiRanks = new ArrayList<>();
-    final VideoConstraints stageVideoConstraints
-        = new VideoConstraints(/* idealHeight */ 720);
-    final VideoConstraints thumbnailVideoConstraints
-        = new VideoConstraints(/* idealHeight */ 180);
+    final VideoSetup stageVideoConstraints
+        = new VideoSetup(
+            VideoPolicy.greedyTo360ThenFavorMotion,
+            new VideoConstraints(/* idealHeight */ 720));
+    final VideoSetup thumbnailVideoConstraints
+        = new VideoSetup(
+            VideoPolicy.empty,
+            new VideoConstraints(/* idealHeight */ 180));
 
     @Test
     public void followActiveSpeaker()
@@ -93,8 +97,8 @@ public class EndpointMultiRankerTest
         assertEquals(endpointMultiRanks.get(2), speaker2MultiRank);
     }
 
-    private EndpointMultiRank makeNextSpeakerWithVideoConstraints(VideoConstraints videoConstraints)
+    private EndpointMultiRank makeNextSpeakerWithVideoConstraints(VideoSetup videoSetup)
     {
-        return new EndpointMultiRank(endpointMultiRanks.size(), videoConstraints, null);
+        return new EndpointMultiRank(endpointMultiRanks.size(), videoSetup, null);
     }
 }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
@@ -192,8 +192,6 @@ class BridgeChannelMessageTest : ShouldSpec() {
             val videoConstraints: org.jitsi.videobridge.VideoConstraints =
                 jacksonObjectMapper().readValue(VIDEO_CONSTRAINTS)
             videoConstraints.idealHeight shouldBe 1080
-            videoConstraints.preferredHeight shouldBe 360
-            videoConstraints.preferredFps shouldBe 30.0
 
             val senderVideoConstraintsMessage = SenderVideoConstraintsMessage(videoConstraints)
             val parsed = parse(senderVideoConstraintsMessage.toJson())
@@ -202,8 +200,6 @@ class BridgeChannelMessageTest : ShouldSpec() {
             parsed as SenderVideoConstraintsMessage
 
             parsed.videoConstraints.idealHeight shouldBe 1080
-            parsed.videoConstraints.preferredHeight shouldBe 360
-            parsed.videoConstraints.preferredFps shouldBe 30.0
         }
 
         "serializing and parsing AddReceiver" {

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
@@ -243,9 +243,7 @@ class BridgeChannelMessageTest : ShouldSpec() {
 
         const val VIDEO_CONSTRAINTS = """
             {
-                "idealHeight": 1080,
-                "preferredHeight": 360,
-                "preferredFps": 30.0
+                "idealHeight": 1080
             }
         """
     }


### PR DESCRIPTION
This commit separates the _video policy_ from the _video constraints_.

Video constraints express the physicall constraints of a video source.
These are used from the bridge in both its video sending and receiving
function: When the bridge acts as a sender they're used to limit the
choice of layers to consider when performing bandwidth distribution.
When the bridge acts as a receiver, it feeds these constraints back to
the client so that the client can reduce its bitrate.

The video policy defines preferences and carries instructions on how to
perform bandwdith distribution, so they are irrelevant in the video
receiving function of the bridge. These instructions are internally
translated as additional constraints by the bandwidth distribution algo.

The motivation behind this commit is to clean-up the `VideoConstraints`
class from information that is irrelevant for the receive-side aspect of
the bridge.