### PR TITLE
handles spaces around hostname

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -27,7 +27,7 @@ case "$1" in
 
         # the default vars
         db_get jitsi-videobridge/jvb-hostname
-        JVB_HOSTNAME_IN="$RET"
+        JVB_HOSTNAME_IN=$(echo "$RET" | xargs echo -n)
 
         # generate config on new install or when we are reconfiguring
         # and all install is different than current one


### PR DESCRIPTION
(users doubleclick a host name and paste result in the installer)
how to reproduce ? install in a clean instance and add a space before the host name
Result:
https://community.jitsi.org/t/installation-problem-on-ubuntu-20-04-2-lts/94776