### PR TITLE
Set Smack XMPP JID cache size on startup.

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
@@ -42,6 +42,8 @@ import org.jitsi.videobridge.util.TaskPools
 import org.jitsi.videobridge.version.JvbVersionService
 import org.jitsi.videobridge.websocket.ColibriWebSocketService
 import org.jitsi.videobridge.xmpp.XmppConnection
+import org.jitsi.videobridge.xmpp.config.XmppClientConnectionConfig
+import org.jxmpp.stringprep.XmppStringPrepUtil
 import kotlin.concurrent.thread
 import org.jitsi.videobridge.octo.singleton as octoRelayService
 import org.jitsi.videobridge.websocket.singleton as webSocketServiceSingleton
@@ -75,6 +77,8 @@ fun main(args: Array<String>) {
     JitsiConfig.reloadNewConfig()
 
     startIce4j()
+
+    XmppStringPrepUtil.setMaxCacheSizes(XmppClientConnectionConfig.jidCacheSize)
 
     val xmppConnection = XmppConnection().apply { start() }
     val shutdownService = ShutdownServiceImpl()

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/config/XmppClientConnectionConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/config/XmppClientConnectionConfig.kt
@@ -57,6 +57,15 @@ class XmppClientConnectionConfig {
         .map(StatsTransportConfig::interval)
         .findFirst()
         .orElse(presenceIntervalProperty)
+
+    companion object {
+        /**
+         * The size to set for Smack's JID cache
+         */
+        val jidCacheSize: Int by config {
+            "videobridge.apis.xmpp-client.jid-cache-size".from(JitsiConfig.newConfig)
+        }
+    }
 }
 
 /**

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -60,6 +60,9 @@ videobridge {
       # The interval at which presence is published in the configured MUCs.
       presence-interval = ${videobridge.stats.interval}
 
+      # The size of the Smack JID cache
+      jid-cache-size = 1000
+
       configs {
         # example-connection-id {
         #   For the properties which should be


### PR DESCRIPTION
Profiling shows us blowing out the Smack XMPP JID parsing cache in large conference tests -- the default cache size is only 100.  This increases it to something bigger than we're likely to need for JVBs for now.