### PR TITLE
Refactor uses of System.currentTimeMillis to use Clock, plumb clock where needed

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -592,30 +592,7 @@ public abstract class Conference
      * @return an <tt>Endpoint</tt> participating in this <tt>Conference</tt>
      */
     @NotNull
-    public Endpoint createLocalEndpoint(String id, boolean iceControlling)
-    {
-        final AbstractEndpoint existingEndpoint = getEndpoint(id);
-        if (existingEndpoint instanceof OctoEndpoint)
-        {
-            // It is possible that an Endpoint was migrated from another bridge
-            // in the conference to this one, and the sources lists (which
-            // implicitly signal the Octo endpoints in the conference) haven't
-            // been updated yet. We'll force the Octo endpoint to expire and
-            // we'll continue with the creation of a new local Endpoint for the
-            // participant.
-            existingEndpoint.expire();
-        }
-        else if (existingEndpoint != null)
-        {
-            throw new IllegalArgumentException("Local endpoint with ID = " + id + "already created");
-        }
-
-        final Endpoint endpoint = new Endpoint(id, this, logger, iceControlling);
-
-        addEndpoint(endpoint);
-
-        return endpoint;
-    }
+    public abstract Endpoint createLocalEndpoint(String id, boolean iceControlling);
 
     /**
      * An endpoint was added or removed.

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -859,18 +859,7 @@ public abstract class Conference
     /**
      * @return The {@link ConfOctoTransport} for this conference.
      */
-    public ConfOctoTransport getTentacle()
-    {
-        if (gid == GID_NOT_SET)
-        {
-            throw new IllegalStateException("Can not enable Octo without the GID being set.");
-        }
-        if (tentacle == null)
-        {
-            tentacle = new ConfOctoTransport(this);
-        }
-        return tentacle;
-    }
+    public abstract ConfOctoTransport getTentacle();
 
     public boolean isOctoEnabled()
     {

--- a/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -314,7 +314,7 @@ public class Endpoint
         bandwidthProbing.enabled = true;
         recurringRunnableExecutor.registerRecurringRunnable(bandwidthProbing);
 
-        iceTransport = new IceTransport(getID(), iceControlling, logger);
+        iceTransport = new IceTransport(getID(), iceControlling, logger, clock);
         setupIceTransport();
         dtlsTransport = new DtlsTransport(logger);
         setupDtlsTransport();

--- a/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -288,7 +288,7 @@ public class Endpoint
                     f.invoke();
                 }
             });
-        bitrateController = new BitrateController(this, diagnosticContext, logger);
+        bitrateController = new BitrateController(this, diagnosticContext, logger, clock);
 
         outgoingSrtpPacketQueue = new PacketInfoQueue(
             getClass().getSimpleName() + "-outgoing-packet-queue",

--- a/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -325,15 +325,6 @@ public class Endpoint
         }
     }
 
-    public Endpoint(
-        String id,
-        Conference conference,
-        Logger parentLogger,
-        boolean iceControlling)
-    {
-        this(id, conference, parentLogger, iceControlling, Clock.systemUTC());
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -165,7 +165,8 @@ public class Videobridge
             new LastNReducer(
                 this::getConferences,
                 JvbLastNKt.jvbLastNSingleton
-            )
+            ),
+            clock
         );
         loadSamplerTask = TaskPools.SCHEDULED_POOL.scheduleAtFixedRate(
             new PacketRateLoadSampler(

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -24,6 +24,7 @@ import org.jitsi.nlj.util.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.utils.queue.*;
 import org.jitsi.utils.version.*;
+import org.jitsi.videobridge.conference.*;
 import org.jitsi.videobridge.health.*;
 import org.jitsi.videobridge.load_management.*;
 import org.jitsi.videobridge.octo.*;
@@ -211,7 +212,7 @@ public class Videobridge
                 if (!conferencesById.containsKey(id))
                 {
                     conference
-                        = new Conference(
+                        = new ConferenceK(
                                 this,
                                 id,
                                 name,

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/AdaptiveSourceProjection.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/AdaptiveSourceProjection.java
@@ -28,6 +28,7 @@ import org.jitsi.videobridge.cc.vp8.*;
 import org.json.simple.*;
 
 import java.lang.*;
+import java.time.*;
 import java.util.*;
 
 /**
@@ -60,6 +61,8 @@ public class AdaptiveSourceProjection
      * parent?
      */
     private final Logger parentLogger;
+
+    @NotNull private final Clock clock;
 
     /**
      * The main SSRC of the source (if simulcast is used, this is the SSRC
@@ -118,13 +121,15 @@ public class AdaptiveSourceProjection
         @NotNull MediaSourceDesc source,
         Runnable keyframeRequester,
         Map<Byte, PayloadType> payloadTypes,
-        Logger parentLogger
+        Logger parentLogger,
+        @NotNull Clock clock
     )
     {
         targetSsrc = source.getPrimarySSRC();
         this.diagnosticContext = diagnosticContext;
         this.payloadTypes = payloadTypes;
         this.parentLogger = parentLogger;
+        this.clock = clock;
         this.logger = parentLogger.createChildLogger(AdaptiveSourceProjection.class.getName(),
             JMap.of("targetSsrc", Long.toString(targetSsrc),
                 "srcEpId", Objects.toString(source.getOwner(), "")));
@@ -286,7 +291,7 @@ public class AdaptiveSourceProjection
                     + payloadType +
                     ", source packet ssrc " + rtpPacket.getSsrc());
                 context = new VP8AdaptiveSourceProjectionContext(
-                    diagnosticContext, payloadTypeObject, rtpState, parentLogger);
+                    diagnosticContext, payloadTypeObject, rtpState, parentLogger, clock);
                 contextPayloadType = payloadType;
             }
             else if (!projectable

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -231,14 +231,6 @@ public class BitrateController
         enableVideoQualityTracing = timeSeriesLogger.isTraceEnabled();
     }
 
-    public BitrateController(
-        Endpoint destinationEndpoint,
-        @NotNull DiagnosticContext diagnosticContext,
-        Logger parentLogger
-    ) {
-        this(destinationEndpoint, diagnosticContext, parentLogger, Clock.systemUTC());
-    }
-
     /**
      * Returns a boolean that indicates whether or not the current bandwidth
      * estimation (in bps) has changed above the configured threshold (in

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -883,7 +883,8 @@ public class BitrateController
                         destinationEndpoint.getConference().requestKeyframe(
                             endpointID, targetSSRC),
                     payloadTypes,
-                    logger);
+                    logger,
+                    clock);
 
             logger.debug(() -> "new source projection for " + sourceBitrateAllocation.source);
 

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveSourceProjectionContext.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveSourceProjectionContext.java
@@ -27,6 +27,7 @@ import org.jitsi.utils.logging2.Logger;
 import org.jitsi.videobridge.cc.*;
 import org.json.simple.*;
 
+import java.time.*;
 import java.util.*;
 
 /**
@@ -73,6 +74,8 @@ public class VP8AdaptiveSourceProjectionContext
      */
     private final PayloadType payloadType;
 
+    private final Clock clock;
+
     /**
      * Ctor.
      *
@@ -83,11 +86,13 @@ public class VP8AdaptiveSourceProjectionContext
             @NotNull DiagnosticContext diagnosticContext,
             @NotNull PayloadType payloadType,
             @NotNull RtpState rtpState,
-            @NotNull Logger parentLogger)
+            @NotNull Logger parentLogger,
+            @NotNull Clock clock)
     {
         this.diagnosticContext = diagnosticContext;
         this.logger = parentLogger.createChildLogger(
             VP8AdaptiveSourceProjectionContext.class.getName());
+        this.clock = clock;
         this.payloadType = payloadType;
         this.vp8QualityFilter = new VP8QualityFilter(parentLogger);
 
@@ -112,7 +117,7 @@ public class VP8AdaptiveSourceProjectionContext
         @NotNull Vp8Packet vp8Packet)
     {
         VP8FrameMap frameMap = vp8FrameMaps.computeIfAbsent(vp8Packet.getSsrc(),
-            ssrc -> new VP8FrameMap(logger));
+            ssrc -> new VP8FrameMap(logger, clock));
         /* TODO: add more context (ssrc?) to frame map's logger? */
 
         return frameMap.insertPacket(vp8Packet);

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
@@ -36,7 +36,7 @@ public class VP8FrameMap
     static final int FRAME_MAP_SIZE = 500; /* Matches PacketCache default size. */
 
     /** Cache mapping picture IDs to frames. */
-    private final FrameHistory frameHistory = new FrameHistory(FRAME_MAP_SIZE);
+    private final FrameHistory frameHistory;
 
     private final Logger logger;
 
@@ -45,9 +45,11 @@ public class VP8FrameMap
      *
      */
     public VP8FrameMap(
-        @NotNull Logger parentLogger)
+        @NotNull Logger parentLogger,
+        @NotNull Clock clock)
     {
         this.logger = parentLogger.createChildLogger(VP8FrameMap.class.getName());
+        this.frameHistory = new FrameHistory(FRAME_MAP_SIZE, clock);
     }
 
     /** Find a frame in the frame map, based on a packet. */
@@ -270,9 +272,9 @@ public class VP8FrameMap
 
     private static class FrameHistory extends ArrayCache<VP8Frame>
     {
-        FrameHistory(int size)
+        FrameHistory(int size, Clock clock)
         {
-            super(size, (k) -> k, false, Clock.systemUTC());
+            super(size, (k) -> k, false, clock);
         }
 
         int numCached = 0;

--- a/jvb/src/main/java/org/jitsi/videobridge/octo/ConfOctoTransport.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/octo/ConfOctoTransport.java
@@ -132,11 +132,6 @@ public class ConfOctoTransport
      * Initializes a new {@link ConfOctoTransport} instance.
      * @param conference the conference.
      */
-    public ConfOctoTransport(Conference conference)
-    {
-        this(conference, Clock.systemUTC());
-    }
-
     public ConfOctoTransport(Conference conference, Clock clock)
     {
         this.conference = conference;

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/EndpointConnectionStatusMonitor.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/EndpointConnectionStatusMonitor.kt
@@ -28,11 +28,11 @@ import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
-class EndpointConnectionStatusMonitor @JvmOverloads constructor(
+class EndpointConnectionStatusMonitor(
     private val conference: Conference,
     private val executor: ScheduledExecutorService,
     parentLogger: Logger,
-    private val clock: Clock = Clock.systemUTC()
+    private val clock: Clock
 ) {
     private val logger = createChildLogger(parentLogger)
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/conference/ConferenceK.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/conference/ConferenceK.kt
@@ -24,6 +24,7 @@ import org.jitsi.videobridge.Endpoint
 import org.jitsi.videobridge.EndpointConnectionStatusMonitor
 import org.jitsi.videobridge.Videobridge
 import org.jitsi.videobridge.message.DominantSpeakerMessage
+import org.jitsi.videobridge.octo.ConfOctoTransport
 import org.jitsi.videobridge.octo.OctoEndpoint
 import org.jitsi.videobridge.util.TaskPools
 import org.json.simple.JSONObject
@@ -67,6 +68,16 @@ class ConferenceK @JvmOverloads constructor(
             tentacle?.endpointExpired(it.id)
             endpointsChanged()
         }
+    }
+
+    override fun getTentacle(): ConfOctoTransport {
+        if (gid == GID_NOT_SET) {
+            throw IllegalStateException("Can not enable Octo without the GID being set.")
+        }
+        if (tentacle == null) {
+            tentacle = ConfOctoTransport(this, clock)
+        }
+        return tentacle
     }
 
     /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/conference/ConferenceK.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/conference/ConferenceK.kt
@@ -16,14 +16,90 @@
 
 package org.jitsi.videobridge.conference
 
+import org.jitsi.utils.logging.DiagnosticContext
+import org.jitsi.utils.logging2.cinfo
 import org.jitsi.videobridge.Conference
 import org.jitsi.videobridge.Videobridge
+import org.json.simple.JSONObject
 import org.jxmpp.jid.EntityBareJid
+import java.time.Clock
+import java.time.Duration
 
-class ConferenceK(
+class ConferenceK @JvmOverloads constructor(
     videobridge: Videobridge,
     id: String,
     confName: EntityBareJid,
     enableLogging: Boolean,
-    gid: Long
-) : Conference(videobridge, id, confName, enableLogging, gid)
+    gid: Long,
+    private val clock: Clock = Clock.systemUTC()
+) : Conference(videobridge, id, confName, enableLogging, gid) {
+
+    private val creationTime = clock.instant()
+
+    override fun newDiagnosticContext(): DiagnosticContext {
+        return DiagnosticContext().apply {
+            put("conf_name", conferenceName)
+            put("conf_creation_time_ms", creationTime.toEpochMilli())
+        }
+    }
+
+    override fun shouldExpire(): Boolean =
+        endpointCount == 0 && Duration.between(creationTime, clock.instant()) > Duration.ofSeconds(20)
+
+    override fun getDebugState(full: Boolean, endpointId: String?): JSONObject {
+        return JSONObject().apply {
+            put("id", id)
+            put("name", conferenceName.toString())
+
+            if (full) {
+                put("gid", gid)
+                put("expired", expired.get())
+                put("creationTime", creationTime.toEpochMilli())
+                put("speechActivity", speechActivity.debugState)
+                put("includeInStatistics", includeInStatistics)
+                put("statistics", statistics.json)
+                tentacle?.let {
+                    put("tentacle", it.debugState)
+                }
+            }
+            val endpoints = JSONObject().apply {
+                endpointsCache.forEach { ep ->
+                    if (endpointId == null || endpointId == ep.id) {
+                        put(ep.id, if (full) ep.debugState else ep.statsId)
+                    }
+                }
+            }
+            put("endpoints", endpoints)
+        }
+    }
+
+    override fun updateStatisticsOnExpire() {
+        val jvbStats = getVideobridge().statistics
+
+        val durationSeconds = Duration.between(creationTime, clock.instant()).seconds
+        jvbStats.totalConferenceSeconds.addAndGet(durationSeconds)
+        jvbStats.totalConferencesCompleted.incrementAndGet()
+
+        jvbStats.totalBytesReceived.addAndGet(statistics.totalBytesReceived.get())
+        jvbStats.totalBytesSent.addAndGet(statistics.totalBytesSent.get())
+        jvbStats.totalPacketsReceived.addAndGet(statistics.totalPacketsReceived.get())
+        jvbStats.totalPacketsSent.addAndGet(statistics.totalPacketsSent.get())
+
+        val hasFailed = statistics.hasIceFailedEndpoint && !statistics.hasIceSucceededEndpoint
+        val hasPartiallyFailed = statistics.hasIceFailedEndpoint && statistics.hasIceSucceededEndpoint
+
+        jvbStats.dtlsFailedEndpoints.addAndGet(statistics.dtlsFailedEndpoints.get())
+
+        if (hasPartiallyFailed) {
+            jvbStats.totalPartiallyFailedConferences.incrementAndGet()
+        }
+
+        if (hasFailed) {
+            jvbStats.totalFailedConferences.incrementAndGet()
+        }
+
+        logger.cinfo {
+            "expire_conf,duration=$durationSeconds,has_failed=$hasFailed,has_partially_failed=$hasPartiallyFailed"
+        }
+    }
+}

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/conference/ConferenceK.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/conference/ConferenceK.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.conference
+
+import org.jitsi.videobridge.Conference
+import org.jitsi.videobridge.Videobridge
+import org.jxmpp.jid.EntityBareJid
+
+class ConferenceK(
+    videobridge: Videobridge,
+    id: String,
+    confName: EntityBareJid,
+    enableLogging: Boolean,
+    gid: Long
+) : Conference(videobridge, id, confName, enableLogging, gid)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/conference/ConferenceK.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/conference/ConferenceK.kt
@@ -33,13 +33,13 @@ import java.io.IOException
 import java.time.Clock
 import java.time.Duration
 
-class ConferenceK @JvmOverloads constructor(
+class ConferenceK(
     videobridge: Videobridge,
     id: String,
     confName: EntityBareJid,
     enableLogging: Boolean,
     gid: Long,
-    private val clock: Clock = Clock.systemUTC()
+    private val clock: Clock
 ) : Conference(videobridge, id, confName, enableLogging, gid) {
 
     private val creationTime = clock.instant()

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/JvbLoadManager.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/JvbLoadManager.kt
@@ -28,11 +28,11 @@ import java.time.Duration
 import java.time.Instant
 import java.util.logging.Level
 
-class JvbLoadManager<T : JvbLoadMeasurement> @JvmOverloads constructor(
+class JvbLoadManager<T : JvbLoadMeasurement>(
     private val jvbLoadThreshold: T,
     private val jvbRecoveryThreshold: T,
     private val loadReducer: JvbLoadReducer,
-    private val clock: Clock = Clock.systemUTC()
+    private val clock: Clock
 ) {
     private val logger = createLogger(minLogLevel = Level.ALL)
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayService.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayService.kt
@@ -24,6 +24,7 @@ import org.jitsi.videobridge.util.TaskPools
 import java.net.SocketAddress
 import java.net.SocketException
 import java.net.UnknownHostException
+import java.time.Clock
 import java.time.Instant
 
 /**
@@ -53,7 +54,9 @@ class OctoRelayService {
         val port = config.bindPort
 
         try {
-            udpTransport = UdpTransport(address, port, logger, OCTO_SO_RCVBUF, OCTO_SO_SNDBUF)
+            // TODO(brian): this should change to have OctoRelayService take a clock which it passes down,
+            // but we need to move it away from being created via the singleton first
+            udpTransport = UdpTransport(address, port, logger, OCTO_SO_RCVBUF, OCTO_SO_SNDBUF, Clock.systemUTC())
         } catch (t: Throwable) {
             when (t) {
                 is UnknownHostException, is SocketException -> {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
@@ -43,7 +43,7 @@ import java.time.Clock
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
 
-class IceTransport @JvmOverloads constructor(
+class IceTransport(
     id: String,
     /**
      * Whether or not the ICE agent created by this transport should be the
@@ -51,7 +51,7 @@ class IceTransport @JvmOverloads constructor(
      */
     controlling: Boolean,
     parentLogger: Logger,
-    private val clock: Clock = Clock.systemUTC()
+    private val clock: Clock
 ) {
     private val logger = createChildLogger(parentLogger)
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/udp/UdpTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/udp/UdpTransport.kt
@@ -43,13 +43,13 @@ import java.util.concurrent.atomic.LongAdder
  * can be done via [send], and a remote address (or a set of remote addresses)
  * must be provided.
  */
-class UdpTransport @JvmOverloads @Throws(SocketException::class, UnknownHostException::class) constructor(
+class UdpTransport @Throws(SocketException::class, UnknownHostException::class) constructor(
     private val bindAddress: String,
     private val bindPort: Int,
     parentLogger: Logger,
     soRcvBuf: Int? = null,
     soSndBuf: Int? = null,
-    private val clock: Clock = Clock.systemUTC()
+    private val clock: Clock
 ) {
     private val logger = createChildLogger(parentLogger, mapOf(
         "address" to bindAddress,

--- a/jvb/src/test/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveSourceProjectionTest.java
+++ b/jvb/src/test/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveSourceProjectionTest.java
@@ -15,6 +15,7 @@ import org.jitsi_modified.impl.neomedia.codec.video.vp8.*;
 import org.junit.*;
 
 import javax.xml.bind.*;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -37,7 +38,7 @@ public class VP8AdaptiveSourceProjectionTest
 
         VP8AdaptiveSourceProjectionContext context =
             new VP8AdaptiveSourceProjectionContext(diagnosticContext, payloadType,
-                initialState, logger);
+                initialState, logger, Clock.systemUTC());
 
         Vp8PacketGenerator generator = new Vp8PacketGenerator(1);
 
@@ -69,7 +70,7 @@ public class VP8AdaptiveSourceProjectionTest
 
         VP8AdaptiveSourceProjectionContext context =
             new VP8AdaptiveSourceProjectionContext(diagnosticContext, payloadType,
-                initialState, logger);
+                initialState, logger, Clock.systemUTC());
 
         int expectedSeq = 10001;
         long expectedTs = 1003000;
@@ -161,7 +162,7 @@ public class VP8AdaptiveSourceProjectionTest
         VP8AdaptiveSourceProjectionContext context =
             new VP8AdaptiveSourceProjectionContext(diagnosticContext,
                 payloadType,
-                initialState, logger);
+                initialState, logger, Clock.systemUTC());
 
         int latestSeq = buffer.get(0).<Vp8Packet>packetAs().getSequenceNumber();
 
@@ -370,7 +371,7 @@ public class VP8AdaptiveSourceProjectionTest
 
         VP8AdaptiveSourceProjectionContext context =
             new VP8AdaptiveSourceProjectionContext(diagnosticContext, payloadType,
-                initialState, logger);
+                initialState, logger, Clock.systemUTC());
 
         PacketInfo firstPacketInfo = generator.nextPacket();
         Vp8Packet firstPacket = firstPacketInfo.packetAs();
@@ -411,7 +412,7 @@ public class VP8AdaptiveSourceProjectionTest
 
         VP8AdaptiveSourceProjectionContext context =
             new VP8AdaptiveSourceProjectionContext(diagnosticContext, payloadType,
-                initialState, logger);
+                initialState, logger, Clock.systemUTC());
 
         PacketInfo firstPacketInfo = generator.nextPacket();
         Vp8Packet firstPacket = firstPacketInfo.packetAs();
@@ -461,7 +462,7 @@ public class VP8AdaptiveSourceProjectionTest
 
         VP8AdaptiveSourceProjectionContext context =
             new VP8AdaptiveSourceProjectionContext(diagnosticContext, payloadType,
-                initialState, logger);
+                initialState, logger, Clock.systemUTC());
 
         PacketInfo firstPacketInfo = generator.nextPacket();
         Vp8Packet firstPacket = firstPacketInfo.packetAs();
@@ -513,7 +514,7 @@ public class VP8AdaptiveSourceProjectionTest
 
         VP8AdaptiveSourceProjectionContext context =
             new VP8AdaptiveSourceProjectionContext(diagnosticContext, payloadType,
-                initialState, logger);
+                initialState, logger, Clock.systemUTC());
 
         int targetIndex = RtpLayerDesc.getIndex(1, 0, 2);
 
@@ -559,7 +560,7 @@ public class VP8AdaptiveSourceProjectionTest
 
         VP8AdaptiveSourceProjectionContext context =
             new VP8AdaptiveSourceProjectionContext(diagnosticContext, payloadType,
-                initialState, logger);
+                initialState, logger, Clock.systemUTC());
 
         int expectedSeq = 10001;
         long expectedTs = 1003000;
@@ -730,7 +731,7 @@ public class VP8AdaptiveSourceProjectionTest
 
         VP8AdaptiveSourceProjectionContext context =
             new VP8AdaptiveSourceProjectionContext(diagnosticContext, payloadType,
-                initialState, logger);
+                initialState, logger, Clock.systemUTC());
 
         int targetTid = 0;
         int decodableTid = 0;
@@ -816,7 +817,7 @@ public class VP8AdaptiveSourceProjectionTest
         VP8AdaptiveSourceProjectionContext context =
             new VP8AdaptiveSourceProjectionContext(diagnosticContext,
                 payloadType,
-                initialState, logger);
+                initialState, logger, Clock.systemUTC());
 
         int expectedSeq = 10001;
         long expectedTs = 1003000;

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/ConferenceTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/ConferenceTest.kt
@@ -19,6 +19,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 import org.jitsi.ConfigTest
+import org.jitsi.videobridge.conference.ConferenceK
 import org.jitsi.videobridge.octo.singleton as octoRelayServiceProvider
 import org.json.simple.JSONObject
 import org.json.simple.parser.JSONParser
@@ -38,7 +39,7 @@ class ConferenceTest : ConfigTest() {
         }
 
         context("Adding local endpoints should work") {
-            with(Conference(videobridge, "id", name, false, Conference.GID_NOT_SET)) {
+            with(ConferenceK(videobridge, "id", name, false, Conference.GID_NOT_SET)) {
                 endpointCount shouldBe 0
                 createLocalEndpoint("abcdabcd", true)
                 endpointCount shouldBe 1
@@ -46,20 +47,20 @@ class ConferenceTest : ConfigTest() {
             }
         }
         context("Enabling octo should fail when the GID is not set") {
-            with(Conference(videobridge, "id", name, false, Conference.GID_NOT_SET)) {
+            with(ConferenceK(videobridge, "id", name, false, Conference.GID_NOT_SET)) {
                 isOctoEnabled shouldBe false
                 shouldThrow<IllegalStateException> {
-                    tentacle
+                    getTentacle()
                 }
                 debugState.shouldBeValidJson()
             }
         }
         context("Enabling octo should work") {
-            with(Conference(videobridge, "id", name, false, 1234)) {
+            with(ConferenceK(videobridge, "id", name, false, 1234)) {
                 isOctoEnabled shouldBe false
-                tentacle
+                getTentacle()
                 isOctoEnabled shouldBe true
-                tentacle.setRelays(listOf("127.0.0.1:4097"))
+                getTentacle().setRelays(listOf("127.0.0.1:4097"))
 
                 debugState.shouldBeValidJson()
             }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/ConferenceTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/ConferenceTest.kt
@@ -24,6 +24,7 @@ import org.jitsi.videobridge.octo.singleton as octoRelayServiceProvider
 import org.json.simple.JSONObject
 import org.json.simple.parser.JSONParser
 import org.jxmpp.jid.impl.JidCreate
+import java.time.Clock
 import kotlin.random.Random
 
 /**
@@ -39,7 +40,7 @@ class ConferenceTest : ConfigTest() {
         }
 
         context("Adding local endpoints should work") {
-            with(ConferenceK(videobridge, "id", name, false, Conference.GID_NOT_SET)) {
+            with(ConferenceK(videobridge, "id", name, false, Conference.GID_NOT_SET, Clock.systemUTC())) {
                 endpointCount shouldBe 0
                 createLocalEndpoint("abcdabcd", true)
                 endpointCount shouldBe 1
@@ -47,7 +48,7 @@ class ConferenceTest : ConfigTest() {
             }
         }
         context("Enabling octo should fail when the GID is not set") {
-            with(ConferenceK(videobridge, "id", name, false, Conference.GID_NOT_SET)) {
+            with(ConferenceK(videobridge, "id", name, false, Conference.GID_NOT_SET, Clock.systemUTC())) {
                 isOctoEnabled shouldBe false
                 shouldThrow<IllegalStateException> {
                     getTentacle()
@@ -56,7 +57,7 @@ class ConferenceTest : ConfigTest() {
             }
         }
         context("Enabling octo should work") {
-            with(ConferenceK(videobridge, "id", name, false, 1234)) {
+            with(ConferenceK(videobridge, "id", name, false, 1234, Clock.systemUTC())) {
                 isOctoEnabled shouldBe false
                 getTentacle()
                 isOctoEnabled shouldBe true


### PR DESCRIPTION
This turned into a bit of a yak-shave...I saw some uses of `System.currentTimeMillis` and wanted to change them to use `Clock`.  Then I hit a case where I had to compare `Duration` instances, which I find awkward in java (you have to use `compareTo`, whereas Kotlin just supports the comparison opereators), so I ended up moving some methods to a Kotlin subclass of Conference (which I've thought would be nice in the past, but not strictly necessary).  Then I wanted to clean up things to consistently using the same `Clock` instance throughout  which I think would open some interesting doors for videobridge testing.  I wasn't able to finish that 100% though, some places need to have the singleton cleanup done first.

I didn't plan on doing this much, but ended up getting sucked into it and figured I'd put it up.  Not urgent.  Going commit-by-commit should keep things pretty simple.