### PR TITLE
synchronize endpoint expiry and endpoint initialization

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -317,12 +317,14 @@ public class ConferenceShim
      */
     private void ensureEndpointCreated(String endpointId, boolean iceControlling)
     {
-        if (conference.getLocalEndpoint(endpointId) != null)
-        {
-            return;
-        }
+        synchronized(conference) {
+            if (conference.getLocalEndpoint(endpointId) != null)
+            {
+                return;
+            }
 
-        conference.createLocalEndpoint(endpointId, iceControlling);
+            conference.createLocalEndpoint(endpointId, iceControlling);
+        }
     }
 
     /**


### PR DESCRIPTION
We're running into routine crashes where we get `null` for a localEndpoint in `ContentShim.createRtpChannel`. This patch ensures that `ConferenceShim.ensureEndpointCreated` does not overlap with endpoint expiry, which seems to be the cause of our issue.