### PR TITLE
Debug rest changes

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/Debug.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/Debug.java
@@ -60,6 +60,35 @@ public class Debug
     // Functions to enable or disable features
 
     /**
+     * Set the state of a given JVB feature
+     * @param feature the feature to enable or disable
+     * @param enabled whether the feature should be enabled
+     * @return HTTP response
+     */
+    @POST
+    @Path("/features/jvb/{feature}/{enabled}")
+    public Response setJvbFeatureState(
+        @PathParam("feature") DebugFeatures feature,
+        @PathParam("enabled") Boolean enabled)
+    {
+        logger.info((enabled ? "Enabling" : "Disabling") + " feature " + feature.getValue());
+        setFeature(feature, enabled);
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/features/jvb/{feature}/{enabled}")
+    public Response setJvbFeatureState2(
+        @PathParam("feature") DebugFeatures feature,
+        @PathParam("enabled") Boolean enabled)
+    {
+        System.out.println("Here with get instead of post!");
+        logger.info((enabled ? "Enabling" : "Disabling") + " feature " + feature.getValue());
+        setFeature(feature, enabled);
+        return Response.ok().build();
+    }
+
+    /**
      * Find out whether the given JVB feature is currently enabled or disabled
      * @param feature the feature to check
      * @return true if the feature is enabled, false otherwise
@@ -97,23 +126,6 @@ public class Debug
                 throw new NotFoundException();
             }
         }
-    }
-
-    /**
-     * Set the state of a given JVB feature
-     * @param feature the feature to enable or disable
-     * @param enabled whether the feature should be enabled
-     * @return HTTP response
-     */
-    @POST
-    @Path("/features/jvb/{feature}/{enabled}")
-    public Response setJvbFeatureState(
-        @PathParam("feature") DebugFeatures feature,
-        @PathParam("enabled") Boolean enabled)
-    {
-        logger.info((enabled ? "Enabling" : "Disabling") + " feature " + feature.getValue());
-        setFeature(feature, enabled);
-        return Response.ok().build();
     }
 
     @POST
@@ -276,62 +288,6 @@ public class Debug
     {
         // Redirect to the new location
         String newTarget = uriInfo.getBaseUri() + "debug/stats/jvb/" + featureName;
-        return Response.status(301).location(URI.create(newTarget)).build();
-    }
-
-    /**
-     * Deprecated, use {@link Debug#setJvbFeatureState(DebugFeatures, Boolean)}
-     * @param featureName feature name
-     * @param uriInfo UriInfo of the request
-     * @return HTTP response
-     */
-    @Deprecated
-    @POST
-    @Path("/enable/{feature_name:.+}")
-    public Response enableFeature(@PathParam("feature_name") String featureName, @Context UriInfo uriInfo)
-    {
-        String newTarget = uriInfo.getBaseUri() + "/features/jvb/" + featureName + "/true";
-        return Response.status(301).location(URI.create(newTarget)).build();
-    }
-
-    /**
-     * Depreacted, use {@link Debug#setJvbFeatureState(DebugFeatures, Boolean)}
-     * @param featureName feature name
-     * @param uriInfo UriInfo of the request
-     * @return HTTP response
-     */
-    @Deprecated
-    @POST
-    @Path("/disable/{feature_name:.+}")
-    public Response disableFeature(@PathParam("feature_name") String featureName, @Context UriInfo uriInfo)
-    {
-        String newTarget = uriInfo.getBaseUri() + "/features/jvb/" + featureName + "/false";
-        return Response.status(301).location(URI.create(newTarget)).build();
-    }
-
-    /**
-     * Deprecated, use {@link Debug#setEndpointFeatureState(String, String, EndpointDebugFeatures, Boolean)}
-     * @param confId the conference id
-     * @param epId the endpoint id
-     * @param featureName the Feature to enable or disable
-     * @param state the feature state in String form. Note that we don't rely on Jersey's automatic parsing here because
-     *              we want /debug/foo/bar/broken/ to return and HTTP 500 error and without the special handling
-     *              inside the method it returns 404.
-     * @return the Response
-     * @throws IllegalArgumentException when parsing the state fails.
-     */
-    @Deprecated
-    @POST
-    @Path("/{confId}/{epId}/{state}/{feature}")
-    public Response toggleEndpointFeature(
-        @PathParam("confId") String confId,
-        @PathParam("epId") String epId,
-        @PathParam("feature") String featureName,
-        @PathParam("state") String state,
-        @Context UriInfo uriInfo)
-    {
-        final boolean enabled = FeatureState.fromString(state) == FeatureState.ENABLE;
-        String newTarget = uriInfo.getBaseUri() + "features/endpoint/" + confId + "/" + epId + "/" + featureName + "/" + enabled;
-        return Response.status(301).location(URI.create(newTarget)).build();
+        return Response.status(302).location(URI.create(newTarget)).build();
     }
 }

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/Debug.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/Debug.java
@@ -56,16 +56,61 @@ public class Debug
 
     private final Logger logger = new LoggerImpl(Debug.class.getName());
 
+    /**
+     * Find out whether the given JVB feature is currently enabled or disabled
+     * @param feature the feature to check
+     * @return true if the feature is enabled, false otherwise
+     */
     @GET
-    @Path("/feature/{feature}")
-    public Boolean getFeatureState(@PathParam("feature") DebugFeatures feature)
+    @Path("/features/jvb/{feature}")
+    public Boolean getJvbFeatureState(@PathParam("feature") DebugFeatures feature)
     {
-        switch (feature) {
-
+        switch (feature)
+        {
+            case PAYLOAD_VERIFICATION: {
+                return Node.Companion.isPayloadVerificationEnabled();
+            }
+            case NODE_STATS: {
+                return StatsKeepingNode.Companion.getEnableStatistics();
+            }
+            case POOL_STATS: {
+                return ByteBufferPool.statisticsEnabled();
+            }
+            case QUEUE_STATS: {
+                return PacketQueue.getEnableStatisticsDefault();
+            }
+            case NODE_TRACING: {
+                return Node.Companion.isNodeTracingEnabled();
+            }
+            case TRANSIT_STATS: {
+                // Always enabled (worth modeling as a 'feature' then?)
+                return true;
+            }
+            case TASK_POOL_STATS: {
+                // Always enabled (worth modeling as a 'feature' then?)
+                return true;
+            }
             default: {
                 throw new NotFoundException();
             }
         }
+    }
+
+    /**
+     * Set the state of a given JVB feature
+     * @param feature the feature to enable or disable
+     * @param enabled whether the feature should be enabled
+     * @return HTTP response
+     */
+    @PUT
+    @Path("/features/jvb/{feature}/{enabled}")
+    public Response getJvbFeatureState(
+        @PathParam("feature") DebugFeatures feature,
+        @PathParam("enabled") Boolean enabled)
+    {
+        logger.info((enabled ? "Enabling" : "Disabling") + " feature " + feature.getValue());
+        setFeature(feature, enabled);
+        return Response.ok().build();
     }
 
     @POST

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/Debug.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/Debug.java
@@ -54,19 +54,18 @@ public class Debug
     @Inject
     private HealthCheckServiceSupplier healthCheckServiceSupplier;
 
-    private Logger logger = new LoggerImpl(Debug.class.getName());
+    private final Logger logger = new LoggerImpl(Debug.class.getName());
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    public String bridgeDebug(@DefaultValue("false") @QueryParam("full") boolean full)
+    @Path("/feature/{feature}")
+    public Boolean getFeatureState(@PathParam("feature") DebugFeatures feature)
     {
-        OrderedJsonObject debugState = videobridge.getDebugState(null, null, full);
+        switch (feature) {
 
-        // Append the health status.
-        Exception result = healthCheckServiceSupplier.get().getResult();
-        debugState.put("health", result == null ? "OK" : result.getMessage());
-
-        return debugState.toJSONString();
+            default: {
+                throw new NotFoundException();
+            }
+        }
     }
 
     @POST
@@ -171,6 +170,19 @@ public class Debug
                 throw new NotFoundException();
             }
         }
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public String bridgeDebug(@DefaultValue("false") @QueryParam("full") boolean full)
+    {
+        OrderedJsonObject debugState = videobridge.getDebugState(null, null, full);
+
+        // Append the health status.
+        Exception result = healthCheckServiceSupplier.get().getResult();
+        debugState.put("health", result == null ? "OK" : result.getMessage());
+
+        return debugState.toJSONString();
     }
 
     @GET

--- a/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
@@ -239,10 +239,9 @@ public class ByteBufferPool
     /**
      * Gets a JSON representation of the statistics about the pool.
      */
-    @SuppressWarnings("unchecked")
-    public static JSONObject getStatsJson()
+    public static OrderedJsonObject getStatsJson()
     {
-        JSONObject stats = new JSONObject();
+        OrderedJsonObject stats = new OrderedJsonObject();
         long numRequestsSum = numRequests.sum();
         long numLargeRequestsSum = numLargeRequests.sum();
         stats.put("outstanding_buffers", bookkeeping.size());

--- a/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
@@ -277,4 +277,10 @@ public class ByteBufferPool
         pool2.enableStatistics(enable);
         pool3.enableStatistics(enable);
     }
+
+    public static boolean statisticsEnabled()
+    {
+        return enableStatistics;
+    }
+
 }

--- a/jvb/src/test/java/org/jitsi/videobridge/rest/root/debug/DebugTest.java
+++ b/jvb/src/test/java/org/jitsi/videobridge/rest/root/debug/DebugTest.java
@@ -18,6 +18,8 @@ package org.jitsi.videobridge.rest.root.debug;
 
 import org.eclipse.jetty.http.*;
 import org.glassfish.hk2.utilities.binding.*;
+import org.glassfish.jersey.client.*;
+import org.glassfish.jersey.logging.*;
 import org.glassfish.jersey.server.*;
 import org.glassfish.jersey.test.*;
 import org.jitsi.health.*;
@@ -33,6 +35,8 @@ import javax.ws.rs.*;
 import javax.ws.rs.client.*;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.*;
+
+import java.util.logging.*;
 
 import static junit.framework.TestCase.*;
 import static org.junit.Assert.assertTrue;
@@ -71,6 +75,12 @@ public class DebugTest extends JerseyTest
         };
     }
 
+    @Override
+    protected void configureClient(ClientConfig config)
+    {
+        config.register(new LoggingFeature(Logger.getAnonymousLogger(), Level.ALL, LoggingFeature.Verbosity.HEADERS_ONLY, 1500));
+    }
+
     @Test
     public void testAllResourcesAreBehindConfig()
     {
@@ -93,7 +103,7 @@ public class DebugTest extends JerseyTest
     }
 
     @Test
-    public void testEnableDebugFeature()
+    public void testEnableJvbFeature()
     {
         Response resp = target(BASE_URL + "/features/jvb/" + DebugFeatures.PAYLOAD_VERIFICATION.getValue() + "/true")
                 .request()
@@ -102,65 +112,58 @@ public class DebugTest extends JerseyTest
     }
 
     @Test
-    public void testEnableEndpointDebugFeature()
-    {
-        Response resp = target(BASE_URL + "/foo/bar/enable/" + EndpointDebugFeatures.PCAP_DUMP.getValue())
-                .request()
-                .post(Entity.json(null));
-        assertEquals(HttpStatus.OK_200, resp.getStatus());
-    }
-
-    @Test
-    public void testEnableNonexistentDebugFeature()
-    {
-        Response resp = target(BASE_URL + "/features/jvb/blah/true")
-                .request()
-                .post(Entity.json(null));
-        assertEquals(HttpStatus.NOT_FOUND_404, resp.getStatus());
-    }
-
-    @Test
-    public void testDisableDebugFeature()
+    public void testDisableJvbFeature()
     {
         Response resp = target(BASE_URL + "/features/jvb/" + DebugFeatures.PAYLOAD_VERIFICATION.getValue() + "/false")
-                .request()
-                .post(Entity.json(null));
+            .request()
+            .post(Entity.json(null));
         assertEquals(HttpStatus.OK_200, resp.getStatus());
     }
 
-    @Test
-    public void testDisableEndpointDebugFeature()
-    {
-        Response resp = target(BASE_URL + "/foo/bar/disable/" + EndpointDebugFeatures.PCAP_DUMP.getValue())
-                .request()
-                .post(Entity.json(null));
-        assertEquals(HttpStatus.OK_200, resp.getStatus());
-    }
 
     @Test
-    public void testInvalidEndpointDebugFeature()
+    public void testEnableNonexistentJvbFeature()
     {
-        Response resp = target(BASE_URL + "/foo/broken/disable/" + EndpointDebugFeatures.PCAP_DUMP.getValue())
-                .request()
-                .post(Entity.json(null));
+        Response resp = target(BASE_URL + "/features/jvb/blah/true")
+            .request()
+            .post(Entity.json(null));
         assertEquals(HttpStatus.NOT_FOUND_404, resp.getStatus());
     }
 
     @Test
-    public void testInvalidEndpointDebugFeatureState()
-    {
-        Response resp = target(BASE_URL + "/foo/bar/broken/" + EndpointDebugFeatures.PCAP_DUMP.getValue())
-                .request()
-                .post(Entity.json(null));
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR_500, resp.getStatus());
-    }
-
-    @Test
-    public void testDisableNonexistentDebugFeature()
+    public void testDisableNonexistentJvbFeature()
     {
         Response resp = target(BASE_URL + "/features/jvb/blah/false")
+            .request()
+            .post(Entity.json(null));
+        assertEquals(HttpStatus.NOT_FOUND_404, resp.getStatus());
+    }
+
+    @Test
+    public void testEnableEndpointFeature()
+    {
+        Response resp = target(BASE_URL + "/features/endpoint/foo/bar/" + EndpointDebugFeatures.PCAP_DUMP.getValue() + "/true")
+                .request()
+                .post(Entity.json(null));
+        assertEquals(HttpStatus.OK_200, resp.getStatus());
+    }
+
+    @Test
+    public void testDisableEndpointFeature()
+    {
+        Response resp = target(BASE_URL + "/features/endpoint/foo/bar/" + EndpointDebugFeatures.PCAP_DUMP.getValue() + "/false")
+                .request()
+                .post(Entity.json(null));
+        assertEquals(HttpStatus.OK_200, resp.getStatus());
+    }
+
+    @Test
+    public void testDisableInvalidEndpointFeature()
+    {
+        Response resp = target(BASE_URL + "/features/endpoint/foo/bar/nonexistent/false")
                 .request()
                 .post(Entity.json(null));
         assertEquals(HttpStatus.NOT_FOUND_404, resp.getStatus());
     }
+
 }

--- a/jvb/src/test/java/org/jitsi/videobridge/rest/root/debug/DebugTest.java
+++ b/jvb/src/test/java/org/jitsi/videobridge/rest/root/debug/DebugTest.java
@@ -97,7 +97,7 @@ public class DebugTest extends JerseyTest
     @Test
     public void testEnableDebugFeature()
     {
-        Response resp = target(BASE_URL + "/enable/" + DebugFeatures.PAYLOAD_VERIFICATION.getValue())
+        Response resp = target(BASE_URL + "/features/jvb/" + DebugFeatures.PAYLOAD_VERIFICATION.getValue() + "/true")
                 .request()
                 .post(Entity.json(null));
         assertEquals(HttpStatus.OK_200, resp.getStatus());
@@ -115,7 +115,7 @@ public class DebugTest extends JerseyTest
     @Test
     public void testEnableNonexistentDebugFeature()
     {
-        Response resp = target(BASE_URL + "/enable/blah")
+        Response resp = target(BASE_URL + "/features/jvb/blah/true")
                 .request()
                 .post(Entity.json(null));
         assertEquals(HttpStatus.NOT_FOUND_404, resp.getStatus());
@@ -124,7 +124,7 @@ public class DebugTest extends JerseyTest
     @Test
     public void testDisableDebugFeature()
     {
-        Response resp = target(BASE_URL + "/disable/" + DebugFeatures.PAYLOAD_VERIFICATION.getValue())
+        Response resp = target(BASE_URL + "/features/jvb/" + DebugFeatures.PAYLOAD_VERIFICATION.getValue() + "/false")
                 .request()
                 .post(Entity.json(null));
         assertEquals(HttpStatus.OK_200, resp.getStatus());
@@ -160,7 +160,7 @@ public class DebugTest extends JerseyTest
     @Test
     public void testDisableNonexistentDebugFeature()
     {
-        Response resp = target(BASE_URL + "/disable/blah")
+        Response resp = target(BASE_URL + "/features/jvb/blah/false")
                 .request()
                 .post(Entity.json(null));
         assertEquals(HttpStatus.NOT_FOUND_404, resp.getStatus());

--- a/jvb/src/test/java/org/jitsi/videobridge/rest/root/debug/DebugTest.java
+++ b/jvb/src/test/java/org/jitsi/videobridge/rest/root/debug/DebugTest.java
@@ -68,8 +68,6 @@ public class DebugTest extends JerseyTest
                 });
                 register(Debug.class);
             }
-
-
         };
     }
 


### PR DESCRIPTION
This PR *changes* the REST endpoints for accessing debug feature stats and changing their states (enabled or disabled). Redirects are added for the accessing endpoints, but not the changing ones (redirects don't seem to play nicely with preserving the HTTP methods).

We used to have:
```
POST /enable/{feature} - turns jvb {feature} on
POST /disable/{feature} - turns jvb {feature} off
POST /{confId}/{epId}/{state}/{feature} - turns endpoint {feature} on or off for a specific endpoint (currently only pcap)
GET  /stats/{feature} - gets the data for a jvb feature (redirect provided)
```

After this change, we now have:

```
POST /features/jvb/{feature}/{enabled} - set the state of jvb feature {feature} (where {enabled} is `true` or `false`)
POST /features/endpoint/{confid}/{epId}/{feature}/{enabled} - set the state of ep feature {feature}
GET  /stats/jvb/{feature} - get the data for jvb feature {feature}
GET  /features/jvb/{feature} - get the state of jvb feature {feature}
GET  /features/endpoint/{confid}/{epId}/{feature} - get the state of endpoint feature {feature}
```