### PR TITLE
Support disabling websocket compression on the bridge channel.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocketServlet.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocketServlet.java
@@ -15,12 +15,15 @@
  */
 package org.jitsi.videobridge.websocket;
 
+import org.eclipse.jetty.websocket.api.extensions.*;
 import org.eclipse.jetty.websocket.servlet.*;
 import org.jetbrains.annotations.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.*;
 
 import java.io.*;
+import java.util.*;
+import java.util.stream.*;
 
 /**
  * @author Boris Grozev
@@ -148,6 +151,12 @@ class ColibriWebSocketServlet
             response.sendError(403, authFailed);
             return null;
         }
+
+        // Disable WebSocket compression, it uses a lot of CPU.
+        List<ExtensionConfig> extensions = response.getExtensions().stream().
+            filter((ext) -> !ext.getName().equals("permessage-deflate")).
+            collect(Collectors.toList());
+        response.setExtensions(extensions);
 
         return new ColibriWebSocket(ids[2], this, endpoint.getMessageTransport());
     }

--- a/jvb/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocketServlet.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocketServlet.java
@@ -155,7 +155,7 @@ class ColibriWebSocketServlet
             return null;
         }
 
-        if (!config.getUseCompression())
+        if (!config.getEnableCompression())
         {
             List<ExtensionConfig> extensions = response.getExtensions().stream().
                     filter((ext) -> !ext.getName().equals("permessage-deflate")).

--- a/jvb/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocketServlet.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocketServlet.java
@@ -20,6 +20,7 @@ import org.eclipse.jetty.websocket.servlet.*;
 import org.jetbrains.annotations.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.*;
+import org.jitsi.videobridge.websocket.config.*;
 
 import java.io.*;
 import java.util.*;
@@ -44,6 +45,8 @@ class ColibriWebSocketServlet
 
     @NotNull
     private final Videobridge videobridge;
+
+    private WebsocketServiceConfig config = new WebsocketServiceConfig();
 
     /**
      * Initializes a new {@link ColibriWebSocketServlet} instance.
@@ -152,11 +155,13 @@ class ColibriWebSocketServlet
             return null;
         }
 
-        // Disable WebSocket compression, it uses a lot of CPU.
-        List<ExtensionConfig> extensions = response.getExtensions().stream().
-            filter((ext) -> !ext.getName().equals("permessage-deflate")).
-            collect(Collectors.toList());
-        response.setExtensions(extensions);
+        if (!config.getUseCompression())
+        {
+            List<ExtensionConfig> extensions = response.getExtensions().stream().
+                    filter((ext) -> !ext.getName().equals("permessage-deflate")).
+                        collect(Collectors.toList());
+            response.setExtensions(extensions);
+        }
 
         return new ColibriWebSocket(ids[2], this, endpoint.getMessageTransport());
     }

--- a/jvb/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocketServlet.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocketServlet.java
@@ -155,7 +155,7 @@ class ColibriWebSocketServlet
             return null;
         }
 
-        if (!config.getEnableCompression())
+        if (!config.shouldEnableCompression())
         {
             List<ExtensionConfig> extensions = response.getExtensions().stream().
                     filter((ext) -> !ext.getName().equals("permessage-deflate")).

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/websocket/config/WebsocketServiceConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/websocket/config/WebsocketServiceConfig.kt
@@ -53,6 +53,15 @@ class WebsocketServiceConfig {
     }
 
     /**
+     * Whether compression (permessage-deflate) should be used for websockets
+     */
+    val useCompression: Boolean by config {
+        onlyIf("Websockets are enabled", ::enabled) {
+            "videobridge.websockets.compression".from(JitsiConfig.newConfig)
+        }
+    }
+
+    /**
      * The server ID used in URLs advertised for COLIBRI WebSockets.
      */
     val serverId: String by config {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/websocket/config/WebsocketServiceConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/websocket/config/WebsocketServiceConfig.kt
@@ -55,9 +55,9 @@ class WebsocketServiceConfig {
     /**
      * Whether compression (permessage-deflate) should be used for websockets
      */
-    val useCompression: Boolean by config {
+    val enableCompression: Boolean by config {
         onlyIf("Websockets are enabled", ::enabled) {
-            "videobridge.websockets.compression".from(JitsiConfig.newConfig)
+            "videobridge.websockets.enable-compression".from(JitsiConfig.newConfig)
         }
     }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/websocket/config/WebsocketServiceConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/websocket/config/WebsocketServiceConfig.kt
@@ -55,11 +55,13 @@ class WebsocketServiceConfig {
     /**
      * Whether compression (permessage-deflate) should be used for websockets
      */
-    val enableCompression: Boolean by config {
+    private val enableCompression: Boolean by config {
         onlyIf("Websockets are enabled", ::enabled) {
             "videobridge.websockets.enable-compression".from(JitsiConfig.newConfig)
         }
     }
+
+    fun shouldEnableCompression() = enableCompression
 
     /**
      * The server ID used in URLs advertised for COLIBRI WebSockets.

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -229,8 +229,8 @@ videobridge {
   websockets {
     enabled=false
     server-id="default-id"
-    # Whether to use WebSocket compression (permessage-deflate)
-    compression = true
+    # Whether to negotiate WebSocket compression (permessage-deflate)
+    enable-compression = true
 
     # Optional, even when 'enabled' is set to true
     # tls=true

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -229,6 +229,8 @@ videobridge {
   websockets {
     enabled=false
     server-id="default-id"
+    # Whether to use WebSocket compression (permessage-deflate)
+    compression = true
 
     # Optional, even when 'enabled' is set to true
     # tls=true


### PR DESCRIPTION
It uses a surprisingly large amount of CPU.
