### PR TITLE
fix: always assume 3 temporal layers

### DIFF
--- a/jvb/src/test/java/org/jitsi/videobridge/xmpp/MediaSourceFactoryTest.java
+++ b/jvb/src/test/java/org/jitsi/videobridge/xmpp/MediaSourceFactoryTest.java
@@ -78,7 +78,7 @@ public class MediaSourceFactoryTest
         assertNotNull(sources);
         assertEquals(1, sources.length);
         MediaSourceDesc source = sources[0];
-        assertEquals(1, source.numRtpLayers());
+        assertEquals(3, source.numRtpLayers());
     }
 
     // 1 video stream, 1 rtx -> 1 source, 1 layer
@@ -104,7 +104,7 @@ public class MediaSourceFactoryTest
         assertNotNull(sources);
         assertEquals(1, sources.length);
         MediaSourceDesc source = sources[0];
-        assertEquals(1, source.numRtpLayers());
+        assertEquals(3, source.numRtpLayers());
     }
 
     // 3 sim streams, 3 rtx -> 1 source, 9 layers
@@ -257,8 +257,8 @@ public class MediaSourceFactoryTest
         assertNotNull(sources);
         assertEquals(3, sources.length);
         assertEquals(9, sources[0].numRtpLayers());
-        assertEquals(1, sources[1].numRtpLayers());
-        assertEquals(1, sources[2].numRtpLayers());
+        assertEquals(3, sources[1].numRtpLayers());
+        assertEquals(3, sources[2].numRtpLayers());
     }
 
     @Test
@@ -283,7 +283,7 @@ public class MediaSourceFactoryTest
         assertNotNull(sources);
         assertEquals(1, sources.length);
         MediaSourceDesc source = sources[0];
-        assertEquals(1, source.numRtpLayers());
+        assertEquals(3, source.numRtpLayers());
     }
 
     @Test


### PR DESCRIPTION
Previously, we assumed that when simulcast was enabled, 3 temporal layers would
be present in each stream and if simulcast wasn't enabled, there would be only
1 temporal layer per stream, but we found that screenshare started sending 2
temporal layers, and we'd therefore start dropping layer 1 packets since we didn't
recognize them.  The truth is we have no way of _knowing_ how many temporal layers
there are going to be (as it's not signaled) unless we dynamically read the layers
as the packets come in (which we may want to do in the future)--but for now we'll
over-estimate how many layers there are per stream to avoid dropping packets for a
layer we don't recognize.  Since there are already situations where chrome sends fewer
temporal layers than we assume, this should be safe.