### PR TITLE
Attempt to fix MediaSourceFactoryTest flakiness

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/xmpp/MediaSourceFactory.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/xmpp/MediaSourceFactory.java
@@ -93,13 +93,6 @@ public class MediaSourceFactory
     private static final boolean ENABLE_VP9_SVC = false;
 
     /**
-     * A boolean that's controlling whether or not to enable SVC filtering for
-     * scalable video codecs.
-     * TODO: make configurable if needed.
-     */
-    private static final Boolean ENABLE_SVC = true;
-
-    /**
      * libjitsi isn't aware of the group semantics names defined in
      * {@link SourceGroupPacketExtension}, which is how we distinguish secondary
      * ssrcs, so we'll translate them into constants defined in libjitsi
@@ -553,7 +546,7 @@ public class MediaSourceFactory
             // As of now, we only ever have 1 spatial layer per stream
             int numSpatialLayersPerStream = 1;
             int numTemporalLayersPerStream = 1;
-            if (sourceSsrcs.size() > 1 && ENABLE_SVC)
+            if (sourceSsrcs.size() > 1)
             {
                 numTemporalLayersPerStream = VP8_SIMULCAST_TEMPORAL_LAYERS;
             }

--- a/jvb/src/main/java/org/jitsi/videobridge/xmpp/MediaSourceFactory.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/xmpp/MediaSourceFactory.java
@@ -40,20 +40,6 @@ public class MediaSourceFactory
         = new LoggerImpl(MediaSourceFactory.class.getName());
 
     /**
-     * The system property name that for a boolean that's controlling whether or
-     * not to enable temporal scalability filtering for VP8.
-     */
-    public static final String ENABLE_SVC_PNAME = "org.jitsi" +
-        ".videobridge.ENABLE_SVC";
-
-    /**
-     * The system property name that for a boolean that's controlling whether or
-     * not to enable temporal scalability filtering for VP8.
-     */
-    public static final String ENABLE_VP9_SVC_PNAME = "org.jitsi" +
-        ".videobridge.ENABLE_VP9_SVC";
-
-    /**
      * The default number of temporal layers to use for VP8 simulcast.
      *
      * FIXME: hardcoded ugh.. this should be either signaled or somehow included
@@ -68,29 +54,6 @@ public class MediaSourceFactory
      * in the RTP stream.
      */
     private static final int VP8_SIMULCAST_BASE_LAYER_HEIGHT = 180;
-
-    /**
-     * The default number of spatial layers to use for VP9 SVC.
-     *
-     * FIXME: hardcoded ugh.. this should be either signaled or somehow included
-     * in the RTP stream.
-     */
-    private static final int VP9_SVC_SPATIAL_LAYERS = 3;
-
-    /**
-     * The default number of spatial layers to use for VP9 SVC.
-     *
-     * FIXME: hardcoded ugh.. this should be either signaled or somehow included
-     * in the RTP stream.
-     */
-    private static final int VP9_SVC_TEMPORAL_LAYERS = 3;
-
-    /**
-     * A boolean that determines whether to enable support for VP9 SVC. This is
-     * experimental and is left disabled by default.
-     * TODO: make configurable if needed.
-     */
-    private static final boolean ENABLE_VP9_SVC = false;
 
     /**
      * libjitsi isn't aware of the group semantics names defined in

--- a/jvb/src/test/java/org/jitsi/videobridge/xmpp/MediaSourceFactoryTest.java
+++ b/jvb/src/test/java/org/jitsi/videobridge/xmpp/MediaSourceFactoryTest.java
@@ -61,7 +61,7 @@ public class MediaSourceFactoryTest
         verifyAll();
     }
 
-    // 1 video stream -> 1 source, 1 encoding
+    // 1 video stream -> 1 source, 1 layer
     @Test
     public void createMediaSource()
     {
@@ -81,7 +81,7 @@ public class MediaSourceFactoryTest
         assertEquals(1, source.numRtpLayers());
     }
 
-    // 1 video stream, 1 rtx -> 1 source, 1 encoding
+    // 1 video stream, 1 rtx -> 1 source, 1 layer
     @Test
     public void createMediaSources1()
     {
@@ -107,7 +107,7 @@ public class MediaSourceFactoryTest
         assertEquals(1, source.numRtpLayers());
     }
 
-    // 3 sim streams, 3 rtx -> 1 source, 9 encodings
+    // 3 sim streams, 3 rtx -> 1 source, 9 layers
     @Test
     public void createMediaSources2()
     {
@@ -155,7 +155,7 @@ public class MediaSourceFactoryTest
         assertEquals(9, source.numRtpLayers());
     }
 
-    // 3 sim streams, svc enabled, 3 rtx -> 1 source, 3 encodings
+    // 3 sim streams, svc enabled, 3 rtx -> 1 source, 3 layers
     @Test
     public void createMediaSources3()
     {

--- a/jvb/src/test/java/org/jitsi/videobridge/xmpp/MediaSourceFactoryTest.java
+++ b/jvb/src/test/java/org/jitsi/videobridge/xmpp/MediaSourceFactoryTest.java
@@ -22,7 +22,6 @@ import org.jitsi.xmpp.extensions.jingle.*;
 import org.junit.*;
 import org.junit.runner.*;
 import org.powermock.modules.junit4.*;
-import org.powermock.reflect.*;
 
 import java.util.*;
 
@@ -65,12 +64,8 @@ public class MediaSourceFactoryTest
     // 1 video stream -> 1 source, 1 encoding
     @Test
     public void createMediaSource()
-        throws Exception
     {
         replayAll();
-
-        Whitebox.setInternalState(
-                MediaSourceFactory.class, "ENABLE_SVC", false);
 
         long videoSsrc = 12345;
 
@@ -89,13 +84,8 @@ public class MediaSourceFactoryTest
     // 1 video stream, 1 rtx -> 1 source, 1 encoding
     @Test
     public void createMediaSources1()
-        throws
-        Exception
     {
         replayAll();
-
-        Whitebox.setInternalState(
-                MediaSourceFactory.class, "ENABLE_SVC", false);
 
         long videoSsrc = 12345;
         long rtxSsrc = 54321;
@@ -109,7 +99,7 @@ public class MediaSourceFactoryTest
 
         MediaSourceDesc[] sources =
             MediaSourceFactory.createMediaSources(
-                Arrays.asList(videoSource, rtx), Arrays.asList(rtxGroup));
+                Arrays.asList(videoSource, rtx), Collections.singletonList(rtxGroup));
 
         assertNotNull(sources);
         assertEquals(1, sources.length);
@@ -117,16 +107,11 @@ public class MediaSourceFactoryTest
         assertEquals(1, source.numRtpLayers());
     }
 
-    // 3 sim streams, 3 rtx -> 1 source, 3 encodings
+    // 3 sim streams, 3 rtx -> 1 source, 9 encodings
     @Test
     public void createMediaSources2()
-        throws
-        Exception
     {
         replayAll();
-
-        Whitebox.setInternalState(
-                MediaSourceFactory.class, "ENABLE_SVC", false);
 
         long videoSsrc1 = 12345;
         long videoSsrc2 = 23456;
@@ -167,23 +152,14 @@ public class MediaSourceFactoryTest
         assertNotNull(sources);
         assertEquals(1, sources.length);
         MediaSourceDesc source = sources[0];
-        assertEquals(3, source.numRtpLayers());
+        assertEquals(9, source.numRtpLayers());
     }
 
     // 3 sim streams, svc enabled, 3 rtx -> 1 source, 3 encodings
     @Test
     public void createMediaSources3()
-        throws
-        Exception
     {
         replayAll();
-
-        // Here we add an override for the config service for a specific setting
-        // NOTE: we can't do this via the mock return values, because the mock
-        // values are only read once for the entire test class (because the
-        // fields are static)
-        Whitebox.setInternalState(
-            MediaSourceFactory.class, "ENABLE_SVC", true);
 
         long videoSsrc1 = 12345;
         long videoSsrc2 = 23456;
@@ -228,12 +204,8 @@ public class MediaSourceFactoryTest
     // 3 sim streams with rtx, 1 stream with rtx, 1 stream without rtx
     @Test
     public void createMediaSources4()
-        throws Exception
     {
         replayAll();
-
-        Whitebox.setInternalState(
-            MediaSourceFactory.class, "ENABLE_SVC", true);
 
         long videoSsrc1 = 12345;
         long videoSsrc2 = 23456;
@@ -304,9 +276,9 @@ public class MediaSourceFactoryTest
 
         MediaSourceDesc[] sources =
             MediaSourceFactory.createMediaSources(
-                Arrays.asList(
-                    videoSource1),
-                Arrays.asList(simGroup));
+                Collections.singletonList(videoSource1),
+                Collections.singletonList(simGroup)
+            );
 
         assertNotNull(sources);
         assertEquals(1, sources.length);
@@ -323,7 +295,7 @@ public class MediaSourceFactoryTest
 
         MediaSourceDesc[] sources =
             MediaSourceFactory.createMediaSources(
-                Arrays.asList(videoSource1),
+                Collections.singletonList(videoSource1),
                 Collections.emptyList()
             );
 


### PR DESCRIPTION
`MediaSourceFactoryTest` has been flaky.  I suspect this may stem from our use of the `Whitebox` lib to modify a static member.  It turns out we don't need this static member, so this PR removes it and adapts the tests (as well as some other cleanup).