### PR TITLE
Add oversending stat

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -780,6 +780,8 @@ public class Endpoint
                 logger.debug(dtlsTransport.getDebugState().toJSONString());
             }
 
+            logger.info("Spent " + bitrateController.getTotalOversendingTime().getSeconds() + " seconds oversending");
+
             transceiver.teardown();
 
             EndpointMessageTransport messageTransport = getMessageTransport();

--- a/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1424,6 +1424,11 @@ public class Endpoint
         return transceiver.isReceivingVideo();
     }
 
+    public boolean isOversending()
+    {
+        return bitrateController.isOversending();
+    }
+
     private class TransceiverEventHandlerImpl implements TransceiverEventHandler
     {
         /**

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -610,6 +610,23 @@ public class BitrateController<T extends BitrateController.MediaSourceContainer>
 
         // Compute the bitrate allocation.
         List<SourceBitrateAllocation> sourceBitrateAllocations = allocate(bweBps, sortedEndpoints);
+        if (!sourceBitrateAllocations.isEmpty())
+        {
+            // If we're oversending, we only do it with a single stream, so check the first
+            // one we're forwarding and see if it required and oversend.  Note: this is not
+            // as flexible as adding up the bitrates and seeing if they exceed the bwe, but
+            // it's more efficient than summing them all up.
+            if (sourceBitrateAllocations.get(0).oversending)
+            {
+                oversendingTimeTracker.startedOversending();
+                oversending = true;
+            }
+            else
+            {
+                oversendingTimeTracker.stoppedOversending();
+                oversending = false;
+            }
+        }
 
         // Update the the controllers based on the allocation and send a
         // notification to the client the set of forwarded endpoints has
@@ -851,15 +868,8 @@ public class BitrateController<T extends BitrateController.MediaSourceContainer>
                         sourceBitrateAllocation.ratedTargetIdx < 0 &&
                         !BitrateControllerConfig.enableOnstageVideoSuspend())
                 {
-                    oversendingTimeTracker.startedOversending();
-                    oversending = true;
                     sourceBitrateAllocation.ratedTargetIdx = 0;
                     sourceBitrateAllocation.oversending = true;
-                }
-                else if (i == 0)
-                {
-                    oversendingTimeTracker.stoppedOversending();
-                    oversending = false;
                 }
                 maxBandwidth -= sourceBitrateAllocation.getTargetBitrate();
 

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -419,7 +419,7 @@ public class BitrateController<T extends BitrateController.MediaSourceContainer>
         debugState.put("lastN", lastN);
         debugState.put("supportsRtx", supportsRtx);
         debugState.put("oversending", oversending);
-        debugState.put("total_oversending_time_secs", oversendingTimeTracker.getTotalOversendingTime().getSeconds());
+        debugState.put("total_oversending_time_secs", oversendingTimeTracker.totalOversendingTime().getSeconds());
         JSONObject adaptiveSourceProjectionsJson = new JSONObject();
         for (Map.Entry<Long, AdaptiveSourceProjection> entry : adaptiveSourceProjectionMap.entrySet())
         {
@@ -1082,7 +1082,7 @@ public class BitrateController<T extends BitrateController.MediaSourceContainer>
 
     public Duration getTotalOversendingTime()
     {
-        return this.oversendingTimeTracker.getTotalOversendingTime();
+        return this.oversendingTimeTracker.totalOversendingTime();
     }
 
     /**

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -282,6 +282,12 @@ public class BitrateController<T extends BitrateController.MediaSourceContainer>
     private Instant lastUpdateTime = Instant.MIN;
 
     /**
+     * Whether or not we are knowingly oversending (due to enableOnstageVideoSuspend being
+     * false)
+     */
+    private boolean oversending = false;
+
+    /**
      * Initializes a new {@link BitrateController} instance which is to
      * belong to a particular {@link Endpoint}.
      */
@@ -410,6 +416,7 @@ public class BitrateController<T extends BitrateController.MediaSourceContainer>
         debugState.put("effectiveVideoConstraints", effectiveConstraintsMap);
         debugState.put("lastN", lastN);
         debugState.put("supportsRtx", supportsRtx);
+        debugState.put("oversending", oversending);
         JSONObject adaptiveSourceProjectionsJson = new JSONObject();
         for (Map.Entry<Long, AdaptiveSourceProjection> entry : adaptiveSourceProjectionMap.entrySet())
         {
@@ -841,8 +848,13 @@ public class BitrateController<T extends BitrateController.MediaSourceContainer>
                         sourceBitrateAllocation.ratedTargetIdx < 0 &&
                         !BitrateControllerConfig.enableOnstageVideoSuspend())
                 {
+                    oversending = true;
                     sourceBitrateAllocation.ratedTargetIdx = 0;
                     sourceBitrateAllocation.oversending = true;
+                }
+                else if (i == 0)
+                {
+                    oversending = false;
                 }
                 maxBandwidth -= sourceBitrateAllocation.getTargetBitrate();
 

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -1080,6 +1080,11 @@ public class BitrateController<T extends BitrateController.MediaSourceContainer>
         return this.oversending;
     }
 
+    public Duration getTotalOversendingTime()
+    {
+        return this.oversendingTimeTracker.getTotalOversendingTime();
+    }
+
     /**
      * A snapshot of the bitrate for a given {@link RtpLayerDesc}.
      */

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -287,6 +287,8 @@ public class BitrateController<T extends BitrateController.MediaSourceContainer>
      */
     private boolean oversending = false;
 
+    private final OversendingTimeTracker oversendingTimeTracker = new OversendingTimeTracker();
+
     /**
      * Initializes a new {@link BitrateController} instance which is to
      * belong to a particular {@link Endpoint}.
@@ -417,6 +419,7 @@ public class BitrateController<T extends BitrateController.MediaSourceContainer>
         debugState.put("lastN", lastN);
         debugState.put("supportsRtx", supportsRtx);
         debugState.put("oversending", oversending);
+        debugState.put("total_oversending_time_secs", oversendingTimeTracker.getTotalOversendingTime().getSeconds());
         JSONObject adaptiveSourceProjectionsJson = new JSONObject();
         for (Map.Entry<Long, AdaptiveSourceProjection> entry : adaptiveSourceProjectionMap.entrySet())
         {
@@ -848,12 +851,14 @@ public class BitrateController<T extends BitrateController.MediaSourceContainer>
                         sourceBitrateAllocation.ratedTargetIdx < 0 &&
                         !BitrateControllerConfig.enableOnstageVideoSuspend())
                 {
+                    oversendingTimeTracker.startedOversending();
                     oversending = true;
                     sourceBitrateAllocation.ratedTargetIdx = 0;
                     sourceBitrateAllocation.oversending = true;
                 }
                 else if (i == 0)
                 {
+                    oversendingTimeTracker.stoppedOversending();
                     oversending = false;
                 }
                 maxBandwidth -= sourceBitrateAllocation.getTargetBitrate();

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/BitrateController.java
@@ -1060,6 +1060,11 @@ public class BitrateController<T extends BitrateController.MediaSourceContainer>
         return this.forwardedEndpointIds.size();
     }
 
+    public boolean isOversending()
+    {
+        return this.oversending;
+    }
+
     /**
      * A snapshot of the bitrate for a given {@link RtpLayerDesc}.
      */

--- a/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -235,6 +235,9 @@ public class VideobridgeStatistics
         int receiveOnlyEndpoints = 0;
         int numAudioSenders = 0;
         int numVideoSenders = 0;
+        // The amount of endpoints to which we're "oversending" (which can occur when
+        // enableOnstageVideoSuspend is false)
+        int numOversending = 0;
 
         for (Conference conference : videobridge.getConferences())
         {
@@ -279,6 +282,10 @@ public class VideobridgeStatistics
             }
             for (Endpoint endpoint : conference.getLocalEndpoints())
             {
+                if (endpoint.isOversending())
+                {
+                    numOversending++;
+                }
                 boolean sendingAudio = endpoint.isSendingAudio();
                 boolean sendingVideo = endpoint.isSendingVideo();
                 if (sendingAudio)
@@ -453,6 +460,7 @@ public class VideobridgeStatistics
                 "stress_level",
                 jvbStats.stressLevel
             );
+            unlockedSetStat("num_eps_oversending", numOversending);
             unlockedSetStat(CONFERENCES, conferences);
             unlockedSetStat(OCTO_CONFERENCES, octoConferences);
             unlockedSetStat(INACTIVE_CONFERENCES, inactiveConferences);

--- a/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -235,7 +235,7 @@ public class VideobridgeStatistics
         int receiveOnlyEndpoints = 0;
         int numAudioSenders = 0;
         int numVideoSenders = 0;
-        // The amount of endpoints to which we're "oversending" (which can occur when
+        // The number of endpoints to which we're "oversending" (which can occur when
         // enableOnstageVideoSuspend is false)
         int numOversending = 0;
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/OversendingTimeTracker.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/OversendingTimeTracker.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.cc
+
+import org.jitsi.nlj.util.NEVER
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+
+class OversendingTimeTracker(
+    private val clock: Clock = Clock.systemUTC()
+) {
+    var totalOversendingTime: Duration = Duration.ofMillis(0)
+        private set
+    private var mostRecentStartOversendingTimestamp: Instant = NEVER
+    private var currentlyOversending: Boolean = false
+
+    fun startedOversending() {
+        if (!currentlyOversending) {
+            currentlyOversending = true
+            mostRecentStartOversendingTimestamp = clock.instant()
+        }
+    }
+
+    fun stoppedOversending() {
+        if (currentlyOversending) {
+            currentlyOversending = false
+            totalOversendingTime += Duration.between(mostRecentStartOversendingTimestamp, clock.instant())
+        }
+    }
+}

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/OversendingTimeTrackerTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/OversendingTimeTrackerTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.cc
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.jitsi.test.time.FakeClock
+import org.jitsi.utils.secs
+import java.time.Duration
+
+class OversendingTimeTrackerTest : ShouldSpec() {
+    private val clock = FakeClock()
+    private val oversendingTracker = OversendingTimeTracker(clock)
+
+    init {
+        context("OversendingTimeTracker") {
+            should("start with a time of 0") {
+                oversendingTracker.totalOversendingTime() shouldBe Duration.ofSeconds(0)
+            }
+            context("when oversending starts") {
+                oversendingTracker.startedOversending()
+                should("increment the oversending time") {
+                    clock.elapse(5.secs)
+                    oversendingTracker.totalOversendingTime() shouldBe 5.secs
+                    clock.elapse(5.secs)
+                    oversendingTracker.totalOversendingTime() shouldBe 10.secs
+                }
+                context("and then stops") {
+                    clock.elapse(5.secs)
+                    oversendingTracker.stoppedOversending()
+                    should("have the correct time") {
+                        oversendingTracker.totalOversendingTime() shouldBe 15.secs
+                    }
+                    context("and time elapses") {
+                        clock.elapse(5.secs)
+                        should("not increase the time") {
+                            oversendingTracker.totalOversendingTime() shouldBe 15.secs
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds two forms of an 'oversending' stat:

It adds a Videobridge stat which counts the total number of endpoints we're currently "oversending" to, as well as a debug state that shows the total oversending time for an endpoint.

Note that this definition of "oversending" is "knowingly oversending" due to `enableOnstateVideoSuspension` being false (so we always force 1 on-stage video stream).

I'm not ecstatic about the implementation of the videobridge stat--I find it odd that `VideobridgeStatistics.java` has to knowingly request all the stats it wants--but I think we already had some plans to clean that up so I did what seemed consistent with the others.