### PR TITLE
Improve performance of determining max height of receiver constraints

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -66,7 +66,7 @@ public abstract class AbstractEndpoint
     /**
      * The map of receiver endpoint id -> video constraints.
      */
-    private final Map<String, VideoConstraints> receiverVideoConstraintsMap = new ConcurrentHashMap<>();
+    private final ReceiverConstraintsMap receiverVideoConstraintsMap = new ReceiverConstraintsMap();
 
     /**
      * The (human readable) display name of this <tt>Endpoint</tt>.
@@ -320,6 +320,7 @@ public abstract class AbstractEndpoint
     public JSONObject getDebugState()
     {
         JSONObject debugState = new JSONObject();
+        // TODO(brian): add a .toMap or something to ReceiverConstraintsMap so we can add it to debug state
         debugState.put("receiverVideoConstraints", receiverVideoConstraintsMap);
         debugState.put("maxReceiverVideoConstraints", maxReceiverVideoConstraints);
         debugState.put("displayName", displayName);
@@ -333,25 +334,15 @@ public abstract class AbstractEndpoint
      * Computes and sets the {@link #maxReceiverVideoConstraints} from the
      * specified video constraints.
      *
-     * @param newVideoConstraints the map of receiver endpoint id -> video
-     * constraints that specifies who (which receiver endpoint) is viewing what
-     * (as determined by the video constraints) from this endpoint (which is the
-     * sender).
+     * @param newMaxHeight the maximum height resulting from the current set of constraints.
+     *                     (Currently we only support constraining the height, and not frame rate.)
      */
-    private void receiverVideoConstraintsChanged(
-        Collection<VideoConstraints> newVideoConstraints)
+    private void receiverVideoConstraintsChanged(int newMaxHeight)
     {
         VideoConstraints oldReceiverMaxVideoConstraints = this.maxReceiverVideoConstraints;
 
-        int maxHeight = newVideoConstraints
-            .stream()
-            .mapToInt(VideoConstraints::getMaxHeight)
-            .max()
-            .orElse(0);
 
-        // Currently we only support constraining the height, and not frame rate.
-
-        VideoConstraints newReceiverMaxVideoConstraints = new VideoConstraints(maxHeight, -1.0);
+        VideoConstraints newReceiverMaxVideoConstraints = new VideoConstraints(newMaxHeight, -1.0);
 
         if (!newReceiverMaxVideoConstraints.equals(oldReceiverMaxVideoConstraints))
         {
@@ -409,7 +400,7 @@ public abstract class AbstractEndpoint
         {
             logger.debug(
                 () -> "Changed receiver constraints: " + receiverId + ": " + newVideoConstraints.getMaxHeight());
-            receiverVideoConstraintsChanged(receiverVideoConstraintsMap.values());
+            receiverVideoConstraintsChanged(receiverVideoConstraintsMap.getMaxHeight());
         }
     }
 
@@ -425,7 +416,7 @@ public abstract class AbstractEndpoint
         if (receiverVideoConstraintsMap.remove(receiverId) != null)
         {
             logger.debug(() -> "Removed receiver " + receiverId);
-            receiverVideoConstraintsChanged(receiverVideoConstraintsMap.values());
+            receiverVideoConstraintsChanged(receiverVideoConstraintsMap.getMaxHeight());
         }
     }
 

--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -320,8 +320,7 @@ public abstract class AbstractEndpoint
     public JSONObject getDebugState()
     {
         JSONObject debugState = new JSONObject();
-        // TODO(brian): add a .toMap or something to ReceiverConstraintsMap so we can add it to debug state
-        debugState.put("receiverVideoConstraints", receiverVideoConstraintsMap);
+        debugState.put("receiverVideoConstraints", receiverVideoConstraintsMap.getDebugState());
         debugState.put("maxReceiverVideoConstraints", maxReceiverVideoConstraints);
         debugState.put("displayName", displayName);
         debugState.put("expired", expired);

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.cc.allocation
+
+/**
+ * A Map of Endpoint IDs to their receiver video constraints.  Tracks the max height of all
+ * of those constraints as new constraints are added and removed.
+ */
+class ReceiverConstraintsMap {
+    private val map = mutableMapOf<String, VideoConstraints>()
+    private val lock = Any()
+    var maxHeight: Int = 0
+        private set
+
+    fun put(key: String, value: VideoConstraints): VideoConstraints? {
+        synchronized(lock) {
+            if (maxHeight < value.maxHeight) {
+                maxHeight = value.maxHeight
+            }
+            return map.put(key, value)
+        }
+    }
+
+    fun remove(key: String): VideoConstraints? {
+        synchronized(lock) {
+            return map.remove(key)?.also { removed ->
+                if (removed.maxHeight == maxHeight) {
+                    maxHeight = map.values.map { it.maxHeight }.max() ?: 0
+                }
+            }
+        }
+    }
+}

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
@@ -41,18 +41,23 @@ class ReceiverConstraintsMap {
         synchronized(lock) {
             return map.remove(key)?.also { removed ->
                 if (removed.maxHeight == maxHeight) {
-                    maxHeight = findNewMax(maxHeight)
+                    maxHeight = findNextMax(maxHeight)
                 }
             }
         }
     }
 
-    // Note: this method must be called with the lock held
-    private fun findNewMax(oldMax: Int): Int {
+    /**
+     * Given the previous max, go through the constraints until we either:
+     * 1) Find a maxHeight equal to the old one or
+     * 2) Go through the whole list, and track the highest value we've seen.
+     * Note: this method must be called with the lock held
+     */
+    private fun findNextMax(oldMaxHeight: Int): Int {
         var maxSeen = 0
         map.values.forEach { constraints ->
-            if (constraints.maxHeight == oldMax) {
-                return oldMax
+            if (constraints.maxHeight == oldMaxHeight) {
+                return oldMaxHeight
             } else if (constraints.maxHeight > maxSeen) {
                 maxSeen = constraints.maxHeight
             }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
@@ -39,9 +39,22 @@ class ReceiverConstraintsMap {
         synchronized(lock) {
             return map.remove(key)?.also { removed ->
                 if (removed.maxHeight == maxHeight) {
-                    maxHeight = map.values.map { it.maxHeight }.max() ?: 0
+                    maxHeight = findNewMax(maxHeight)
                 }
             }
         }
+    }
+
+    // Note: this method must be called with the lock held
+    private fun findNewMax(oldMax: Int): Int {
+        var maxSeen = 0
+        map.values.forEach { constraints ->
+            if (constraints.maxHeight == oldMax) {
+                return oldMax
+            } else if (constraints.maxHeight > maxSeen) {
+                maxSeen = constraints.maxHeight
+            }
+        }
+        return maxSeen
     }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
@@ -67,6 +67,6 @@ class ReceiverConstraintsMap {
 
     fun getDebugState() = OrderedJsonObject().apply {
         put("maxHeight", maxHeight)
-        put("constraints", map)
+        put("constraints", map.toMap())
     }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
@@ -16,6 +16,8 @@
 
 package org.jitsi.videobridge.cc.allocation
 
+import org.jitsi.nlj.util.OrderedJsonObject
+
 /**
  * A Map of Endpoint IDs to their receiver video constraints.  Tracks the max height of all
  * of those constraints as new constraints are added and removed.
@@ -56,5 +58,10 @@ class ReceiverConstraintsMap {
             }
         }
         return maxSeen
+    }
+
+    fun getDebugState() = OrderedJsonObject().apply {
+        put("maxHeight", maxHeight)
+        put("constraints", map)
     }
 }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMapTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMapTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.cc.allocation
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+
+class ReceiverConstraintsMapTest : ShouldSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    val constraints = ReceiverConstraintsMap()
+
+    context("receiver constraints map") {
+        should("track the max height correctly") {
+            constraints.maxHeight shouldBe 0
+            constraints.put("1", VideoConstraints(1, 30.0))
+            constraints.maxHeight shouldBe 1
+            constraints.put("2", VideoConstraints(2, 30.0))
+            constraints.maxHeight shouldBe 2
+            constraints.put("3", VideoConstraints(3, 30.0))
+            constraints.maxHeight shouldBe 3
+
+            constraints.remove("3")
+            constraints.maxHeight shouldBe 2
+
+            constraints.put("1", VideoConstraints(4, 30.0))
+            constraints.maxHeight shouldBe 4
+
+            constraints.remove("1")
+            constraints.maxHeight shouldBe 2
+
+            constraints.remove("2")
+            constraints.maxHeight shouldBe 0
+        }
+    }
+})


### PR DESCRIPTION
When doing large call testing, we noticed a very hot call path where we figure out what the maximum height of a set of constraints is.  This change keeps track of the max height as constraints are added and removed from the map so we don't have to walk the entire thing to find it.

Note: `AbstractEndpoint#receiverVideoConstraintsChanged` should probably take a some structure which has max values for various constraints, but currently we only look at maxHeight so rather than define that new class now, I changed the function to just take `int maxHeight`.  It won't be difficult to expand that later when we use other constraints.