### PR TITLE
fix: Fixes #1412 NoClassDefFoundError JdkDeserializers

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,6 +1,4 @@
 jvb/target/dependency/*		usr/share/jitsi-videobridge/lib
-jvb-api/jvb-api-client/target/dependency/*		usr/share/jitsi-videobridge/lib
-jvb-api/jvb-api-common/target/dependency/*		usr/share/jitsi-videobridge/lib
 jvb/lib/videobridge.rc		usr/share/jitsi-videobridge/lib
 jvb/lib/logging.properties		etc/jitsi/videobridge
 jitsi-videobridge.jar		usr/share/jitsi-videobridge


### PR DESCRIPTION
Fixes error `Exception in thread "Global IO pool-3" java.lang.NoClassDefFoundError: Could not initialize class com.fasterxml.jackson.databind.deser.std.JdkDeserializers` that is due to dependencies of different versions.