### PR TITLE
port rest api to new config

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
@@ -15,8 +15,6 @@
  */
 package org.jitsi.videobridge.rest;
 
-import java.util.*;
-
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.servlet.*;
 import org.glassfish.jersey.servlet.*;
@@ -48,6 +46,8 @@ public class RESTBundleActivator
      */
     public static final String JETTY_PROPERTY_PREFIX
         = "org.jitsi.videobridge.rest.private";
+
+    private final RestBundleActivatorConfig config = new RestBundleActivatorConfig();
 
     /**
      * Initializes a new {@code RESTBundleActivator} instance.
@@ -102,7 +102,7 @@ public class RESTBundleActivator
         if (b)
         {
             // The REST API of Videobridge does not start by default.
-            b = getCfgBoolean(Videobridge.REST_API_PNAME, false);
+            b = config.getEnabled();
         }
         return b;
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/RestBundleActivatorConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/RestBundleActivatorConfig.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge
+
+import org.jitsi.config.JitsiConfig
+import org.jitsi.metaconfig.config
+
+class RestBundleActivatorConfig {
+    val enabled: Boolean by config {
+        // If the value was passed via a command line arg, we set it as a system
+        // variable at this path, which the new config will pick up
+        Videobridge.REST_API_PNAME.from(JitsiConfig.newConfig)
+        "videobridge.apis.rest.enabled".from(JitsiConfig.newConfig)
+    }
+}

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -52,6 +52,9 @@ videobridge {
         # }
       }
     }
+    rest {
+      enabled = false
+    }
     jvb-api {
       enabled = false
     }


### PR DESCRIPTION
I bumped into this when updating AbstractJettyBundleActivator to new config.  RESTBundleActivator was still using an old config, so this PR removes that usage.