### PR TITLE
Ep connection monitor fixes

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -174,7 +174,7 @@ public class Conference
      */
     private ScheduledFuture<?> updateLastNEndpointsFuture;
 
-    private EndpointConnectionStatusMonitor epConnectionStatusMonitor;
+    private final EndpointConnectionStatusMonitor epConnectionStatusMonitor;
 
     /**
      * Initializes a new <tt>Conference</tt> instance which is to represent a
@@ -242,6 +242,10 @@ public class Conference
             epConnectionStatusMonitor =
                 new EndpointConnectionStatusMonitor(this, TaskPools.SCHEDULED_POOL, logger);
             epConnectionStatusMonitor.start();
+        }
+        else
+        {
+            epConnectionStatusMonitor = null;
         }
 
     }

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -531,6 +531,11 @@ public class Conference
 
         logger.info("Expiring.");
 
+        if (epConnectionStatusMonitor != null)
+        {
+            epConnectionStatusMonitor.stop();
+        }
+
         if (updateLastNEndpointsFuture != null)
         {
             updateLastNEndpointsFuture.cancel(true);

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -179,7 +179,7 @@ public class Conference
      */
     private ScheduledFuture<?> updateLastNEndpointsFuture;
 
-    private final EndpointConnectionStatusMonitor epConnectionStatusMonitor;
+    private EndpointConnectionStatusMonitor epConnectionStatusMonitor;
 
     /**
      * Initializes a new <tt>Conference</tt> instance which is to represent a
@@ -244,11 +244,11 @@ public class Conference
             eventAdmin.sendEvent(EventFactory.conferenceCreated(this));
             Videobridge.Statistics videobridgeStatistics = videobridge.getStatistics();
             videobridgeStatistics.totalConferencesCreated.incrementAndGet();
+            epConnectionStatusMonitor =
+                new EndpointConnectionStatusMonitor(this, TaskPools.SCHEDULED_POOL, logger);
+            epConnectionStatusMonitor.start();
         }
 
-        epConnectionStatusMonitor =
-            new EndpointConnectionStatusMonitor(this, TaskPools.SCHEDULED_POOL, logger);
-        epConnectionStatusMonitor.start();
     }
 
     /**

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -15,19 +15,17 @@
  */
 package org.jitsi.videobridge;
 
-import edu.umd.cs.findbugs.annotations.*;
 import org.jetbrains.annotations.*;
-import org.jetbrains.annotations.Nullable;
 import org.jitsi.eventadmin.*;
 import org.jitsi.nlj.*;
 import org.jitsi.rtp.*;
 import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.*;
 import org.jitsi.rtp.rtp.*;
 import org.jitsi.utils.collections.*;
-import org.jitsi.utils.logging.DiagnosticContext;
-import org.jitsi.utils.logging2.*;
+import org.jitsi.utils.logging.*;
 import org.jitsi.utils.logging2.Logger;
 import org.jitsi.utils.logging2.LoggerImpl;
+import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.message.*;
 import org.jitsi.videobridge.octo.*;
 import org.jitsi.videobridge.shim.*;
@@ -36,18 +34,15 @@ import org.jitsi.xmpp.extensions.colibri.*;
 import org.json.simple.*;
 import org.jxmpp.jid.parts.*;
 import org.jxmpp.stringprep.*;
-import org.osgi.framework.*;
 
 import java.io.*;
-import java.lang.*;
-import java.lang.SuppressWarnings;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
 import java.util.stream.*;
 
-import static org.jitsi.utils.collections.JMap.entry;
+import static org.jitsi.utils.collections.JMap.*;
 
 /**
  * Represents a conference in the terms of Jitsi Videobridge.
@@ -95,7 +90,7 @@ public class Conference
      * The indicator which determines whether {@link #expire()} has been called
      * on this <tt>Conference</tt>.
      */
-    private AtomicBoolean expired = new AtomicBoolean(false);
+    private final AtomicBoolean expired = new AtomicBoolean(false);
 
     /**
      * The locally unique identifier of this conference (i.e. unique across the


### PR DESCRIPTION
This PR fixes a couple things from the ep connection status monitor refactoring done in https://github.com/jitsi/jitsi-videobridge/pull/1384:

1. Correctly stop the monitor when a conference expires.  This was not an issue before as we had a single, global ep connection status monitor
1. Don't perform ep connection status monitoring for health check conferences.  The old code didn't ignore health check conferences, but it's a waste to monitor endpoint connection status for them.

I also cleaned up a couple low-hanging-fruit IDE warnings.