### PR TITLE
reuse jackson object mapper instance

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/message/BridgeChannelMessage.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/message/BridgeChannelMessage.kt
@@ -69,10 +69,11 @@ sealed class BridgeChannelMessage(
     open fun toJson(): String = ObjectMapper().writeValueAsString(this)
 
     companion object {
+        private val mapper = jacksonObjectMapper()
         @JvmStatic
         @Throws(JsonProcessingException::class, JsonMappingException::class)
         fun parse(string: String): BridgeChannelMessage {
-            return jacksonObjectMapper().readValue(string)
+            return mapper.readValue(string)
         }
     }
 }


### PR DESCRIPTION
We saw this come up in our load test traces, and from the simple test I wrote it looks like it could be a decent win: Parsing 1000 EndpointMessages went from ~1 second with the old code to ~60ms.