### PR TITLE
Fix: don't over-send bandwidth probing, and send bandwidth probing even when no sources can be sent.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/cc/BandwidthProbing.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/BandwidthProbing.java
@@ -54,13 +54,6 @@ import java.util.*;
       */
      public boolean enabled = false;
 
-     /**
-      * The number of bytes left over from one run of probing to the next.  The
-      * primary use case for this is when the number of bytes we want to send is
-      * less than the size of an RTP header extension.
-      */
-     long bytesLeftOver = 0;
-
      private Long latestBwe = -1L;
 
      private DiagnosticContext diagnosticContext;
@@ -123,8 +116,7 @@ import java.util.*;
          long totalNeededBps = bitrateControllerStatus.currentIdealBps - bitrateControllerStatus.currentTargetBps;
          if (totalNeededBps < 1)
          {
-             // Don't need to send any probing.
-             bytesLeftOver = 0;
+             // Not much.
              return;
          }
 
@@ -159,15 +151,12 @@ import java.util.*;
          if (paddingBps < 1)
          {
              // Not much.
-             bytesLeftOver = 0;
              return;
          }
 
-         long bytes = (config.getPaddingPeriodMs() * paddingBps / 1000 / 8) + bytesLeftOver;
+         int bytes = (int) (config.getPaddingPeriodMs() * paddingBps / 1000 / 8);
 
-         long bytesSent = probingDataSender.sendProbing(bitrateControllerStatus.activeSsrcs, bytes);
-
-         bytesLeftOver = Math.min(bytes - bytesSent, 0);
+         int bytesSent = probingDataSender.sendProbing(bitrateControllerStatus.activeSsrcs, bytes);
      }
 
      @Override
@@ -200,6 +189,6 @@ import java.util.*;
           * @param numBytes the number of probing bytes we want to send
           * @return the number of bytes of probing data actually sent
           */
-         int sendProbing(Collection<Long> mediaSsrcs, long numBytes);
+         int sendProbing(Collection<Long> mediaSsrcs, int numBytes);
      }
  }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/octo/config/OctoRtpSender.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/octo/config/OctoRtpSender.kt
@@ -89,7 +89,7 @@ class OctoRtpSender(
         keyframeRequester.requestKeyframe(mediaSsrc)
     }
 
-    override fun sendProbing(mediaSsrc: Long, numBytes: Int): Int = 0
+    override fun sendProbing(mediaSsrcs: Collection<Long>, numBytes: Int): Int = 0
 
     override fun setSrtpTransformers(srtpTransformers: SrtpTransformers) {}
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-media-transform</artifactId>
-                <version>1.0-183-gf4ee7e7</version>
+                <version>1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>rtp</artifactId>
-                <version>1.0-53-g6a4fa99</version>
+                <version>1.0-54-ge0d663c</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-media-transform</artifactId>
-                <version>1.0-SNAPSHOT</version>
+                <version>1.0-184-g50d6747</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Should fix observed packet losses.