### PR TITLE
feat: Handle Colibri requests asynchronously.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -236,17 +236,16 @@ public class Conference
                     // TODO: we can avoid reaching into Videobridge here by merging VideobridgeShim into ConferenceShim
                     long start = System.currentTimeMillis();
                     IQ response = videobridge.handleColibriConferenceIQ(this, request.getRequest());
-                    long end = System.currentTimeMillis() - request.getReceiveTime();
+                    long end = System.currentTimeMillis();
                     long processingDelay = end - start;
-                    request.getProcessingDelayStats().addDelay(processingDelay);
-
                     long totalDelay = end - request.getReceiveTime();
-                    if (totalDelay > 100)
-                    {
-                        logger.warn("Took " + totalDelay + " ms to handle IQ (processing took "
-                                + processingDelay + " ms): " + request.getRequest().toXML());
-                    }
+                    request.getProcessingDelayStats().addDelay(processingDelay);
                     request.getTotalDelayStats().addDelay(totalDelay);
+                    if (processingDelay > 100)
+                    {
+                        logger.warn("Took " + processingDelay + " ms to process an IQ (total delay "
+                                + totalDelay + " ms): " + request.getRequest().toXML());
+                    }
                     request.getCallback().invoke(response);
                 }
                 catch (Throwable e)

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -18,6 +18,7 @@ package org.jitsi.videobridge;
 import org.jetbrains.annotations.*;
 import org.jitsi.nlj.*;
 import org.jitsi.rtp.*;
+import org.jitsi.rtp.Packet;
 import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.*;
 import org.jitsi.rtp.rtp.*;
 import org.jitsi.utils.collections.*;
@@ -25,11 +26,15 @@ import org.jitsi.utils.logging.*;
 import org.jitsi.utils.logging2.Logger;
 import org.jitsi.utils.logging2.LoggerImpl;
 import org.jitsi.utils.logging2.*;
+import org.jitsi.utils.queue.*;
 import org.jitsi.videobridge.message.*;
 import org.jitsi.videobridge.octo.*;
 import org.jitsi.videobridge.shim.*;
 import org.jitsi.videobridge.util.*;
+import org.jitsi.videobridge.xmpp.*;
 import org.jitsi.xmpp.extensions.colibri.*;
+import org.jitsi.xmpp.util.*;
+import org.jivesoftware.smack.packet.*;
 import org.json.simple.*;
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.impl.*;
@@ -39,7 +44,6 @@ import java.io.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
-import java.util.stream.*;
 
 import static org.jitsi.utils.collections.JMap.*;
 
@@ -164,6 +168,8 @@ public class Conference
     @NotNull
     private final EndpointConnectionStatusMonitor epConnectionStatusMonitor;
 
+    private final PacketQueue<XmppConnection.ColibriRequest> colibriQueue;
+
     /**
      * Initializes a new <tt>Conference</tt> instance which is to represent a
      * conference in the terms of Jitsi Videobridge which has a specific
@@ -219,6 +225,35 @@ public class Conference
         videobridgeStatistics.totalConferencesCreated.incrementAndGet();
         epConnectionStatusMonitor = new EndpointConnectionStatusMonitor(this, TaskPools.SCHEDULED_POOL, logger);
         epConnectionStatusMonitor.start();
+
+        colibriQueue= new PacketQueue<>(
+            100,
+            true,
+            "colibri-queue-" + id,
+            request ->
+            {
+                try
+                {
+                    // TODO: we can avoid reaching into Videobridge here by merging VideobridgeShim into ConferenceShim
+                    IQ response = videobridge.handleColibriConferenceIQ(this, request.getRequest());
+                    long delay = System.currentTimeMillis() - request.getReceiveTime();
+                    if (delay > 100)
+                    {
+                        logger.warn("Took " + delay + " ms to handle IQ: " + request.getRequest().toXML());
+                    }
+                    request.getDelayStats().addDelay(delay);
+                    request.getCallback().invoke(response);
+                }
+                catch (Throwable e)
+                {
+                    logger.warn("Failed to handle colibri request: ", e);
+                    request.getCallback().invoke(
+                            IQUtils.createError(request.getRequest(), XMPPError.Condition.internal_server_error));
+                }
+                return true;
+            },
+            TaskPools.IO_POOL
+        );
     }
 
     /**
@@ -240,6 +275,11 @@ public class Conference
         {
             return new NoOpDiagnosticContext();
         }
+    }
+
+    public void enqueueColibriRequest(XmppConnection.ColibriRequest request)
+    {
+        colibriQueue.add(request);
     }
 
     /**
@@ -485,6 +525,8 @@ public class Conference
         }
 
         logger.info("Expiring.");
+
+        colibriQueue.close();
 
         epConnectionStatusMonitor.stop();
 

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -226,7 +226,7 @@ public class Conference
         epConnectionStatusMonitor = new EndpointConnectionStatusMonitor(this, TaskPools.SCHEDULED_POOL, logger);
         epConnectionStatusMonitor.start();
 
-        colibriQueue= new PacketQueue<>(
+        colibriQueue = new PacketQueue<>(
             100,
             true,
             "colibri-queue-" + id,
@@ -248,7 +248,10 @@ public class Conference
                 {
                     logger.warn("Failed to handle colibri request: ", e);
                     request.getCallback().invoke(
-                            IQUtils.createError(request.getRequest(), XMPPError.Condition.internal_server_error));
+                            IQUtils.createError(
+                                    request.getRequest(),
+                                    XMPPError.Condition.internal_server_error,
+                                    e.getMessage()));
                 }
                 return true;
             },

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -350,18 +350,101 @@ public class Videobridge
     }
 
     /**
-     * Handles a <tt>ColibriConferenceIQ</tt> stanza which represents a request.
-     *
-     * @param conferenceIQ the <tt>ColibriConferenceIQ</tt> stanza represents
-     * the request to handle
-     * @return an <tt>org.jivesoftware.smack.packet.IQ</tt> stanza which
-     * represents the response to the specified request or <tt>null</tt> to
-     * reply with <tt>feature-not-implemented</tt>
+     * Handles a COLIBRI request synchronously.
      */
-    public IQ handleColibriConferenceIQ(ColibriConferenceIQ conferenceIQ)
+    public IQ handleColibriConferenceIQ(ColibriConferenceIQ conferenceIq)
     {
-        return shim.handleColibriConferenceIQ(conferenceIQ);
+        return handleColibriConferenceIQ(null, conferenceIq);
     }
+
+    /**
+     * Handles a COLIBRI request synchronously.
+     * @param conference The conference which is the target of the request. If not provided ({@code null}, it will
+     * be retrieved or created based on the ID provided in request.
+     * @param conferenceIq The COLIBRI request.
+     * @return The response in the form of an {@link IQ}. It is either an error or a {@link ColibriConferenceIQ}.
+     */
+    public IQ handleColibriConferenceIQ(Conference conference, ColibriConferenceIQ conferenceIq)
+    {
+        if (conference == null)
+        {
+            try
+            {
+                conference = getOrCreateConference(conferenceIq);
+            }
+            catch (ConferenceNotFoundException e)
+            {
+                return IQUtils.createError(
+                        conferenceIq,
+                        XMPPError.Condition.bad_request,
+                        "Conference not found for ID: " + conferenceIq.getID());
+            }
+            catch (InGracefulShutdownException e)
+            {
+                return ColibriConferenceIQ.createGracefulShutdownErrorResponse(conferenceIq);
+            }
+        }
+
+        return shim.handleColibriConferenceIQ(conference, conferenceIq);
+    }
+
+    /**
+     * Handles a COLIBRI request asynchronously.
+     */
+    private void handleColibriRequest(XmppConnection.ColibriRequest request)
+    {
+        ColibriConferenceIQ conferenceIq = request.getRequest();
+        Conference conference;
+        try
+        {
+            conference = getOrCreateConference(conferenceIq);
+        }
+        catch (ConferenceNotFoundException e)
+        {
+            request.getCallback().invoke(
+                    IQUtils.createError(
+                            conferenceIq,
+                            XMPPError.Condition.bad_request,
+                            "Conference not found for ID: " + conferenceIq.getID()));
+            return;
+        }
+        catch (InGracefulShutdownException e)
+        {
+            request.getCallback().invoke(ColibriConferenceIQ.createGracefulShutdownErrorResponse(conferenceIq));
+            return;
+        }
+
+        // It is now the responsibility of Conference to send a response.
+        conference.enqueueColibriRequest(request);
+    }
+
+    private @NotNull Conference getOrCreateConference(ColibriConferenceIQ conferenceIq)
+            throws ConferenceNotFoundException, InGracefulShutdownException
+    {
+        String conferenceId = conferenceIq.getID();
+        if (conferenceId == null && isShutdownInProgress())
+        {
+            throw new InGracefulShutdownException();
+        }
+
+        if (conferenceId == null)
+        {
+            return createConference(conferenceIq.getName(), VideobridgeShim.parseGid(conferenceIq.getGID()));
+        }
+        else
+        {
+            Conference conference = getConference(conferenceId);
+            if (conference == null)
+            {
+                throw new ConferenceNotFoundException();
+            }
+            return conference;
+        }
+    }
+
+    private class ConferenceNotFoundException extends Exception {}
+    private class InGracefulShutdownException extends Exception {}
+
 
     /**
      * Handles <tt>HealthCheckIQ</tt> by performing health check on this
@@ -622,9 +705,9 @@ public class Videobridge
     {
         @NotNull
         @Override
-        public IQ colibriConferenceIqReceived(@NotNull ColibriConferenceIQ iq)
+        public void colibriConferenceIqReceived(@NotNull XmppConnection.ColibriRequest request)
         {
-            return handleColibriConferenceIQ(iq);
+            handleColibriRequest(request);
         }
 
         @NotNull
@@ -653,8 +736,6 @@ public class Videobridge
         {
             return handleHealthCheckIQ(iq);
         }
-
-
     }
 
     /**

--- a/jvb/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/shim/VideobridgeShim.java
@@ -248,37 +248,8 @@ public class VideobridgeShim
      * represents the response to the specified request or <tt>null</tt> to
      * reply with <tt>feature-not-implemented</tt>
      */
-    public IQ handleColibriConferenceIQ(
-            ColibriConferenceIQ conferenceIQ)
+    public IQ handleColibriConferenceIQ(Conference conference, ColibriConferenceIQ conferenceIQ)
     {
-        logger.debug(() -> "Got ColibriConferenceIq:\n" + conferenceIQ.toXML());
-
-        Conference conference;
-
-        String conferenceId = conferenceIQ.getID();
-        if (conferenceId == null)
-        {
-            if (videobridge.isShutdownInProgress())
-            {
-                return ColibriConferenceIQ.createGracefulShutdownErrorResponse(conferenceIQ);
-            }
-            else
-            {
-                conference = videobridge.createConference(conferenceIQ.getName(), parseGid(conferenceIQ.getGID()));
-            }
-        }
-        else
-        {
-            conference = videobridge.getConference(conferenceId);
-            if (conference == null)
-            {
-                return IQUtils.createError(
-                        conferenceIQ,
-                        XMPPError.Condition.bad_request,
-                        "Conference not found for ID: " + conferenceId);
-            }
-        }
-
         ConferenceShim conferenceShim = conference.getShim();
         ColibriConferenceIQ responseConferenceIQ = new ColibriConferenceIQ();
         conference.describeShallow(responseConferenceIQ);
@@ -427,7 +398,7 @@ public class VideobridgeShim
      * @return the GID parsed as a {@code long}, or
      * {@link Conference#GID_NOT_SET -1} on failure.
      */
-    private static long parseGid(String gidStr)
+    public static long parseGid(String gidStr)
     {
         long gid;
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
@@ -265,7 +265,7 @@ class XmppConnection : IQListener {
         @JvmStatic
         fun getStatsJson(): OrderedJsonObject = OrderedJsonObject().apply {
             put("colibri", colibriDelayStats.toJson())
-            put("colibri_processing", colibriProcessingDelayStats)
+            put("colibri_processing", colibriProcessingDelayStats.toJson())
             put("health", healthDelayStats.toJson())
             put("version", versionDelayStats.toJson())
         }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
@@ -25,6 +25,7 @@ import org.jitsi.xmpp.extensions.colibri.ColibriConferenceIQ
 import org.jitsi.xmpp.extensions.colibri.ShutdownIQ
 import org.jitsi.xmpp.extensions.health.HealthCheckIQ
 import org.jitsi.xmpp.mucclient.IQListener
+import org.jitsi.xmpp.mucclient.MucClient
 import org.jitsi.xmpp.mucclient.MucClientConfiguration
 import org.jitsi.xmpp.mucclient.MucClientManager
 import org.jitsi.xmpp.util.IQUtils
@@ -56,7 +57,8 @@ class XmppConnection : IQListener {
         if (running.compareAndSet(false, true)) {
             mucClientManager.apply {
                 registerIQ(HealthCheckIQ())
-                registerIQ(ColibriConferenceIQ())
+                // Colibri IQs are handled async.
+                registerIQ(ColibriConferenceIQ(), false)
                 registerIQ(Version())
                 registerIQ(ShutdownIQ.createForceShutdownIQ())
                 registerIQ(ShutdownIQ.createGracefulShutdownIQ())
@@ -153,30 +155,38 @@ class XmppConnection : IQListener {
     /**
      * Process an incoming IQ
      */
-    override fun handleIq(iq: IQ?): IQ? {
+    override fun handleIq(iq: IQ?, mucClient: MucClient): IQ? {
         if (iq == null) {
             return null
         }
         logger.cdebug { "RECV: ${iq.toXML()}" }
 
         return when (iq.type) {
-            IQ.Type.get, IQ.Type.set -> handleIqRequest(iq).also { logger.cdebug { "SENT: ${it.toXML() ?: "null"}" } }
+            IQ.Type.get, IQ.Type.set -> handleIqRequest(iq, mucClient).also {
+                logger.cdebug { "SENT: ${it?.toXML() ?: "null"}" }
+            }
             else -> null
         }
     }
 
-    private fun handleIqRequest(iq: IQ): IQ {
+    private fun handleIqRequest(iq: IQ, mucClient: MucClient): IQ? {
         val handler = eventHandler ?: return IQUtils.createError(
             iq,
             XMPPError.Condition.service_unavailable,
             "Service unavailable"
         )
-        return when (iq) {
+        val response = when (iq) {
             is Version -> measureDelay(versionDelayStats, { iq.toXML() }) {
                 handler.versionIqReceived(iq)
             }
-            is ColibriConferenceIQ -> measureDelay(colibriDelayStats, { iq.toXML() }) {
-                handler.colibriConferenceIqReceived(iq)
+            is ColibriConferenceIQ -> {
+                // Colibri IQs are handled async.
+                handler.colibriConferenceIqReceived(
+                    ColibriRequest(iq, colibriDelayStats) { response ->
+                        mucClient.sendStanza(response.setResponseTo(iq))
+                    }
+                )
+                null
             }
             is HealthCheckIQ -> measureDelay(healthDelayStats, { iq.toXML() }) {
                 handler.healthCheckIqReceived(iq)
@@ -186,11 +196,15 @@ class XmppConnection : IQListener {
                 XMPPError.Condition.service_unavailable,
                 "Unsupported IQ request ${iq.childElementName}"
             )
-        }.apply {
-            from = iq.to
-            stanzaId = iq.stanzaId
-            to = iq.from
         }
+
+        return response?.setResponseTo(iq)
+    }
+
+    private fun IQ.setResponseTo(request: IQ) = apply {
+        from = request.to
+        stanzaId = request.stanzaId
+        to = request.from
     }
 
     private fun <T> measureDelay(delayStats: DelayStats, context: () -> CharSequence, block: () -> T): T {
@@ -205,10 +219,26 @@ class XmppConnection : IQListener {
     }
 
     interface EventHandler {
-        fun colibriConferenceIqReceived(iq: ColibriConferenceIQ): IQ
+        fun colibriConferenceIqReceived(request: ColibriRequest)
         fun versionIqReceived(iq: Version): IQ
         fun healthCheckIqReceived(iq: HealthCheckIQ): IQ
     }
+
+    data class ColibriRequest(
+        /**
+         * The IQ which was received.
+         */
+        val request: ColibriConferenceIQ,
+        /**
+         * The [DelayStats] instance which is to be updated with the time it took to handle the request.
+         */
+        val delayStats: DelayStats,
+        val receiveTime: Long = System.currentTimeMillis(),
+        /**
+         * The callback to use to send the response.
+         */
+        val callback: (IQ) -> Unit
+    )
 
     companion object {
         private val FEATURES = arrayOf(

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <jetty.version>9.4.35.v20201120</jetty.version>
         <kotlin.version>1.3.72</kotlin.version>
         <kotest.version>4.1.3</kotest.version>
-        <jicoco.version>1.1-79-g6099be5</jicoco.version>
+        <jicoco.version>1.1-80-g6411afd</jicoco.version>
         <jitsi.utils.version>1.0-78-g5d25e9b</jitsi.utils.version>
         <maven-shade-plugin.version>3.2.2</maven-shade-plugin.version>
         <spotbugs.version>4.1.4</spotbugs.version>


### PR DESCRIPTION
This is somewhat awkward for two reasons:
1. We need to maintain the synchronous handling because of [COLIBRI over REST](https://github.com/jitsi/jitsi-videobridge/blob/master/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/conferences/Conferences.java#L171)
2. The existance of VideobridgeShim. I think we can just merge the remainder of it in ConferenceShim, but I'd rather not do the change right now.