### PR TITLE
Run lastNEndpointsChanged asynchronously in Conference#endpointSourcesChanged.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -676,7 +676,8 @@ public class Conference
     public void endpointSourcesChanged(AbstractEndpoint endpoint)
     {
         // Force an update to be propagated to each endpoint's bitrate controller.
-        lastNEndpointsChanged();
+        // We run this async because this method is called in the Colibri critical path.
+        lastNEndpointsChangedAsync();
     }
 
     /**


### PR DESCRIPTION
This is called in the Colibri message processing critical path.