### PR TITLE
Enforce an interval at which BitrateController#update runs

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -220,7 +220,7 @@ public class BitrateController
     /**
      * The last time {@link BitrateController#update()} was called
      */
-    private Instant lastUpdateTime = Instant.MAX;
+    private Instant lastUpdateTime = Instant.MIN;
 
     /**
      * Initializes a new {@link BitrateController} instance which is to

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/config/BitrateControllerConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/config/BitrateControllerConfig.kt
@@ -19,6 +19,7 @@ package org.jitsi.videobridge.cc.config
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
+import java.time.Duration
 
 class BitrateControllerConfig {
     companion object {
@@ -108,5 +109,15 @@ class BitrateControllerConfig {
 
         @JvmStatic
         fun onstageIdealHeightPx() = onstageIdealHeightPx
+
+        /**
+         * The maximum amount of time we'll run before recalculating which streams we'll
+         * forward.
+         */
+        private val maxTimeBetweenCalculations: Duration by
+            config("videobridge.cc.max-time-between-calculations".from(JitsiConfig.newConfig))
+
+        @JvmStatic
+        fun maxTimeBetweenCalculations() = maxTimeBetweenCalculations
     }
 }

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -44,6 +44,10 @@ videobridge {
 
     # How often we check to send probing data
     padding-period=15ms
+
+    # How often we'll force recalculations of forwarded
+    # streams
+    max-time-between-calculations = 15 seconds
   }
   # The APIs by which the JVB can be controlled
   apis {


### PR DESCRIPTION
This PR adds a configurable interval at which we'll force a call to `BitrateController#update` if it has not run.  

I'll note that the scheduling of `update` tasks is not foolproof with regards to potential duplicates: to address this I think we'd probably implement a _minimum_ time between updates as well.  I can add that if we think it would be worthwhile, but we don't currently gate calls to `update` and this didn't seem like it would add a significant increase.