### PR TITLE
feat(systemd): restart jvb service automatically

### DIFF
--- a/debian/jitsi-videobridge2.service
+++ b/debian/jitsi-videobridge2.service
@@ -20,6 +20,8 @@ LimitNPROC=65000
 LimitNOFILE=65000
 ExecStart=/bin/bash -c "exec /usr/share/jitsi-videobridge/jvb.sh ${JVB_OPTS} < /dev/null >> ${LOGFILE} 2>&1"
 ExecStartPost=/bin/bash -c "echo $MAINPID > /var/run/jitsi-videobridge/jitsi-videobridge.pid"
+Restart=on-failure
+RestartSec=2
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When the jvb process exits abnormally (e.g. due to a oom condition),
systemd will restart the process.

fixes #1353