### PR TITLE
update jmt to get dtls buffer leak fix

### DIFF
--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -443,6 +443,7 @@
           <jvmTarget>1.8</jvmTarget>
           <args>
             <arg>-Xallow-result-return-type</arg>
+            <arg>-Xopt-in=kotlin.ExperimentalStdlibApi</arg>
           </args>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-media-transform</artifactId>
-                <version>1.0-217-gf849e2d</version>
+                <version>1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
See https://github.com/jitsi/jitsi-media-transform/pull/330