### PR TITLE
Rework http server config

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/RESTBundleActivator.java
@@ -54,7 +54,7 @@ public class RESTBundleActivator
      */
     public RESTBundleActivator()
     {
-        super(JETTY_PROPERTY_PREFIX, "videobridge.rest.private");
+        super(JETTY_PROPERTY_PREFIX, "videobridge.http-servers.private");
     }
 
     /**

--- a/jvb/src/main/java/org/jitsi/videobridge/websocket/WebSocketBundleActivator.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/websocket/WebSocketBundleActivator.java
@@ -51,7 +51,7 @@ public class WebSocketBundleActivator
      */
     public WebSocketBundleActivator()
     {
-        super(JETTY_PROPERTY_PREFIX, "videobridge.rest");
+        super(JETTY_PROPERTY_PREFIX, "videobridge.http-servers.public");
     }
 
     /**

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -52,6 +52,7 @@ videobridge {
         # }
       }
     }
+    # The COLIBRI REST API
     rest {
       enabled = false
     }

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -70,6 +70,7 @@ videobridge {
     # The HTTP server which can only be accessed via localhost
     private {
       # See JettyBundleActivatorConfig in Jicoco for values
+      host = 127.0.0.1
     }
   }
   octo {

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -60,6 +60,16 @@ videobridge {
       enabled = false
     }
   }
+  http-servers {
+    # The HTTP server which can be accessed publicly (used for things like websockets)
+    public {
+      # See JettyBundleActivatorConfig in Jicoco for values
+    }
+    # The HTTP server which can only be accessed via localhost
+    private {
+      # See JettyBundleActivatorConfig in Jicoco for values
+    }
+  }
   octo {
     # Whether or not Octo is enabled
     enabled=false

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -64,6 +64,8 @@ videobridge {
     # The HTTP server which can be accessed publicly (used for things like websockets)
     public {
       # See JettyBundleActivatorConfig in Jicoco for values
+      port = -1
+      tls-port = -1
     }
     # The HTTP server which can only be accessed via localhost
     private {

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -61,13 +61,15 @@ videobridge {
     }
   }
   http-servers {
-    # The HTTP server which can be accessed publicly (used for things like websockets)
+    # The HTTP server which hosts services intended for 'public' use
+    # (e.g. websockets for the bridge channel connection)
     public {
       # See JettyBundleActivatorConfig in Jicoco for values
       port = -1
       tls-port = -1
     }
-    # The HTTP server which can only be accessed via localhost
+    # The HTTP server which hosts services intended for 'private' use
+    # (e.g. health or debug stats)
     private {
       # See JettyBundleActivatorConfig in Jicoco for values
       host = 127.0.0.1


### PR DESCRIPTION
This PR changes the location of the http server configuration to make it more explicit.  It also restores a the previous default behavior of disabling the public http server by default (this was broken unintentionally in https://github.com/jitsi/jitsi-videobridge/pull/1375).

No other changes are needed here as there was no default config before.