### PR TITLE
Fix NullPointerException if conferenceName is not defined.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -1123,7 +1123,10 @@ public class Conference
     {
         JSONObject debugState = new JSONObject();
         debugState.put("id", id);
-        debugState.put("name", conferenceName.toString());
+        if (conferenceName != null)
+        {
+            debugState.put("name", conferenceName.toString());
+        }
 
         if (full)
         {


### PR DESCRIPTION
This null-check is present in constructor but missing in getDebugState