### PR TITLE
Allow enabling/disabling buffer pool bookkeeping via (private) REST API

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/Debug.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/Debug.java
@@ -108,6 +108,9 @@ public class Debug
             case POOL_STATS: {
                 return ByteBufferPool.statisticsEnabled();
             }
+            case POOL_BOOKKEEPING: {
+                return ByteBufferPool.bookkeepingEnabled();
+            }
             case QUEUE_STATS: {
                 return PacketQueue.getEnableStatisticsDefault();
             }
@@ -205,6 +208,10 @@ public class Debug
             }
             case POOL_STATS: {
                 ByteBufferPool.enableStatistics(enabled);
+                break;
+            }
+            case POOL_BOOKKEEPING: {
+                ByteBufferPool.enableBookkeeping(enabled);
                 break;
             }
             case QUEUE_STATS: {

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/DebugFeatures.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/DebugFeatures.java
@@ -25,6 +25,7 @@ public enum DebugFeatures
     PAYLOAD_VERIFICATION("payload-verification"),
     NODE_STATS("node-stats"),
     POOL_STATS("pool-stats"),
+    POOL_BOOKKEEPING("pool-bookkeeping"),
     QUEUE_STATS("queue-stats"),
     TRANSIT_STATS("transit-stats"),
     TASK_POOL_STATS("task-pool-stats"),

--- a/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
@@ -284,6 +284,11 @@ public class ByteBufferPool
     public static void enableBookkeeping(boolean enable)
     {
         bookkeepingEnabled = enable;
+        if (!enable)
+        {
+            bookkeeping.clear();
+            returnedBookkeeping.clear();
+        }
     }
 
     public static boolean bookkeepingEnabled()

--- a/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
@@ -93,7 +93,7 @@ public class ByteBufferPool
     /**
      * Whether to enable or disable book keeping.
      */
-    public static Boolean enableBookkeeping = false;
+    private static Boolean bookkeepingEnabled = false;
 
     /**
      * Total number of buffers requested.
@@ -163,7 +163,7 @@ public class ByteBufferPool
             numLargeRequests.increment();
         }
 
-        if (enableBookkeeping)
+        if (bookkeepingEnabled)
         {
             int arrayId = System.identityHashCode(buf);
 
@@ -188,7 +188,7 @@ public class ByteBufferPool
 
         int len = buf.length;
 
-        if (enableBookkeeping)
+        if (bookkeepingEnabled)
         {
             int arrayId = System.identityHashCode(buf);
             logger.info("Thread " + threadId() + " returned " + len + "-byte buffer "
@@ -279,6 +279,16 @@ public class ByteBufferPool
     public static boolean statisticsEnabled()
     {
         return enableStatistics;
+    }
+
+    public static void enableBookkeeping(boolean enable)
+    {
+        bookkeepingEnabled = enable;
+    }
+
+    public static boolean bookkeepingEnabled()
+    {
+        return bookkeepingEnabled;
     }
 
 }

--- a/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
@@ -19,7 +19,6 @@ package org.jitsi.videobridge.util;
 import org.jetbrains.annotations.*;
 import org.jitsi.nlj.util.*;
 import org.jitsi.utils.logging2.*;
-import org.json.simple.*;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -94,7 +93,7 @@ public class ByteBufferPool
     /**
      * Whether to enable or disable book keeping.
      */
-    public static final Boolean ENABLE_BOOKKEEPING = false;
+    public static Boolean enableBookkeeping = false;
 
     /**
      * Total number of buffers requested.
@@ -164,7 +163,7 @@ public class ByteBufferPool
             numLargeRequests.increment();
         }
 
-        if (ENABLE_BOOKKEEPING)
+        if (enableBookkeeping)
         {
             int arrayId = System.identityHashCode(buf);
 
@@ -189,7 +188,7 @@ public class ByteBufferPool
 
         int len = buf.length;
 
-        if (ENABLE_BOOKKEEPING)
+        if (enableBookkeeping)
         {
             int arrayId = System.identityHashCode(buf);
             logger.info("Thread " + threadId() + " returned " + len + "-byte buffer "

--- a/jvb/src/main/java/org/jitsi/videobridge/util/PartitionedByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/PartitionedByteBufferPool.java
@@ -68,7 +68,7 @@ class PartitionedByteBufferPool
 
     /**
      * Whether to keep track of request/return rates and other basic statistics.
-     * As opposed to {@link ByteBufferPool#ENABLE_BOOKKEEPING} this has a
+     * As opposed to {@link ByteBufferPool#enableBookkeeping} this has a
      * relatively low overhead and can be kept on in production if necessary.
      */
     private boolean enableStatistics = false;
@@ -252,7 +252,7 @@ class PartitionedByteBufferPool
          */
         private byte[] getBuffer(int requiredSize)
         {
-            if (ByteBufferPool.ENABLE_BOOKKEEPING)
+            if (ByteBufferPool.enableBookkeeping)
             {
                 logger.info("partition " + id + " request number "
                         + (numRequests.sum() + 1) + ", pool has size "
@@ -281,7 +281,7 @@ class PartitionedByteBufferPool
             }
             else if (buf.length < requiredSize)
             {
-                if (ByteBufferPool.ENABLE_BOOKKEEPING)
+                if (ByteBufferPool.enableBookkeeping)
                 {
                     logger.info("Needed buffer of size " + requiredSize
                             + ", got size " + buf.length + " retrying");
@@ -315,7 +315,7 @@ class PartitionedByteBufferPool
                 numNoAllocationNeeded.increment();
             }
 
-            if (ByteBufferPool.ENABLE_BOOKKEEPING)
+            if (ByteBufferPool.enableBookkeeping)
             {
                 logger.info("got buffer " + System.identityHashCode(buf)
                         + " from thread " + Thread.currentThread().getId()
@@ -330,7 +330,7 @@ class PartitionedByteBufferPool
          */
         private void returnBuffer(@NotNull byte[] buf)
         {
-            if (ByteBufferPool.ENABLE_BOOKKEEPING)
+            if (ByteBufferPool.enableBookkeeping)
             {
                 logger.info("returned buffer " + System.identityHashCode(buf) +
                         " from thread " + Thread.currentThread().getId() + ", partition " + id +

--- a/jvb/src/main/java/org/jitsi/videobridge/util/PartitionedByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/PartitionedByteBufferPool.java
@@ -68,7 +68,7 @@ class PartitionedByteBufferPool
 
     /**
      * Whether to keep track of request/return rates and other basic statistics.
-     * As opposed to {@link ByteBufferPool#enableBookkeeping} this has a
+     * As opposed to {@link ByteBufferPool#bookkeepingEnabled()} this has a
      * relatively low overhead and can be kept on in production if necessary.
      */
     private boolean enableStatistics = false;
@@ -252,7 +252,7 @@ class PartitionedByteBufferPool
          */
         private byte[] getBuffer(int requiredSize)
         {
-            if (ByteBufferPool.enableBookkeeping)
+            if (ByteBufferPool.bookkeepingEnabled())
             {
                 logger.info("partition " + id + " request number "
                         + (numRequests.sum() + 1) + ", pool has size "
@@ -281,7 +281,7 @@ class PartitionedByteBufferPool
             }
             else if (buf.length < requiredSize)
             {
-                if (ByteBufferPool.enableBookkeeping)
+                if (ByteBufferPool.bookkeepingEnabled())
                 {
                     logger.info("Needed buffer of size " + requiredSize
                             + ", got size " + buf.length + " retrying");
@@ -315,7 +315,7 @@ class PartitionedByteBufferPool
                 numNoAllocationNeeded.increment();
             }
 
-            if (ByteBufferPool.enableBookkeeping)
+            if (ByteBufferPool.bookkeepingEnabled())
             {
                 logger.info("got buffer " + System.identityHashCode(buf)
                         + " from thread " + Thread.currentThread().getId()
@@ -330,7 +330,7 @@ class PartitionedByteBufferPool
          */
         private void returnBuffer(@NotNull byte[] buf)
         {
-            if (ByteBufferPool.enableBookkeeping)
+            if (ByteBufferPool.bookkeepingEnabled())
             {
                 logger.info("returned buffer " + System.identityHashCode(buf) +
                         " from thread " + Thread.currentThread().getId() + ", partition " + id +


### PR DESCRIPTION
This PR implements buffer pool "bookkeeping" as a "debug feature" which can be turned on and off using the existing private rest api.  The "get stats" path does not apply for this feature, as this feature doesn't maintain stats, just logs issues.  We could look at changing that, but I think that should probably be in a different PR anyhow.