### PR TITLE
only disable complete suspension for highest priority endpoint when forwarding

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -960,6 +960,16 @@ public class BitrateController
 
                 maxBandwidth += sourceBitrateAllocation.getTargetBitrate();
                 sourceBitrateAllocation.improve(maxBandwidth);
+                // We will "force" forward the lowest layer of the highest priority (first in line)
+                // participant if we weren't able to allocate any bandwidth for it and
+                // enableOnstageVideoSuspend is false.
+                if (i == 0 &&
+                        sourceBitrateAllocation.ratedTargetIdx < 0 &&
+                        !BitrateControllerConfig.enableOnstageVideoSuspend())
+                {
+                    sourceBitrateAllocation.ratedTargetIdx = 0;
+                    sourceBitrateAllocation.oversending = true;
+                }
                 maxBandwidth -= sourceBitrateAllocation.getTargetBitrate();
 
                 newRatedTargetIndices[i]
@@ -1442,14 +1452,8 @@ public class BitrateController
 
             if (ratedTargetIdx == -1 && ratedPreferredIdx > -1)
             {
-                if (!BitrateControllerConfig.enableOnstageVideoSuspend())
-                {
-                    ratedTargetIdx = 0;
-                    oversending = ratedIndices[0].bps > maxBps;
-                }
-
-                // Boost on stage participant to 360p, if there's enough bw.
-                for (int i = ratedTargetIdx + 1; i < ratedIndices.length; i++)
+                // Boost on stage participant to preferred, if there's enough bw.
+                for (int i = 0; i < ratedIndices.length; i++)
                 {
                     if (i > ratedPreferredIdx || maxBps < ratedIndices[i].bps)
                     {


### PR DESCRIPTION
fix: This PR fixes an issue that was causing dramatic oversending for participants with low bandwidth in tile view.  Before this change, when the `enableOnstageVideoSuspend` config parameter was false (which is the default setting) we would end up forwarding the lowest quality layer for _all_ participants when a receiver was in tile view, even if their bandwidth couldn't handle it.  `enableOnstageVideoSuspend` was intended to prevent the suspension of a screenshare stream so that receivers would always receiver screenshare, but the way it was implemented ended up resulting in this issue due to changes in https://github.com/jitsi/jitsi-videobridge/pull/1250 which altered the definition of what ended up being considered as an 'on stage' participant.  The fix allows only forcing the forwarding of a stream for the highest priority endpoint.