### PR TITLE
Remove unused deps

### DIFF
--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -80,11 +80,6 @@
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.igniterealtime.smack</groupId>
-      <artifactId>smack-extensions</artifactId>
-      <version>${smack.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>15.0</version>

--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -60,11 +60,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>dom4j</groupId>
-      <artifactId>dom4j</artifactId>
-      <version>1.6.1</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>28.2-jre</version>

--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -164,11 +164,6 @@
       <version>4.3.1</version>
     </dependency>
     <dependency>
-      <groupId>xpp3</groupId>
-      <artifactId>xpp3</artifactId>
-      <version>1.1.4c</version>
-    </dependency>
-    <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-jdk8</artifactId>
       <version>${kotlin.version}</version>

--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -296,12 +296,6 @@
         <version>1.6.2</version>
         <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>jicoco-test-kotlin</artifactId>
-      <version>${jicoco.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
         <jetty.version>9.4.15.v20190215</jetty.version>
         <kotlin.version>1.3.71</kotlin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <smack.version>4.2.4-47d17fc</smack.version>
         <jicoco.version>1.1-39-g6b2d353</jicoco.version>
         <jitsi.utils.version>1.0-55-g21baf6e</jitsi.utils.version>
         <maven-shade-plugin.version>3.2.2</maven-shade-plugin.version>


### PR DESCRIPTION
From what I can tell, these deps can be safely removed.  Some of them are no longer used at all, and some are still in the dependency tree but not used directly by JVB.