### PR TITLE
Fire events from Endpoint

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -25,6 +25,7 @@ import org.jitsi.utils.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.message.*;
 import org.jitsi.videobridge.rest.root.debug.*;
+import org.jitsi.videobridge.util.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.json.simple.*;
 
@@ -96,6 +97,8 @@ public abstract class AbstractEndpoint
      * all receivers.
      */
     private VideoConstraints maxReceiverVideoConstraints = defaultMaxReceiverVideoConstraints;
+
+    protected final EventEmitter<EventHandler> eventEmitter = new EventEmitter<>();
 
     /**
      * Initializes a new {@link AbstractEndpoint} instance.
@@ -178,6 +181,16 @@ public abstract class AbstractEndpoint
     public Conference getConference()
     {
         return conference;
+    }
+
+    void addEventHandler(EventHandler eventHandler)
+    {
+        eventEmitter.addHandler(eventHandler);
+    }
+
+    void removeEventHandler(EventHandler eventHandler)
+    {
+        eventEmitter.removeHandler(eventHandler);
     }
 
     /**
@@ -443,5 +456,9 @@ public abstract class AbstractEndpoint
             logger.debug(() -> "Removed receiver " + receiverId);
             receiverVideoConstraintsChanged(receiverVideoConstraintsMap.values());
         }
+    }
+
+    interface EventHandler {
+        void iceSucceeded();
     }
 }

--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -461,5 +461,6 @@ public abstract class AbstractEndpoint
     interface EventHandler {
         void iceSucceeded();
         void iceFailed();
+        void sourcesChanged();
     }
 }

--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -462,5 +462,6 @@ public abstract class AbstractEndpoint
         void iceSucceeded();
         void iceFailed();
         void sourcesChanged();
+        void audioLevelChanged(long level);
     }
 }

--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -462,6 +462,5 @@ public abstract class AbstractEndpoint
         void iceSucceeded();
         void iceFailed();
         void sourcesChanged();
-        void audioLevelChanged(long level);
     }
 }

--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -460,5 +460,6 @@ public abstract class AbstractEndpoint
 
     interface EventHandler {
         void iceSucceeded();
+        void iceFailed();
     }
 }

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -655,9 +655,24 @@ public class Conference
 
         final Endpoint endpoint = new Endpoint(id, this, logger, iceControlling);
 
+        subscribeToEndpointEvents(endpoint);
+
         addEndpoint(endpoint);
 
         return endpoint;
+    }
+
+    private void subscribeToEndpointEvents(AbstractEndpoint endpoint)
+    {
+        endpoint.addEventHandler(new AbstractEndpoint.EventHandler()
+        {
+            @Override
+            public void iceSucceeded()
+            {
+                getStatistics().hasIceSucceededEndpoint = true;
+                getVideobridge().getStatistics().totalIceSucceeded.incrementAndGet();
+            }
+        });
     }
 
     /**

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -679,6 +679,12 @@ public class Conference
                 getStatistics().hasIceFailedEndpoint = true;
                 getVideobridge().getStatistics().totalIceFailed.incrementAndGet();
             }
+
+            @Override
+            public void sourcesChanged()
+            {
+                endpointSourcesChanged(endpoint);
+            }
         });
     }
 

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -672,6 +672,13 @@ public class Conference
                 getStatistics().hasIceSucceededEndpoint = true;
                 getVideobridge().getStatistics().totalIceSucceeded.incrementAndGet();
             }
+
+            @Override
+            public void iceFailed()
+            {
+                getStatistics().hasIceFailedEndpoint = true;
+                getVideobridge().getStatistics().totalIceFailed.incrementAndGet();
+            }
         });
     }
 

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -685,12 +685,6 @@ public class Conference
             {
                 endpointSourcesChanged(endpoint);
             }
-
-            @Override
-            public void audioLevelChanged(long level)
-            {
-                getSpeechActivity().levelChanged(endpoint, level);
-            }
         });
     }
 

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -685,6 +685,12 @@ public class Conference
             {
                 endpointSourcesChanged(endpoint);
             }
+
+            @Override
+            public void audioLevelChanged(long level)
+            {
+                getSpeechActivity().levelChanged(endpoint, level);
+            }
         });
     }
 

--- a/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -386,8 +386,10 @@ public class Endpoint
 
             @Override
             public void failed() {
-                getConference().getStatistics().hasIceFailedEndpoint = true;
-                getConference().getVideobridge().getStatistics().totalIceFailed.incrementAndGet();
+                eventEmitter.fireEvent(handler -> {
+                    handler.iceFailed();
+                    return Unit.INSTANCE;
+                });
             }
 
             @Override

--- a/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -375,8 +375,10 @@ public class Endpoint
             @Override
             public void connected() {
                 logger.info("ICE connected");
-                getConference().getStatistics().hasIceSucceededEndpoint = true;
-                getConference().getVideobridge().getStatistics().totalIceSucceeded.incrementAndGet();
+                eventEmitter.fireEvent(handler -> {
+                    handler.iceSucceeded();
+                    return Unit.INSTANCE;
+                });
                 transceiver.setOutgoingPacketHandler(outgoingSrtpPacketQueue::add);
                 TaskPools.IO_POOL.submit(iceTransport::startReadingData);
                 TaskPools.IO_POOL.submit(dtlsTransport::startDtlsHandshake);

--- a/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1110,7 +1110,10 @@ public class Endpoint
     {
         if (transceiver.setMediaSources(mediaSources))
         {
-            getConference().endpointSourcesChanged(this);
+            eventEmitter.fireEvent(handler -> {
+                handler.sourcesChanged();
+                return Unit.INSTANCE;
+            });
         }
     }
 

--- a/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1431,10 +1431,7 @@ public class Endpoint
         @Override
         public void audioLevelReceived(long sourceSsrc, long level)
         {
-            eventEmitter.fireEvent(handler -> {
-                handler.audioLevelChanged(level);
-                return Unit.INSTANCE;
-            });
+            getConference().getSpeechActivity().levelChanged(Endpoint.this, level);
         }
 
         /**

--- a/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1431,7 +1431,10 @@ public class Endpoint
         @Override
         public void audioLevelReceived(long sourceSsrc, long level)
         {
-            getConference().getSpeechActivity().levelChanged(Endpoint.this, level);
+            eventEmitter.fireEvent(handler -> {
+                handler.audioLevelChanged(level);
+                return Unit.INSTANCE;
+            });
         }
 
         /**


### PR DESCRIPTION
This is the start of some work to get rid of all the dependencies on `Conference` we have in `AbstractEndpoint` and its subclasses.  It uses the `EventEmitter` class introduced in https://github.com/jitsi/jitsi-videobridge/pull/1473, so that PR will need to be merged first.