### PR TITLE
Added mute video moderation feature

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Endpoint.java
@@ -1360,6 +1360,8 @@ public class Endpoint
     public void updateForceMute()
     {
         boolean audioForcedMuted = false;
+        boolean videoForceMuted  = false;
+
         for (ChannelShim channelShim : channelShims)
         {
             if (!channelShim.allowIncomingMedia())
@@ -1370,13 +1372,14 @@ public class Endpoint
                         audioForcedMuted = true;
                         break;
                     case VIDEO:
-                        logger.warn(() -> "Tried to mute the incoming video stream, but that is not currently " +
-                            "supported");
+                        videoForceMuted  = true;
                         break;
                 }
             }
         }
+
         transceiver.forceMuteAudio(audioForcedMuted);
+        transceiver.forceMuteVideo(videoForceMuted);
     }
 
     /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/octo/config/OctoRtpReceiver.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/octo/config/OctoRtpReceiver.kt
@@ -171,6 +171,10 @@ class OctoRtpReceiver(
         // No op(?)
     }
 
+    override fun forceMuteVideo(shouldMute: Boolean) {
+        // noop
+    }
+
     override fun getPacketStreamStats(): PacketStreamStats.Snapshot {
         TODO("Not yet implemented")
     }

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-media-transform</artifactId>
-                <version>1.0-SNAPSHOT</version>
+                <version>1.0-214-gfc6cda2</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-media-transform</artifactId>
-                <version>1.0-214-gfc6cda2</version>
+                <version>1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
This change adds the ability for a moderator to deactivate the camera of other participants. The implementation uses the same approach that was implemented to mute audio of other participants.

This feature consists of multiple PRs:
- https://github.com/jitsi/jitsi-media-transform/pull/327
- https://github.com/jitsi/jitsi-videobridge/pull/1569
- https://github.com/jitsi/jitsi-xmpp-extensions/pull/36
- https://github.com/jitsi/jicofo/pull/695
- https://github.com/jitsi/lib-jitsi-meet/pull/1496
- https://github.com/jitsi/jitsi-meet/pull/8630