### PR TITLE
Fix scenario where endpoint connection status can get stuck on 'inactive'

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/EndpointConnectionStatusMonitor.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/EndpointConnectionStatusMonitor.kt
@@ -85,6 +85,9 @@ class EndpointConnectionStatusMonitor @JvmOverloads constructor(
                     "${endpoint.id} is having trouble establishing the connection " +
                         "and will be marked as inactive"
                 }
+                synchronized(inactiveEndpointIds) {
+                    inactiveEndpointIds += endpoint.id
+                }
                 notifyStatusChange(endpoint.id, false, null)
                 return
             } else {

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/EndpointConnectionStatusMonitorTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/EndpointConnectionStatusMonitorTest.kt
@@ -104,9 +104,14 @@ class EndpointConnectionStatusMonitorTest : ShouldSpec({
                     broadcastCalls shouldHaveSize 2
                     broadcastCalls.forAny { (msg, sendToOcto) ->
                         sendToOcto && msg.endpoint == "1" && msg.active == "false"
+                        sendToOcto shouldBe true
+                        msg.endpoint shouldBe "1"
+                        msg.active shouldBe "false"
                     }
                     broadcastCalls.forAny { (msg, sendToOcto) ->
-                        sendToOcto && msg.endpoint == "2" && msg.active == "false"
+                        sendToOcto shouldBe true
+                        msg.endpoint shouldBe "2"
+                        msg.active shouldBe "false"
                     }
                 }
                 context("and then become active") {
@@ -153,10 +158,14 @@ class EndpointConnectionStatusMonitorTest : ShouldSpec({
                     sendMessageCalls.shouldBeEmpty()
                     broadcastCalls shouldHaveSize 2
                     broadcastCalls.forAny { (msg, sendToOcto) ->
-                        sendToOcto && msg.endpoint == "1" && msg.active == "false"
+                        sendToOcto shouldBe true
+                        msg.endpoint shouldBe "1"
+                        msg.active shouldBe "false"
                     }
                     broadcastCalls.forAny { (msg, sendToOcto) ->
-                        sendToOcto && msg.endpoint == "2" && msg.active == "false"
+                        sendToOcto shouldBe true
+                        msg.endpoint shouldBe "2"
+                        msg.active shouldBe "false"
                     }
                 }
                 context("but then one becomes active") {

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/EndpointConnectionStatusMonitorTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/EndpointConnectionStatusMonitorTest.kt
@@ -109,6 +109,28 @@ class EndpointConnectionStatusMonitorTest : ShouldSpec({
                         sendToOcto && msg.endpoint == "2" && msg.active == "false"
                     }
                 }
+                context("and then become active") {
+                    clock.elapse(30.secs)
+                    eps.forEach {
+                        every { it.lastIncomingActivity } returns clock.instant()
+                    }
+                    executor.runOne()
+                    should("fire broadcast active events for the local endpoints") {
+                        sendMessageCalls.shouldBeEmpty()
+                        // 2 from the messages when it went inactive, and 2 more now for going active
+                        broadcastCalls shouldHaveSize 4
+                        broadcastCalls.forAny { (msg, sendToOcto) ->
+                            sendToOcto shouldBe true
+                            msg.endpoint shouldBe "1"
+                            msg.active shouldBe "true"
+                        }
+                        broadcastCalls.forAny { (msg, sendToOcto) ->
+                            sendToOcto shouldBe true
+                            msg.endpoint shouldBe "2"
+                            msg.active shouldBe "true"
+                        }
+                    }
+                }
             }
         }
         context("when the endpoints have had activity") {


### PR DESCRIPTION
@paweldomas noticed a scenario where, if the first time the `EndpointConnectionStatusMonitor` checked a given endpoint's status and it had no activity at that time, we would notify endpoints that it was inactive but not _track_ it as having been marked as inactive in the bridge, so we'd never send an update when it went active (since the bridge didn't remember it had been marked as inactive).


I still need to look over this a bit more, but so far the unit test seems to confirm the issue and the fix.  Putting it up so @paweldomas can take a look.