### PR TITLE
ref: Remove unused fields from ForwardedEndpointsMessage.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -292,15 +292,9 @@ public class Endpoint
         BitrateController.EventHandler bcEventHandler = new BitrateController.EventHandler()
         {
             @Override
-            public void lastNEndpointsChanged(
-                    Collection<String> forwardedEndpoints,
-                    Collection<String> endpointsEnteringLastN,
-                    Collection<String> conferenceEndpoints)
+            public void forwardedEndpointsChanged(Collection<String> forwardedEndpoints)
             {
-                sendLastNEndpointsChangeEvent(
-                        forwardedEndpoints,
-                        endpointsEnteringLastN,
-                        conferenceEndpoints);
+                sendForwardedEndpointsMessage(forwardedEndpoints);
             }
 
             @Override
@@ -1018,34 +1012,14 @@ public class Endpoint
     }
 
     /**
-     * Sends a message to this {@link Endpoint} in order to notify it that the
-     * list/set of {@code lastN} has changed.
+     * Sends a message to this {@link Endpoint} in order to notify it that the set of endpoints for which the bridge
+     * is sending video has changed.
      *
      * @param forwardedEndpoints the collection of forwarded endpoints.
-     * @param endpointsEnteringLastN the <tt>Endpoint</tt>s which are entering
-     * the list of <tt>Endpoint</tt>s defined by <tt>lastN</tt>
-     * @param conferenceEndpoints the collection of all endpoints in the
-     * conference.
      */
-    private void sendLastNEndpointsChangeEvent(
-        Collection<String> forwardedEndpoints,
-        Collection<String> endpointsEnteringLastN,
-        Collection<String> conferenceEndpoints)
+    private void sendForwardedEndpointsMessage(Collection<String> forwardedEndpoints)
     {
-        // We want endpointsEnteringLastN to always to reported. Consequently,
-        // we will pretend that all lastNEndpoints are entering if no explicit
-        // endpointsEnteringLastN is specified.
-        // XXX do we really want that?
-        if (endpointsEnteringLastN == null)
-        {
-            endpointsEnteringLastN = forwardedEndpoints;
-        }
-
-        ForwardedEndpointsMessage msg
-                = new ForwardedEndpointsMessage(
-                    forwardedEndpoints,
-                    endpointsEnteringLastN,
-                    conferenceEndpoints);
+        ForwardedEndpointsMessage msg = new ForwardedEndpointsMessage(forwardedEndpoints);
 
         TaskPools.IO_POOL.submit(() -> {
             try

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/message/BridgeChannelMessage.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/message/BridgeChannelMessage.kt
@@ -347,14 +347,13 @@ class EndpointConnectionStatusMessage(
 
 /**
  * A message sent from the bridge to a client, indicating the set of endpoints that are currently being forwarded.
- *
- * TODO: document the semantics of the fields.
  */
 class ForwardedEndpointsMessage(
     @get:JsonProperty("lastNEndpoints")
-    val forwardedEndpoints: Collection<String>,
-    val endpointsEnteringLastN: Collection<String>,
-    val conferenceEndpoints: Collection<String>
+    /**
+     * The set of endpoints for which the bridge is currently sending video.
+     */
+    val forwardedEndpoints: Collection<String>
 ) : BridgeChannelMessage(TYPE) {
     /**
      * Serialize using json-simple because it's faster.
@@ -364,8 +363,6 @@ class ForwardedEndpointsMessage(
         // json-simple does not property serialize collections properly (it handles [List]s correctly, but not [Set]s)
         // As a short-term solution force the use of a list.
         this["lastNEndpoints"] = ArrayList(forwardedEndpoints)
-        this["endpointsEnteringLastN"] = ArrayList(endpointsEnteringLastN)
-        this["conferenceEndpoints"] = ArrayList(conferenceEndpoints)
     }.toJSONString()
 
     companion object {

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
@@ -167,18 +167,14 @@ class BridgeChannelMessageTest : ShouldSpec() {
 
         context("serializing and parsing ForwardedEndpointsMessage") {
             val forwardedEndpoints = setOf("a", "b", "c")
-            val endpointsEnteringLastN = setOf("b", "c")
-            val conferenceEndpoints = listOf("a", "b", "c", "d")
 
-            val message = ForwardedEndpointsMessage(forwardedEndpoints, endpointsEnteringLastN, conferenceEndpoints)
+            val message = ForwardedEndpointsMessage(forwardedEndpoints)
             val parsed = parse(message.toJson())
 
             parsed.shouldBeInstanceOf<ForwardedEndpointsMessage>()
             parsed as ForwardedEndpointsMessage
 
             parsed.forwardedEndpoints shouldContainExactly forwardedEndpoints
-            parsed.endpointsEnteringLastN shouldContainExactly endpointsEnteringLastN
-            parsed.conferenceEndpoints shouldContainExactly conferenceEndpoints
 
             // Make sure the forwardedEndpoints field is serialized as lastNEndpoints as the client (presumably) expects
             val parsedJson = JSONParser().parse(message.toJson())


### PR DESCRIPTION
The jitsi-meet client no longer relies on the "endpointsEnteringLastN" and "conferenceEndpoints" fields, and they carry no useful information.
