### PR TITLE
add support for new config file in debian installs

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -71,6 +71,8 @@ case "$1" in
 
         OLD_JITSI_CONFIG="/usr/share/jitsi-videobridge/.sip-communicator/sip-communicator.properties"
         NEW_JITSI_CONFIG="/etc/jitsi/videobridge/sip-communicator.properties"
+        HOCON_CONFIG="/etc/jitsi/videobridge/jvb.conf"
+
         if [ -f $OLD_JITSI_CONFIG ]; then
             mv $OLD_JITSI_CONFIG $NEW_JITSI_CONFIG
             echo "# Config has moved to /etc/jitsi/videobridge/
@@ -89,7 +91,8 @@ case "$1" in
             echo "JAVA_SYS_PROPS=\"-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/etc/jitsi\
  -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=videobridge\
  -Dnet.java.sip.communicator.SC_LOG_DIR_LOCATION=/var/log/jitsi\
- -Djava.util.logging.config.file=/etc/jitsi/videobridge/logging.properties\"" >> $CONFIG
+ -Djava.util.logging.config.file=/etc/jitsi/videobridge/logging.properties\
+ -Dconfig.file=$HOCON_CONFIG\"" >> $CONFIG
         fi
 
         # unused old parameter, systemd unit files does not resolve bash variables,
@@ -115,6 +118,12 @@ case "$1" in
             echo "org.jitsi.videobridge.xmpp.user.shard.PASSWORD=$JVB_SECRET" >> $NEW_JITSI_CONFIG
             echo "org.jitsi.videobridge.xmpp.user.shard.MUC_JIDS=JvbBrewery@internal.auth.$JVB_HOSTNAME" >> $NEW_JITSI_CONFIG
             echo "org.jitsi.videobridge.xmpp.user.shard.MUC_NICKNAME=$(uuidgen)" >> $NEW_JITSI_CONFIG
+        fi
+
+        if [ ! -f $HOCON_CONFIG ]; then
+            echo "Generating an empty hocon config"
+            echo "videobridge {
+            }" >> $HOCON_CONFIG
         fi
 
         APIS_VALUE=$(grep -v '^\s*#' $CONFIG | grep -oPe '--apis=\K(\w*,*\w*)' || true)

--- a/debian/postinst
+++ b/debian/postinst
@@ -91,8 +91,12 @@ case "$1" in
             echo "JAVA_SYS_PROPS=\"-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/etc/jitsi\
  -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=videobridge\
  -Dnet.java.sip.communicator.SC_LOG_DIR_LOCATION=/var/log/jitsi\
- -Djava.util.logging.config.file=/etc/jitsi/videobridge/logging.properties\
- -Dconfig.file=$HOCON_CONFIG\"" >> $CONFIG
+ -Djava.util.logging.config.file=/etc/jitsi/videobridge/logging.properties\"" >> $CONFIG
+        fi
+
+        # Updates config so new and old installs will start using the new config file
+        if ! grep -q "\-Dconfig.file" "$CONFIG"; then
+            sed -i 's|JAVA_SYS_PROPS="|JAVA_SYS_PROPS="-Dconfig.file='"$HOCON_CONFIG"' |g' $CONFIG
         fi
 
         # unused old parameter, systemd unit files does not resolve bash variables,


### PR DESCRIPTION
The intent here is to generate an empty `jvb.conf` if one doesn't exist, and pass this config file (via `-Dconfig.file`) to the bridge when starting up so that debian installs can support the new configuration.

I didn't go so far as to migrate any configurations put in `sip-communicator.properties` into the new config, as the logic in this script is already pretty complex (already supports migrating from an old, _old_ config file). Maybe there's some code that can be cleaned up/removed there for the older cases?