### PR TITLE
JVB-wide last-n value

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -119,12 +119,6 @@ public class BitrateController
         = TimeSeriesLogger.getTimeSeriesLogger(BitrateController.class);
 
     /**
-     * An empty set of {@link String}s instance.
-     */
-    private static final Set<String> INITIAL_EMPTY_SET
-        = Collections.unmodifiableSet(new HashSet<>(0));
-
-    /**
      * The {@link AdaptiveSourceProjection}s that this instance is managing, keyed
      * by the SSRCs of the associated {@link MediaSourceDesc}.
      */
@@ -136,7 +130,7 @@ public class BitrateController
      * represented by their IDs. Required for backwards compatibility with
      * existing LastN code.
      */
-    private Set<String> forwardedEndpointIds = INITIAL_EMPTY_SET;
+    private Set<String> forwardedEndpointIds = Collections.emptySet();
 
     /**
      * A boolean that indicates whether to enable or disable the video quality

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -1017,7 +1017,7 @@ public class BitrateController
         List<SourceBitrateAllocation> sourceBitrateAllocations
             = new ArrayList<>();
 
-        int adjustedLastN = this.lastN;
+        int adjustedLastN = JvbLastNKt.calculateLastN(this.lastN, JvbLastNKt.jvbLastNSingleton.getJvbLastN());
         if (adjustedLastN < 0)
         {
             // If lastN is disabled, pretend lastN == szConference.

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/JvbLastN.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/JvbLastN.kt
@@ -40,8 +40,6 @@ val jvbLastNSingleton: JvbLastN = JvbLastN()
 fun calculateLastN(lastN1: Int, lastN2: Int): Int {
     return if (lastN1 != -1 && lastN2 != -1) {
         minOf(lastN1, lastN2)
-    } else if (lastN1 == -1 && lastN2 == -1) {
-        -1
     } else {
         if (lastN1 == -1) lastN2 else lastN1
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/JvbLastN.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/JvbLastN.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge
+
+import org.jitsi.config.JitsiConfig
+import org.jitsi.metaconfig.config
+import org.jitsi.metaconfig.from
+import java.util.function.Supplier
+
+/**
+ * A JVB-wide last-n value which will be observed by all endpoints
+ * on this bridge.
+ *
+ * A value of -1 means no limit is enforced.
+ */
+class JvbLastN : Supplier<Int> {
+    private val defaultJvbLastN: Int by config("videobridge.cc.jvb-last-n".from(JitsiConfig.newConfig))
+    var jvbLastN: Int = defaultJvbLastN
+
+    override fun get(): Int = jvbLastN
+}
+
+@JvmField
+val jvbLastNSingleton: JvbLastN = JvbLastN()
+
+fun calculateLastN(lastN1: Int, lastN2: Int): Int {
+    return if (lastN1 != -1 && lastN2 != -1) {
+        minOf(lastN1, lastN2)
+    } else if (lastN1 == -1 && lastN2 == -1) {
+        -1
+    } else {
+        if (lastN1 == -1) lastN2 else lastN1
+    }
+}

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -48,6 +48,11 @@ videobridge {
     # How often we'll force recalculations of forwarded
     # streams
     max-time-between-calculations = 15 seconds
+
+    # A JVB-wide last-n value, observed by all endpoints.  Endpoints
+    # will take the minimum of their setting and this one (-1 implies
+    # no last-n limit)
+    jvb-last-n = -1
   }
   # The APIs by which the JVB can be controlled
   apis {

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/JvbLastNKtTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/JvbLastNKtTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+
+class JvbLastNKtTest : ShouldSpec({
+    context("calculateLastN") {
+        should("return the correct result") {
+            calculateLastN(-1, -1) shouldBe -1
+            calculateLastN(-1, 10) shouldBe 10
+            calculateLastN(10, -1) shouldBe 10
+            calculateLastN(2, 3) shouldBe 2
+        }
+    }
+})


### PR DESCRIPTION
This is another step in survival-last-n: it implements a last-n setting on the JVB level which will be applied to all endpoints.  Endpoints do not just take this JVB value, but instead the minimum of any last-n setting they have at the endpoint level and this JVB setting.  Soon, the load manager will leverage this field to reduce load on the bridge when needed.