### PR TITLE
OctoRelayService cleanup

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayServiceProvider.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayServiceProvider.kt
@@ -21,7 +21,11 @@ import org.jitsi.videobridge.octo.config.OctoConfig
 class OctoRelayServiceProvider {
     private val octoRelayService: OctoRelayService? by lazy {
         if (OctoConfig.config.enabled) {
-            OctoRelayService()
+            try {
+                OctoRelayService()
+            } catch (t: Throwable) {
+                null
+            }
         } else {
             null
         }


### PR DESCRIPTION
There were some awkward flows in `OctoRelayService` where we didn't initialize members until `start`, so they had to be nullable.  This moves the initialization to the constructor so we can avoid that.