### PR TITLE
Change BufferPool bookkeeping

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
@@ -72,7 +72,8 @@ public class ByteBufferPool
     private static final Map<byte[], Exception> bookkeeping
             = Collections.synchronizedMap(new IdentityHashMap<>());
 
-    private static final Map<byte[], Queue<BufferEvent>> bufferEvents = Collections.synchronizedMap(new IdentityHashMap<>());
+    private static final Map<byte[], Queue<BufferEvent>> bufferEvents =
+        Collections.synchronizedMap(new IdentityHashMap<>());
 
     private static class ReturnedBufferBookkeepingInfo
     {
@@ -195,7 +196,8 @@ public class ByteBufferPool
             int arrayId = System.identityHashCode(buf);
             Exception s;
             Exception stackTrace = new Exception();
-            bufferEvents.computeIfAbsent(buf, k -> new LinkedBlockingQueue<>()).add(new BufferEvent(BufferEvent.RETURN, System.currentTimeMillis(), stackTrace));
+            bufferEvents.computeIfAbsent(buf, k -> new LinkedBlockingQueue<>())
+                .add(new BufferEvent(BufferEvent.RETURN, System.currentTimeMillis(), stackTrace));
             if ((s = bookkeeping.remove(buf)) != null)
             {
                 returnedBookkeeping.put(buf, new ReturnedBufferBookkeepingInfo(s, stackTrace));

--- a/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
@@ -282,6 +282,7 @@ public class ByteBufferPool
         {
             outstandingBuffers.clear();
             returnedBuffers.clear();
+            bufferEvents.clear();
         }
     }
 

--- a/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
@@ -65,16 +65,16 @@ public class ByteBufferPool
      */
     private static final Logger logger = new LoggerImpl(ByteBufferPool.class.getName());
 
-    /**
-     * A debug data structure which tracks outstanding buffers and tracks from where (via
-     * a stack trace) they were requested and returned.
-     */
     private static final Set<byte[]> outstandingBuffers =
         Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
 
     private static final Set<byte[]> returnedBuffers =
         Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
 
+    /**
+     * A debug data structure which tracks all events (requests and returns) for a given
+     * buffer
+     */
     private static final Map<byte[], Queue<BufferEvent>> bufferEvents =
         Collections.synchronizedMap(new IdentityHashMap<>());
 

--- a/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
@@ -93,7 +93,7 @@ public class ByteBufferPool
     /**
      * Whether to enable or disable book keeping.
      */
-    private static Boolean bookkeepingEnabled = false;
+    private static Boolean bookkeepingEnabled = true;
 
     /**
      * Total number of buffers requested.
@@ -201,7 +201,7 @@ public class ByteBufferPool
             }
             else if ((b = returnedBookkeeping.get(arrayId)) != null)
             {
-                logger.info("Thread " + threadId()
+                logger.error("Thread " + threadId()
                     + " returned a previously-returned " + len + "-byte buffer at\n"
                     + UtilKt.getStackTrace() +
                     "previously returned at\n" +
@@ -209,7 +209,7 @@ public class ByteBufferPool
             }
             else
             {
-                logger.info("Thread " + threadId()
+                logger.error("Thread " + threadId()
                     + " returned a " + len + "-byte buffer we didn't give out from\n"
                     + UtilKt.getStackTrace());
             }

--- a/jvb/src/main/java/org/jitsi/videobridge/util/PartitionedByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/PartitionedByteBufferPool.java
@@ -270,13 +270,6 @@ class PartitionedByteBufferPool
          */
         private byte[] getBuffer(int requiredSize)
         {
-            if (ByteBufferPool.bookkeepingEnabled())
-            {
-                logger.info("partition " + id + " request number "
-                        + (numRequests.sum() + 1) + ", pool has size "
-                        + pool.size());
-            }
-
             if (enableStatistics)
             {
                 numRequests.increment();
@@ -333,12 +326,6 @@ class PartitionedByteBufferPool
                 numNoAllocationNeeded.increment();
             }
 
-            if (ByteBufferPool.bookkeepingEnabled())
-            {
-                logger.info("got buffer " + System.identityHashCode(buf)
-                        + " from thread " + Thread.currentThread().getId()
-                        + ", partition " + id + " now has size " + pool.size());
-            }
             return buf;
         }
 
@@ -348,14 +335,6 @@ class PartitionedByteBufferPool
          */
         private void returnBuffer(@NotNull byte[] buf)
         {
-            if (ByteBufferPool.bookkeepingEnabled())
-            {
-                logger.info("returned buffer " + System.identityHashCode(buf) +
-                        " from thread " + Thread.currentThread().getId() + ", partition " + id +
-                        " now has size " + pool.size());
-
-            }
-
             if (enableStatistics)
             {
                 numReturns.increment();

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
@@ -23,6 +23,7 @@ import org.jitsi.cmd.CmdLine
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.MetaconfigLogger
 import org.jitsi.metaconfig.MetaconfigSettings
+import org.jitsi.nlj.transform.node.Node
 import org.jitsi.rest.JettyBundleActivatorConfig
 import org.jitsi.rest.createServer
 import org.jitsi.rest.enableCors
@@ -49,6 +50,11 @@ import org.jitsi.videobridge.websocket.singleton as webSocketServiceSingleton
 fun main(args: Array<String>) {
     val cmdLine = CmdLine().apply { parse(args) }
     val logger = LoggerImpl("org.jitsi.videobridge.Main")
+
+    logger.info("Enabling Node tracing")
+    Node.enableNodeTracing(true)
+    logger.info("Enabling payload verification")
+    Node.enablePayloadVerification(true)
 
     setupMetaconfigLogger()
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
@@ -23,8 +23,6 @@ import org.jitsi.cmd.CmdLine
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.MetaconfigLogger
 import org.jitsi.metaconfig.MetaconfigSettings
-import org.jitsi.nlj.transform.node.Node
-import org.jitsi.nlj.transform.node.debug.BufferTracePlugin
 import org.jitsi.rest.JettyBundleActivatorConfig
 import org.jitsi.rest.createServer
 import org.jitsi.rest.enableCors
@@ -40,7 +38,6 @@ import org.jitsi.videobridge.stats.MucStatsTransport
 import org.jitsi.videobridge.stats.StatsCollector
 import org.jitsi.videobridge.stats.VideobridgeStatistics
 import org.jitsi.videobridge.stats.callstats.CallstatsService
-import org.jitsi.videobridge.util.ByteBufferPool
 import org.jitsi.videobridge.util.TaskPools
 import org.jitsi.videobridge.version.JvbVersionService
 import org.jitsi.videobridge.websocket.ColibriWebSocketService
@@ -52,15 +49,6 @@ import org.jitsi.videobridge.websocket.singleton as webSocketServiceSingleton
 fun main(args: Array<String>) {
     val cmdLine = CmdLine().apply { parse(args) }
     val logger = LoggerImpl("org.jitsi.videobridge.Main")
-
-    logger.info("Enabling Node tracing")
-    Node.enableNodeTracing(true)
-    logger.info("Enabling payload verification")
-    Node.enablePayloadVerification(true)
-//    logger.info("Adding buffer trace plugin")
-//    Node.plugins.add(BufferTracePlugin)
-    logger.info("Enabling pool stats")
-    ByteBufferPool.enableStatistics(true)
 
     setupMetaconfigLogger()
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
@@ -24,6 +24,7 @@ import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.MetaconfigLogger
 import org.jitsi.metaconfig.MetaconfigSettings
 import org.jitsi.nlj.transform.node.Node
+import org.jitsi.nlj.transform.node.debug.BufferTracePlugin
 import org.jitsi.rest.JettyBundleActivatorConfig
 import org.jitsi.rest.createServer
 import org.jitsi.rest.enableCors
@@ -39,6 +40,7 @@ import org.jitsi.videobridge.stats.MucStatsTransport
 import org.jitsi.videobridge.stats.StatsCollector
 import org.jitsi.videobridge.stats.VideobridgeStatistics
 import org.jitsi.videobridge.stats.callstats.CallstatsService
+import org.jitsi.videobridge.util.ByteBufferPool
 import org.jitsi.videobridge.util.TaskPools
 import org.jitsi.videobridge.version.JvbVersionService
 import org.jitsi.videobridge.websocket.ColibriWebSocketService
@@ -55,6 +57,10 @@ fun main(args: Array<String>) {
     Node.enableNodeTracing(true)
     logger.info("Enabling payload verification")
     Node.enablePayloadVerification(true)
+//    logger.info("Adding buffer trace plugin")
+//    Node.plugins.add(BufferTracePlugin)
+    logger.info("Enabling pool stats")
+    ByteBufferPool.enableStatistics(true)
 
     setupMetaconfigLogger()
 


### PR DESCRIPTION
While trying to track down some buffer issues, I found that we were hitting hash collisions using `System.identityHashCode` on buffers as a key in our bookkeeping.  @JonathanLennox found `IdentityHashMap` which uses a combination of `identityHashCode` and equality to compare and that has fared better, so this PR changes the BufferPool bookkeeping structures to use `IdentityHashMap`.

I also found that we can just store an `Exception` of the stacktraces and expand it into a `String` only when needed, which appears to give a performance boost, so this PR changes the tracking to use `Exception` instead of `String`.

We also used to log on every buffer request and return, but that didn't give a complete picture and was very chatty.  I changed it to instead track a timeline per buffer of all requests and returns which makes tracking down issues easier.

The intermittent commits here were due to some debugging and are completely "undone", so the best way to view this would be to view the entire diff (not commit by commit).  I'll be getting rid of those commit messages when merging.