### PR TITLE
handle octo relay service failing to start in getStats

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayService.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayService.kt
@@ -85,21 +85,21 @@ class OctoRelayService {
     }
 
     fun getStats(): Stats {
-        val octoUdpTransportStats = udpTransport!!.getStats()
-        val octoTransportStats = bridgeOctoTransport!!.getStats()
+        val octoUdpTransportStats = udpTransport?.getStats()
+        val octoTransportStats = bridgeOctoTransport?.getStats()
         return Stats(
-            bytesReceived = octoUdpTransportStats.bytesReceived,
-            bytesSent = octoUdpTransportStats.bytesSent,
-            packetsReceived = octoUdpTransportStats.packetsReceived,
-            packetsSent = octoUdpTransportStats.packetsSent,
-            receiveBitrate = octoUdpTransportStats.receiveBitRate,
-            receivePacketRate = octoUdpTransportStats.receivePacketRate,
-            packetsDropped = octoUdpTransportStats.incomingPacketsDropped +
-                    octoTransportStats.numInvalidPackets +
-                    octoTransportStats.numIncomingDroppedNoHandler,
-            sendBitrate = octoUdpTransportStats.sendBitRate,
-            sendPacketRate = octoUdpTransportStats.sendPacketRate,
-            relayId = bridgeOctoTransport!!.relayId
+            bytesReceived = octoUdpTransportStats?.bytesReceived ?: 0,
+            bytesSent = octoUdpTransportStats?.bytesSent ?: 0,
+            packetsReceived = octoUdpTransportStats?.packetsReceived ?: 0,
+            packetsSent = octoUdpTransportStats?.packetsSent ?: 0,
+            receiveBitrate = octoUdpTransportStats?.receiveBitRate ?: 0,
+            receivePacketRate = octoUdpTransportStats?.receivePacketRate ?: 0,
+            packetsDropped = (octoUdpTransportStats?.incomingPacketsDropped ?: 0) +
+                    (octoTransportStats?.numInvalidPackets ?: 0) +
+                    (octoTransportStats?.numIncomingDroppedNoHandler ?: 0),
+            sendBitrate = octoUdpTransportStats?.sendBitRate ?: 0,
+            sendPacketRate = octoUdpTransportStats?.sendPacketRate ?: 0,
+            relayId = bridgeOctoTransport?.relayId ?: "no relay ID"
         )
     }
 


### PR DESCRIPTION
`OctoRelayService` currently has an awkward flow where `start` can swallow an exception and be in a state where it was enabled, and therefore exists, but hasn't set its `udpTransport` and `bridgeOctoTransport` members, which causes an issue when calling `OctoRelayService#getStats`.

This fix changes `getStats` to handle the cases where those members are null, but the plan in the future will be to avoid this awkward state of `OctoRelayService` altogether (likely by having it fail to be created at all).