### PR TITLE
Allow sending EndpointMessage to the custom Endpoints.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
@@ -559,15 +559,15 @@ class EndpointMessageTransport
             String to = message.getTo();
 
             AbstractEndpoint targetEndpoint = conference.getEndpoint(to);
-            if (targetEndpoint instanceof Endpoint)
-            {
-                targets = Collections.singletonList(targetEndpoint);
-                sendToOcto = false;
-            }
-            else if (targetEndpoint instanceof OctoEndpoint)
+            if (targetEndpoint instanceof OctoEndpoint)
             {
                 targets = Collections.emptyList();
                 sendToOcto = true;
+            }
+            else if (targetEndpoint != null)
+            {
+                targets = Collections.singletonList(targetEndpoint);
+                sendToOcto = false;
             }
             else
             {


### PR DESCRIPTION
In our project we use bare JVB as a library and for some reason we have custom implementation of AbstractEndpoint for communication with regular Endpoints in a conference. At the moment EndpointMessages are not sent to that "custom" EP since it is not Endpoint nor OctoEndpoint.
I would like to ask you to merge this small change to allow messaging with any kind of AbstractEndpoint.