### PR TITLE
Update: Use latest jicoco.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <jetty.version>9.4.33.v20201020</jetty.version>
         <kotlin.version>1.3.72</kotlin.version>
         <kotest.version>4.1.3</kotest.version>
-        <jicoco.version>1.1-65-ga09b9f5</jicoco.version>
+        <jicoco.version>1.1-68-gf620376</jicoco.version>
         <jitsi.utils.version>1.0-60-g07c4a0b</jitsi.utils.version>
         <maven-shade-plugin.version>3.2.2</maven-shade-plugin.version>
         <spotbugs.version>4.1.4</spotbugs.version>


### PR DESCRIPTION
Built with latest jetty, jersey, and typesafe config libs.