### PR TITLE
move ice4j overrides to application.conf

### DIFF
--- a/jvb/src/main/resources/application.conf
+++ b/jvb/src/main/resources/application.conf
@@ -1,0 +1,22 @@
+# This file contains overrides for libraries JVB uses
+ice4j {
+  consent-freshness {
+    // Sends "consent freshness" check every 3 seconds
+    interval = 3 seconds
+    // Retry max 5 times which will take up to 2500ms, that is before the next "consent freshness" transaction starts.
+    max-retransmissions = 5
+  }
+  harvest {
+    // In the majority of use-cases the clients which connect to Jitsi Videobridge are not in the same network, so we
+    // don't need to advertise link-local addresses.
+    use-link-local-addresses = false
+
+    udp {
+      // Configure the receive buffer size for the sockets used for the
+      // single-port mode to be 10MB.
+      receive-buffer-size = 10485760
+
+      use-dynamic-ports = false
+    }
+  }
+}

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -272,24 +272,3 @@ videobridge {
   }
 }
 
-ice4j {
-  consent-freshness {
-    // Sends "consent freshness" check every 3 seconds
-    interval = 3 seconds
-    // Retry max 5 times which will take up to 2500ms, that is before the next "consent freshness" transaction starts.
-    max-retransmissions = 5
-  }
-  harvest {
-    // In the majority of use-cases the clients which connect to Jitsi Videobridge are not in the same network, so we
-    // don't need to advertise link-local addresses.
-    use-link-local-addresses = false
-
-    udp {
-      // Configure the receive buffer size for the sockets used for the
-      // single-port mode to be 10MB.
-      receive-buffer-size = 10485760
-
-      use-dynamic-ports = false
-    }
-  }
-}

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <kotlin.version>1.3.72</kotlin.version>
         <kotest.version>4.1.3</kotest.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jicoco.version>1.1-60-g3bc6ace</jicoco.version>
+        <jicoco.version>1.1-62-g1befa88</jicoco.version>
         <jitsi.utils.version>1.0-60-g07c4a0b</jitsi.utils.version>
         <maven-shade-plugin.version>3.2.2</maven-shade-plugin.version>
         <spotbugs.version>4.0.1</spotbugs.version>


### PR DESCRIPTION
This, in combination with the linked jicoco-config PR, fixes JVB config overrides of properties it uses (previously it worked in some envs coincidentally based on classpath loading order, but did always fail to properly override ICE4j config when deploying a fat jar).

Depends on https://github.com/jitsi/jicoco/pull/118