### PR TITLE
Refactor ServiceBinder to take services instances instead of using global singletons

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/Application.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/Application.java
@@ -17,6 +17,7 @@
 package org.jitsi.videobridge.rest.root;
 
 import org.glassfish.jersey.server.*;
+import org.jitsi.videobridge.*;
 import org.jitsi.videobridge.rest.*;
 import org.jitsi.videobridge.rest.binders.*;
 import org.jitsi.videobridge.rest.filters.*;
@@ -25,9 +26,10 @@ import static org.jitsi.videobridge.rest.RestConfig.config;
 
 public class Application extends ResourceConfig
 {
-    public Application()
+    public Application(
+        Videobridge videobridge)
     {
-        register(new ServiceBinder());
+        register(new ServiceBinder(videobridge));
         // Filters
         register(ConfigFilter.class);
         // Register all resources in the package

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/Application.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/Application.java
@@ -21,6 +21,7 @@ import org.jitsi.videobridge.*;
 import org.jitsi.videobridge.rest.*;
 import org.jitsi.videobridge.rest.binders.*;
 import org.jitsi.videobridge.rest.filters.*;
+import org.jitsi.videobridge.stats.*;
 import org.jitsi.videobridge.xmpp.*;
 
 import static org.jitsi.videobridge.rest.RestConfig.config;
@@ -29,12 +30,14 @@ public class Application extends ResourceConfig
 {
     public Application(
         Videobridge videobridge,
-        XmppConnection xmppConnection)
+        XmppConnection xmppConnection,
+        StatsManager statsManager)
     {
         register(
             new ServiceBinder(
                 videobridge,
-                xmppConnection
+                xmppConnection,
+                statsManager
             )
         );
         // Filters

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/Application.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/Application.java
@@ -21,15 +21,22 @@ import org.jitsi.videobridge.*;
 import org.jitsi.videobridge.rest.*;
 import org.jitsi.videobridge.rest.binders.*;
 import org.jitsi.videobridge.rest.filters.*;
+import org.jitsi.videobridge.xmpp.*;
 
 import static org.jitsi.videobridge.rest.RestConfig.config;
 
 public class Application extends ResourceConfig
 {
     public Application(
-        Videobridge videobridge)
+        Videobridge videobridge,
+        XmppConnection xmppConnection)
     {
-        register(new ServiceBinder(videobridge));
+        register(
+            new ServiceBinder(
+                videobridge,
+                xmppConnection
+            )
+        );
         // Filters
         register(ConfigFilter.class);
         // Register all resources in the package

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/conferences/Conferences.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/conferences/Conferences.java
@@ -35,13 +35,13 @@ import java.util.*;
 public class Conferences
 {
     @Inject
-    private VideobridgeSupplier videobridgeSupplier;
+    private Videobridge videobridge;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public String getConferences()
     {
-        Videobridge videobridge = videobridgeSupplier.get();
+        Videobridge videobridge = this.videobridge;
         List<ColibriConferenceIQ> conferenceIQs = new ArrayList<>();
 
         for (Conference conference : videobridge.getConferences())
@@ -69,7 +69,7 @@ public class Conferences
     @Path("/{confId}")
     public String getConference(@PathParam("confId") String confId)
     {
-        Conference conference = videobridgeSupplier.get().getConference(confId);
+        Conference conference = videobridge.getConference(confId);
 
         if (conference == null)
         {
@@ -91,7 +91,7 @@ public class Conferences
     @Path("/{confId}/dominant-speaker-identification")
     public String getDominantSpeakerIdentification(@PathParam("confId") String confId)
     {
-        Conference conference = videobridgeSupplier.get().getConference(confId);
+        Conference conference = videobridge.getConference(confId);
 
         if (conference == null)
         {
@@ -140,7 +140,7 @@ public class Conferences
     @Produces(MediaType.APPLICATION_JSON)
     public String patchConference(@PathParam("confId") String confId, String requestBody)
     {
-        Conference conference = videobridgeSupplier.get().getConference(confId);
+        Conference conference = videobridge.getConference(confId);
         if (conference == null)
         {
             throw new NotFoundException();
@@ -168,7 +168,7 @@ public class Conferences
 
     private String getVideobridgeIqResponseAsJson(ColibriConferenceIQ request)
     {
-        IQ responseIq = videobridgeSupplier.get()
+        IQ responseIq = videobridge
                 .handleColibriConferenceIQ(request);
 
         if (responseIq.getError() != null)

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClient.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClient.java
@@ -35,7 +35,7 @@ import javax.ws.rs.core.*;
 public class MucClient
 {
     @Inject
-    protected XmppConnectionSupplier xmppConnectionSupplier;
+    protected XmppConnection xmppConnection;
 
     @Path("/add")
     @POST
@@ -51,7 +51,6 @@ public class MucClient
         {
             return Response.status(HttpServletResponse.SC_BAD_REQUEST).build();
         }
-        XmppConnection xmppConnection = xmppConnectionSupplier.get();
         if (xmppConnection.addMucClient((JSONObject)o))
         {
             return Response.ok().build();
@@ -69,7 +68,6 @@ public class MucClient
         {
             return Response.status(HttpServletResponse.SC_BAD_REQUEST).build();
         }
-        XmppConnection xmppConnection = xmppConnectionSupplier.get();
         if (xmppConnection.removeMucClient((JSONObject)o))
         {
             return Response.ok().build();

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/shutdown/Shutdown.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/shutdown/Shutdown.java
@@ -35,7 +35,7 @@ import javax.ws.rs.core.*;
 public class Shutdown
 {
     @Inject
-    protected VideobridgeSupplier videobridgeSupplier;
+    protected Videobridge videobridge;
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -43,7 +43,7 @@ public class Shutdown
     {
         try
         {
-            videobridgeSupplier.get().shutdown(shutdown.isGraceful);
+            videobridge.shutdown(shutdown.isGraceful);
             return Response.ok().build();
         }
         catch (Throwable t)

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/stats/Stats.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/stats/Stats.java
@@ -30,15 +30,15 @@ import javax.ws.rs.core.*;
 public class Stats
 {
     @Inject
-    protected StatsManagerSupplier statsManagerSupplier;
+    protected StatsManager statsManager;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public String getStats()
     {
-        StatsManager statsManager = statsManagerSupplier.get();
+        StatsManager statsManager = this.statsManager;
 
-        if (statsManagerSupplier != null)
+        if (this.statsManager != null)
         {
             Statistics videobridgeStats =
                 statsManager.getStatistics().stream()

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/Debug.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/Debug.java
@@ -48,7 +48,7 @@ public class Debug
 {
     @Inject
     @SuppressWarnings("unused")
-    private VideobridgeSupplier videobridgeSupplier;
+    private Videobridge videobridge;
 
     private Logger logger = new LoggerImpl(Debug.class.getName());
 
@@ -56,7 +56,7 @@ public class Debug
     @Produces(MediaType.APPLICATION_JSON)
     public String bridgeDebug(@DefaultValue("false") @QueryParam("full") boolean full)
     {
-        OrderedJsonObject confJson = videobridgeSupplier.get().getDebugState(null, null, full);
+        OrderedJsonObject confJson = videobridge.getDebugState(null, null, full);
         return confJson.toJSONString();
     }
 
@@ -88,7 +88,7 @@ public class Debug
             @PathParam("feature") EndpointDebugFeatures feature,
             @PathParam("state") String state)
     {
-        Conference conference = videobridgeSupplier.get().getConference(confId);
+        Conference conference = videobridge.getConference(confId);
         if (conference == null)
         {
             throw new NotFoundException("No conference was found with the specified id.");
@@ -170,7 +170,7 @@ public class Debug
             @PathParam("confId") String confId,
             @DefaultValue("true") @QueryParam("full") boolean full)
     {
-        OrderedJsonObject confJson = videobridgeSupplier.get().getDebugState(confId, null, full);
+        OrderedJsonObject confJson = videobridge.getDebugState(confId, null, full);
         return confJson.toJSONString();
     }
 
@@ -182,7 +182,7 @@ public class Debug
             @PathParam("epId") String epId,
             @DefaultValue("true") @QueryParam("full") boolean full)
     {
-        OrderedJsonObject confJson = videobridgeSupplier.get().getDebugState(confId, epId, full);
+        OrderedJsonObject confJson = videobridge.getDebugState(confId, epId, full);
         return confJson.toJSONString();
     }
 
@@ -200,7 +200,7 @@ public class Debug
                 return ByteBufferPool.getStatsJson().toJSONString();
             }
             case QUEUE_STATS: {
-                return videobridgeSupplier.get().getQueueStats().toJSONString();
+                return videobridge.getQueueStats().toJSONString();
             }
             case TRANSIT_STATS: {
                 return PacketTransitStats.getStatsJson().toJSONString();

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/JettyHelpers.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/JettyHelpers.kt
@@ -127,6 +127,8 @@ fun createServer(config: JettyBundleActivatorConfig): Server {
     }
 }
 
+fun JettyBundleActivatorConfig.isEnabled(): Boolean = port != -1 || tlsPort != -1
+
 // Note: it's technically possible that this cast fails, but
 // shouldn't happen in practice given that the above methods always install
 // a ServletContextHandler handler.

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
@@ -122,7 +122,7 @@ fun main(args: Array<String>) {
     )
     val privateHttpServer = if (privateServerConfig.isEnabled()) {
         logger.info("Starting private http server")
-        val restApp = Application()
+        val restApp = Application(videobridge().get())
         createServer(privateServerConfig).also {
             it.servletContextHandler.addServlet(
                 ServletHolder(ServletContainer(restApp)),

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
@@ -122,7 +122,7 @@ fun main(args: Array<String>) {
     )
     val privateHttpServer = if (privateServerConfig.isEnabled()) {
         logger.info("Starting private http server")
-        val restApp = Application(videobridge().get())
+        val restApp = Application(videobridge().get(), xmppConnection)
         createServer(privateServerConfig).also {
             it.servletContextHandler.addServlet(
                 ServletHolder(ServletContainer(restApp)),

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
@@ -122,7 +122,7 @@ fun main(args: Array<String>) {
     )
     val privateHttpServer = if (privateServerConfig.isEnabled()) {
         logger.info("Starting private http server")
-        val restApp = Application(videobridge().get(), xmppConnection)
+        val restApp = Application(videobridge().get(), xmppConnection, statsMgr)
         createServer(privateServerConfig).also {
             it.servletContextHandler.addServlet(
                 ServletHolder(ServletContainer(restApp)),

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/rest/binders/ServiceBinder.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/rest/binders/ServiceBinder.kt
@@ -19,18 +19,19 @@ package org.jitsi.videobridge.rest.binders
 import org.glassfish.hk2.utilities.binding.AbstractBinder
 import org.jitsi.health.HealthCheckServiceSupplier
 import org.jitsi.version.VersionServiceSupplier
-import org.jitsi.videobridge.VideobridgeSupplier
+import org.jitsi.videobridge.Videobridge
 import org.jitsi.videobridge.health.jvbHealthCheckServiceSupplier
 import org.jitsi.videobridge.stats.StatsManagerSupplier
+import org.jitsi.videobridge.stats.statsManagerSupplier
 import org.jitsi.videobridge.version.jvbVersionServiceSupplier
 import org.jitsi.videobridge.xmpp.XmppConnectionSupplier
-import org.jitsi.videobridge.videobridgeSupplier
-import org.jitsi.videobridge.stats.statsManagerSupplier
 import org.jitsi.videobridge.xmpp.xmppConnectionSupplier
 
-class ServiceBinder : AbstractBinder() {
+class ServiceBinder(
+    val videobridge: Videobridge
+) : AbstractBinder() {
     override fun configure() {
-        bind(videobridgeSupplier).to(VideobridgeSupplier::class.java)
+        bind(videobridge).to(Videobridge::class.java)
         bind(statsManagerSupplier).to(StatsManagerSupplier::class.java)
         bind(xmppConnectionSupplier).to(XmppConnectionSupplier::class.java)
         bind(jvbHealthCheckServiceSupplier).to(HealthCheckServiceSupplier::class.java)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/rest/binders/ServiceBinder.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/rest/binders/ServiceBinder.kt
@@ -24,16 +24,16 @@ import org.jitsi.videobridge.health.jvbHealthCheckServiceSupplier
 import org.jitsi.videobridge.stats.StatsManagerSupplier
 import org.jitsi.videobridge.stats.statsManagerSupplier
 import org.jitsi.videobridge.version.jvbVersionServiceSupplier
-import org.jitsi.videobridge.xmpp.XmppConnectionSupplier
-import org.jitsi.videobridge.xmpp.xmppConnectionSupplier
+import org.jitsi.videobridge.xmpp.XmppConnection
 
 class ServiceBinder(
-    val videobridge: Videobridge
+    val videobridge: Videobridge,
+    val xmppConnection: XmppConnection
 ) : AbstractBinder() {
     override fun configure() {
         bind(videobridge).to(Videobridge::class.java)
         bind(statsManagerSupplier).to(StatsManagerSupplier::class.java)
-        bind(xmppConnectionSupplier).to(XmppConnectionSupplier::class.java)
+        bind(xmppConnection).to(XmppConnection::class.java)
         bind(jvbHealthCheckServiceSupplier).to(HealthCheckServiceSupplier::class.java)
         bind(jvbVersionServiceSupplier).to(VersionServiceSupplier::class.java)
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/rest/binders/ServiceBinder.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/rest/binders/ServiceBinder.kt
@@ -21,18 +21,18 @@ import org.jitsi.health.HealthCheckServiceSupplier
 import org.jitsi.version.VersionServiceSupplier
 import org.jitsi.videobridge.Videobridge
 import org.jitsi.videobridge.health.jvbHealthCheckServiceSupplier
-import org.jitsi.videobridge.stats.StatsManagerSupplier
-import org.jitsi.videobridge.stats.statsManagerSupplier
+import org.jitsi.videobridge.stats.StatsManager
 import org.jitsi.videobridge.version.jvbVersionServiceSupplier
 import org.jitsi.videobridge.xmpp.XmppConnection
 
 class ServiceBinder(
     val videobridge: Videobridge,
-    val xmppConnection: XmppConnection
+    val xmppConnection: XmppConnection,
+    val statsManager: StatsManager
 ) : AbstractBinder() {
     override fun configure() {
         bind(videobridge).to(Videobridge::class.java)
-        bind(statsManagerSupplier).to(StatsManagerSupplier::class.java)
+        bind(statsManager).to(StatsManager::class.java)
         bind(xmppConnection).to(XmppConnection::class.java)
         bind(jvbHealthCheckServiceSupplier).to(HealthCheckServiceSupplier::class.java)
         bind(jvbVersionServiceSupplier).to(VersionServiceSupplier::class.java)

--- a/jvb/src/test/java/org/jitsi/videobridge/rest/root/colibri/stats/StatsTest.java
+++ b/jvb/src/test/java/org/jitsi/videobridge/rest/root/colibri/stats/StatsTest.java
@@ -34,22 +34,19 @@ import static org.mockito.Mockito.*;
 
 public class StatsTest extends JerseyTest
 {
-    protected StatsManagerSupplier statsManagerSupplier;
     protected StatsManager statsManager;
     protected static final String BASE_URL = "colibri/stats";
 
     @Override
     protected Application configure()
     {
-        statsManagerSupplier = mock(StatsManagerSupplier.class);
         statsManager = mock(StatsManager.class);
-        when(statsManagerSupplier.get()).thenReturn(statsManager);
 
         enable(TestProperties.LOG_TRAFFIC);
         enable(TestProperties.DUMP_ENTITY);
         return new ResourceConfig() {
             {
-                register(new MockBinder<>(statsManagerSupplier, StatsManagerSupplier.class));
+                register(new MockBinder<>(statsManager, StatsManager.class));
                 register(Stats.class);
             }
         };

--- a/jvb/src/test/java/org/jitsi/videobridge/rest/root/debug/DebugTest.java
+++ b/jvb/src/test/java/org/jitsi/videobridge/rest/root/debug/DebugTest.java
@@ -22,7 +22,6 @@ import org.glassfish.jersey.test.*;
 import org.jitsi.videobridge.*;
 import org.jitsi.videobridge.rest.*;
 import org.jitsi.videobridge.rest.annotations.*;
-import org.jitsi.videobridge.util.*;
 import org.junit.*;
 import org.reflections.*;
 import org.reflections.scanners.*;
@@ -39,16 +38,13 @@ import static org.mockito.Mockito.*;
 
 public class DebugTest extends JerseyTest
 {
-    protected VideobridgeSupplier videobridgeSupplier;
     protected Videobridge videobridge;
     protected static final String BASE_URL = "/debug";
 
     @Override
     protected Application configure()
     {
-        videobridgeSupplier = mock(VideobridgeSupplier.class);
         videobridge = mock(Videobridge.class);
-        when(videobridgeSupplier.get()).thenReturn(videobridge);
 
         Endpoint endpoint = mock(Endpoint.class);
         Conference conference = mock(Conference.class);
@@ -59,7 +55,7 @@ public class DebugTest extends JerseyTest
         enable(TestProperties.DUMP_ENTITY);
         return new ResourceConfig() {
             {
-                register(new MockBinder<>(videobridgeSupplier, VideobridgeSupplier.class));
+                register(new MockBinder<>(videobridge, Videobridge.class));
                 register(Debug.class);
             }
         };

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClientTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClientTest.kt
@@ -26,7 +26,6 @@ import org.glassfish.jersey.test.JerseyTest
 import org.glassfish.jersey.test.TestProperties
 import org.jitsi.videobridge.rest.MockBinder
 import org.jitsi.videobridge.xmpp.XmppConnection
-import org.jitsi.videobridge.xmpp.XmppConnectionSupplier
 import org.json.simple.JSONObject
 import org.junit.Test
 import javax.ws.rs.client.Entity
@@ -34,20 +33,16 @@ import javax.ws.rs.core.Application
 
 class MucClientTest : JerseyTest() {
     private lateinit var xmppConnection: XmppConnection
-    private lateinit var xmppConnectionSupplier: XmppConnectionSupplier
     private val baseUrl = "/colibri/muc-client"
 
     override fun configure(): Application {
         xmppConnection = mockk()
-        xmppConnectionSupplier = mockk {
-            every { get() } returns xmppConnection
-        }
 
         enable(TestProperties.LOG_TRAFFIC)
         enable(TestProperties.DUMP_ENTITY)
         return object : ResourceConfig() {
             init {
-                register(MockBinder(xmppConnectionSupplier, XmppConnectionSupplier::class.java))
+                register(MockBinder(xmppConnection, XmppConnection::class.java))
                 register(MucClient::class.java)
             }
         }


### PR DESCRIPTION
This is more work on https://github.com/jitsi/jitsi-videobridge/issues/1444, and passes instances down from Main instead of having other classes grab them via singletons.