### PR TITLE
Survival last n fixes

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/LastNReducer.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/LastNReducer.kt
@@ -99,7 +99,8 @@ class LastNReducer(
             logger.cdebug { "No recovery necessary, no JVB last-n is set" }
             return false
         }
-        val newLastN = (currLastN * recoverScale).toInt()
+        // We want to make sure the last-n value increases by at least 1
+        val newLastN = maxOf(currLastN + 1, (currLastN * recoverScale).toInt())
         if (newLastN >= maxEnforcedLastN) {
             logger.info(
                 "JVB last-n was $currLastN, increasing to $newLastN which is beyond the max enforced value" +

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -163,7 +163,7 @@ videobridge {
         # load
         impact-time = 1 minute
         # The lowest value we'll set for last-n
-        minimum-last-n-value = 0
+        minimum-last-n-value = 1
         # The highest last-n value we'll enforce.  Once the enforced last-n exceeds this value
         # we'll remove the limit entirely
         maximum-enforced-last-n-value = 40


### PR DESCRIPTION
This PR addresses 2 things:

1) Increases the minimum last-n value from 0 to 1.  This is more in line with the fact that we, by default, always allow the on-stage participant be forwarded, so we won't run into any weird conflicts between survival last n and that code

2) Fixes an issue with recovery: before, we'd increase the current last-n value by the configured recovery scale but for small numbers (especially 0...) this can result in the increase being too small to reach the next integer, so the last-n value gets "stuck".  The second commit ensures we always increase the value by at least one when recovering.

I plan to merge the commits here without squashing.