### PR TITLE
change octorelayservice to not be an osgi service

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Main.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Main.java
@@ -21,6 +21,8 @@ import org.jitsi.cmd.*;
 import org.jitsi.meet.*;
 import org.jitsi.metaconfig.*;
 import org.jitsi.utils.logging2.*;
+import org.jitsi.videobridge.octo.*;
+import org.jitsi.videobridge.octo.config.*;
 import org.jitsi.videobridge.osgi.*;
 
 /**
@@ -81,6 +83,23 @@ public class Main
         System.setProperty(
                 Videobridge.REST_API_PNAME,
                 Boolean.toString(apis.contains(Videobridge.REST_API)));
+
+        OctoRelayService octoRelayService = OctoRelayServiceProviderKt.singleton().get();
+        if (octoRelayService != null)
+        {
+            octoRelayService.start();
+        }
+
+        Logger logger = new LoggerImpl("org.jitsi.videobridge.Main");
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() ->
+        {
+            logger.info("Shutdown hook running");
+            if (octoRelayService != null)
+            {
+                octoRelayService.stop();
+            }
+        }));
 
         ComponentMain main = new ComponentMain();
         BundleConfig osgiBundles = new BundleConfig();

--- a/jvb/src/main/java/org/jitsi/videobridge/octo/ConfOctoTransport.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/octo/ConfOctoTransport.java
@@ -145,10 +145,7 @@ public class ConfOctoTransport
         this.conferenceId = conference.getGid();
         this.clock = clock;
         this.logger = conference.getLogger().createChildLogger(this.getClass().getName());
-        BundleContext bundleContext = conference.getBundleContext();
-        OctoRelayService octoRelayService
-            = bundleContext == null ? null :
-            ServiceUtils2.getService(bundleContext, OctoRelayService.class);
+        OctoRelayService octoRelayService = OctoRelayServiceProviderKt.singleton().get();
 
         if (octoRelayService == null)
         {

--- a/jvb/src/main/java/org/jitsi/videobridge/osgi/BundleConfig.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/osgi/BundleConfig.java
@@ -66,9 +66,6 @@ public class BundleConfig
             "org/jitsi/videobridge/xmpp/ClientConnectionImpl"
         },
         {
-            "org/jitsi/videobridge/octo/OctoRelayService"
-        },
-        {
             "org/jitsi/videobridge/EndpointConnectionStatus"
         }
     };

--- a/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -473,8 +473,7 @@ public class VideobridgeStatistics
                     TOTAL_PACKETS_RECEIVED, jvbStats.totalPacketsReceived.get());
             unlockedSetStat(TOTAL_PACKETS_SENT, jvbStats.totalPacketsSent.get());
 
-            OctoRelayService relayService
-                = ServiceUtils2.getService(bundleContext, OctoRelayService.class);
+            OctoRelayService relayService = OctoRelayServiceProviderKt.singleton().get();
             OctoRelayService.Stats octoRelayServiceStats
                 = relayService == null ? null : relayService.getStats();
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayService.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayService.kt
@@ -21,14 +21,12 @@ import org.jitsi.videobridge.octo.config.OctoConfig.Companion.config
 import org.jitsi.videobridge.transport.octo.BridgeOctoTransport
 import org.jitsi.videobridge.transport.udp.UdpTransport
 import org.jitsi.videobridge.util.TaskPools
-import org.osgi.framework.BundleActivator
-import org.osgi.framework.BundleContext
 import java.net.SocketAddress
 import java.net.SocketException
 import java.net.UnknownHostException
 import java.time.Instant
 
-class OctoRelayService : BundleActivator {
+class OctoRelayService {
     /**
      * The [UdpTransport] used to send and receive Octo data
      */
@@ -40,7 +38,7 @@ class OctoRelayService : BundleActivator {
     var bridgeOctoTransport: BridgeOctoTransport? = null
         private set
 
-    override fun start(bundleContext: BundleContext) {
+    fun start() {
         if (!config.enabled) {
             logger.info("Octo relay is disabled")
             return
@@ -78,15 +76,10 @@ class OctoRelayService : BundleActivator {
             }
         }
         TaskPools.IO_POOL.submit { udpTransport!!.startReadingData() }
-
-        bundleContext.registerService(
-            OctoRelayService::class.java.name,
-            this,
-            null
-        )
     }
 
-    override fun stop(context: BundleContext?) {
+    fun stop() {
+        logger.info("Stopping")
         udpTransport?.stop()
         bridgeOctoTransport?.stop()
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayServiceProvider.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayServiceProvider.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.octo
+
+import org.jitsi.videobridge.octo.config.OctoConfig
+
+class OctoRelayServiceProvider {
+    private val octoRelayService: OctoRelayService? by lazy {
+        if (OctoConfig.config.enabled) {
+            OctoRelayService()
+        } else {
+            null
+        }
+    }
+
+    fun get(): OctoRelayService? = octoRelayService
+}
+
+private val supplierSingleton: OctoRelayServiceProvider = OctoRelayServiceProvider()
+
+fun singleton(): OctoRelayServiceProvider = supplierSingleton


### PR DESCRIPTION
There wasn't much preventing `OctoRelayService` from becoming a 'regular' class instead of an OSGi service, so this PR moves it away from an OSGi service.

Although I didn't do it here, it wouldn't be too bad to plumb in an `OctoRelayServiceSupplier` instance to the classes that need it which would prevent them accessing a global singleton.  Neither of those classes currently have tests so I didn't bother doing that here.