### PR TITLE
set the port on the http connector

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/JettyHelpers.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/JettyHelpers.kt
@@ -101,6 +101,7 @@ fun createSecureJettyServer(
         HttpConnectionFactory(config)
     ).apply {
         this.host = host
+        this.port = port
     }
     server.addConnector(connector)
     return server


### PR DESCRIPTION
I was setting the port inside the `HttpConfiguration` but not on the `ServerConnector` for the secure Jetty setup, which was resulting in the secure Jetty server starting on a random port.

It turns out we don't seem to need the custom `HttpConfiguration` and it was confusing to set the port in a couple places, so I removed that and we now just use a default `HttpConnectionFactory` (which instantiates a default `HttpConfiguration`)