### PR TITLE
Remove conf/ep creation from health checks

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -111,7 +111,7 @@ public class Conference
     private final long gid;
 
     /**
-     * The world readable name of this instance if any.
+     * The world readable name of this instance
      */
     @NotNull
     private final EntityBareJid conferenceName;
@@ -161,7 +161,7 @@ public class Conference
      * endpoints stopping or starting to their video streams (which affects the order).
      */
     private ScheduledFuture<?> updateLastNEndpointsFuture;
-    
+
     @NotNull
     private final EndpointConnectionStatusMonitor epConnectionStatusMonitor;
 
@@ -174,8 +174,6 @@ public class Conference
      * <tt>Conference</tt> instance is to be initialized
      * @param id the (unique) ID of the new instance to be initialized
      * @param conferenceName world readable name of this conference
-     * {@link Conference} and its sub-components, and whether this conference
-     * should be considered when generating statistics.
      * @param gid the optional "global" id of the conference.
      */
     public Conference(Videobridge videobridge,

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -161,8 +161,9 @@ public class Conference
      * endpoints stopping or starting to their video streams (which affects the order).
      */
     private ScheduledFuture<?> updateLastNEndpointsFuture;
-
-    @NotNull private final EndpointConnectionStatusMonitor epConnectionStatusMonitor;
+    
+    @NotNull
+    private final EndpointConnectionStatusMonitor epConnectionStatusMonitor;
 
     /**
      * Initializes a new <tt>Conference</tt> instance which is to represent a

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -111,7 +111,7 @@ public class Conference
     private final long gid;
 
     /**
-     * The world readable name of this instance
+     * The world readable name of this instance if any.
      */
     private final EntityBareJid conferenceName;
 

--- a/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -319,10 +319,7 @@ public class Endpoint
         dtlsTransport = new DtlsTransport(logger);
         setupDtlsTransport();
 
-        if (conference.includeInStatistics())
-        {
-            conference.getVideobridge().getStatistics().totalEndpoints.incrementAndGet();
-        }
+        conference.getVideobridge().getStatistics().totalEndpoints.incrementAndGet();
     }
 
     public Endpoint(
@@ -748,7 +745,7 @@ public class Endpoint
 
             updateStatsOnExpire();
             this.transceiver.stop();
-            if (logger.isDebugEnabled() && getConference().includeInStatistics())
+            if (logger.isDebugEnabled())
             {
                 logger.debug(transceiver.getNodeStats().prettyPrint(0));
                 logger.debug(bitrateController.getDebugState().toJSONString());

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -225,13 +225,7 @@ public class Videobridge
             {
                 if (!conferencesById.containsKey(id))
                 {
-                    conference
-                        = new Conference(
-                                this,
-                                id,
-                                name,
-                                enableLogging,
-                                gid);
+                    conference = new Conference(this, id, name, gid);
                     conferencesById.put(id, conference);
                 }
             }
@@ -278,14 +272,11 @@ public class Videobridge
                 + " gid=" + conference.getGid()
                 + " logging=" + enableLogging);
 
-        if (conference.includeInStatistics())
+        eventEmitter.fireEvent(handler ->
         {
-            eventEmitter.fireEvent(handler ->
-            {
-                handler.conferenceCreated(conference);
-                return Unit.INSTANCE;
-            });
-        }
+            handler.conferenceCreated(conference);
+            return Unit.INSTANCE;
+        });
 
         return conference;
     }
@@ -323,14 +314,11 @@ public class Videobridge
             {
                 conferencesById.remove(id);
                 conference.expire();
-                if (conference.includeInStatistics())
+                eventEmitter.fireEvent(handler ->
                 {
-                    eventEmitter.fireEvent(handler ->
-                    {
-                        handler.conferenceExpired(conference);
-                        return Unit.INSTANCE;
-                    });
-                }
+                    handler.conferenceExpired(conference);
+                    return Unit.INSTANCE;
+                });
             }
         }
 

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -185,7 +185,7 @@ public class Videobridge
         {
             xmppConnection.setEventHandler(new XmppConnectionEventHandler());
         }
-        healthChecker = new JvbHealthChecker(this);
+        healthChecker = new JvbHealthChecker();
         versionService = new JvbVersionService();
         this.shutdownService = shutdownService;
     }

--- a/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -225,10 +225,6 @@ public class VideobridgeStatistics
         {
             ConferenceShim conferenceShim = conference.getShim();
             //TODO: can/should we do everything here via the shim only?
-            if (!conference.includeInStatistics())
-            {
-                continue;
-            }
             conferences++;
             if (conference.isP2p())
             {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/health/JvbHealthChecker.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/health/JvbHealthChecker.kt
@@ -19,15 +19,10 @@ package org.jitsi.videobridge.health
 import org.ice4j.ice.harvest.MappingCandidateHarvesters
 import org.jitsi.health.HealthCheckService
 import org.jitsi.health.HealthChecker
-import org.jitsi.videobridge.Conference
-import org.jitsi.videobridge.Videobridge
 import org.jitsi.videobridge.health.config.HealthConfig
 import org.jitsi.videobridge.ice.Harvesters
-import org.jitsi.videobridge.sctp.SctpConfig
 
-class JvbHealthChecker(
-    private val videobridge: Videobridge
-) : HealthCheckService {
+class JvbHealthChecker : HealthCheckService {
     private val config = HealthConfig()
     private val healthChecker = HealthChecker(
         config.interval,
@@ -49,31 +44,7 @@ class JvbHealthChecker(
         }
 
         // TODO: check if XmppConnection is configured and connected.
-
-        val conference = videobridge.createConference(null, false)
-        try {
-            checkConference(conference)
-        } finally {
-            videobridge.expireConference(conference)
-        }
     }
 
     override fun getResult(): Exception? = healthChecker.result
-
-    companion object {
-        private var epId: Long = 0
-        fun checkConference(conference: Conference) {
-            val numEndpoints = 2
-            repeat(numEndpoints) { index ->
-                val iceControlling = index % 2 == 0
-                val endpoint = conference.createLocalEndpoint(epId++.toString(), iceControlling)
-                if (SctpConfig.config.enabled) {
-                    endpoint.createSctpConnection()
-                }
-            }
-
-            // NOTE(brian): We can't attempt an ICE connection between the endpoints in single-port mode.  I think
-            // this is because both agents bind to the single port and we can't demux the ice packets correctly.
-        }
-    }
 }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/ConferenceTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/ConferenceTest.kt
@@ -17,19 +17,22 @@ package org.jitsi.videobridge
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.mockk.every
 import io.mockk.mockk
 import org.jitsi.ConfigTest
-import org.jitsi.videobridge.octo.singleton as octoRelayServiceProvider
 import org.json.simple.JSONObject
 import org.json.simple.parser.JSONParser
 import org.jxmpp.jid.impl.JidCreate
 import kotlin.random.Random
+import org.jitsi.videobridge.octo.singleton as octoRelayServiceProvider
 
 /**
  * This is a high-level test for [Conference] and related functionality.
  */
 class ConferenceTest : ConfigTest() {
-    private val videobridge = mockk<Videobridge>()
+    private val videobridge = mockk<Videobridge> {
+        every { statistics } returns Videobridge.Statistics()
+    }
 
     init {
         val name = JidCreate.entityBareFrom("roomName@somedomain.com")
@@ -38,7 +41,7 @@ class ConferenceTest : ConfigTest() {
         }
 
         context("Adding local endpoints should work") {
-            with(Conference(videobridge, "id", name, false, Conference.GID_NOT_SET)) {
+            with(Conference(videobridge, "id", name, Conference.GID_NOT_SET)) {
                 endpointCount shouldBe 0
                 createLocalEndpoint("abcdabcd", true)
                 endpointCount shouldBe 1
@@ -46,7 +49,7 @@ class ConferenceTest : ConfigTest() {
             }
         }
         context("Enabling octo should fail when the GID is not set") {
-            with(Conference(videobridge, "id", name, false, Conference.GID_NOT_SET)) {
+            with(Conference(videobridge, "id", name, Conference.GID_NOT_SET)) {
                 isOctoEnabled shouldBe false
                 shouldThrow<IllegalStateException> {
                     tentacle
@@ -55,7 +58,7 @@ class ConferenceTest : ConfigTest() {
             }
         }
         context("Enabling octo should work") {
-            with(Conference(videobridge, "id", name, false, 1234)) {
+            with(Conference(videobridge, "id", name, 1234)) {
                 isOctoEnabled shouldBe false
                 tentacle
                 isOctoEnabled shouldBe true


### PR DESCRIPTION
After discussing with @bgrozev, this aspect of the check was adding very little value and leads to some awkwardness with having to deal with these "special" conferences, so removing this logic.  It's possible we'll bring it back in some other form in the future.