### PR TITLE
fix: Avoid IllegalStateException when StatsCollector is disabled

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/Application.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/Application.java
@@ -31,14 +31,14 @@ public class Application extends ResourceConfig
     public Application(
             Videobridge videobridge,
             XmppConnection xmppConnection,
-            StatsCollector statsManager)
+            StatsCollector statsCollector)
 
     {
         register(
             new ServiceBinder(
                 videobridge,
                 xmppConnection,
-                statsManager
+                statsCollector
             )
         );
         // Filters

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/stats/Stats.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/stats/Stats.java
@@ -20,6 +20,7 @@ import org.jitsi.videobridge.rest.*;
 import org.jitsi.videobridge.rest.annotations.*;
 import org.jitsi.videobridge.stats.*;
 import org.json.simple.*;
+import org.jvnet.hk2.annotations.*;
 
 import javax.inject.*;
 import javax.ws.rs.*;
@@ -30,6 +31,7 @@ import javax.ws.rs.core.*;
 public class Stats
 {
     @Inject
+    @Optional
     protected StatsCollector statsManager;
 
     @GET

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/rest/binders/ServiceBinder.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/rest/binders/ServiceBinder.kt
@@ -28,11 +28,15 @@ import org.jitsi.videobridge.xmpp.XmppConnection
 class ServiceBinder(
     private val videobridge: Videobridge,
     private val xmppConnection: XmppConnection,
-    private val statsCollector: StatsCollector
+    private val statsCollector: StatsCollector?
 ) : AbstractBinder() {
     override fun configure() {
         bind(videobridge).to(Videobridge::class.java)
-        bind(statsCollector).to(StatsCollector::class.java)
+        // We have to test this, because the nullablle 'StatsCollector?' type doesn't play
+        // nicely in hk2 since we're binding to 'StatsCollector'
+        if (statsCollector != null) {
+            bind(statsCollector).to(StatsCollector::class.java)
+        }
         bind(xmppConnection).to(XmppConnection::class.java)
         // These are still suppliers rather than direct instances because that's what
         // Jicoco requires


### PR DESCRIPTION
Stats can be disabled, and this was causing an issue when crossing a Java -> Kotlin boundary as Kotlin was expecting a non-null type, but this was from java so it didn't get enforced (hence why we didn't see this at compile time).  Jersey/hk2 didn't play too nicely with injecting a nullable type, so I had to play with that a bit and only conditionally inject in the non-null case and mark the injection as `Optional`.  

Fixes https://github.com/jitsi/jitsi-videobridge/issues/1503