### PR TITLE
Signal video type (camera, screenshare, none)

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -111,6 +111,13 @@ public abstract class AbstractEndpoint
         this.id = Objects.requireNonNull(id, "id");
     }
 
+    /**
+     * Return the {@link VideoType} that the endpoint has advertised as available. This reflects the type of stream
+     * even when the stream is suspended (e.g. due to no receivers being subscribed to it).
+     *
+     * In other words, CAMERA or SCREENSHARE means that the endpoint has an available stream, which may be suspended.
+     * NONE means that the endpoint has signaled that it has no available streams.
+     */
     @NotNull
     public VideoType getVideoType()
     {

--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -122,7 +122,7 @@ public abstract class AbstractEndpoint
      * In other words, CAMERA or SCREENSHARE means that the endpoint has an available stream, which may be suspended.
      * NONE means that the endpoint has signaled that it has no available streams.
      *
-     * Note that when the endpoint has not advertised any sources, the video type is necessarily {@code NONE}.
+     * Note that when the endpoint has not advertised any video sources, the video type is necessarily {@code NONE}.
      */
     @NotNull
     public VideoType getVideoType()

--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -25,6 +25,7 @@ import org.jitsi.utils.event.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.cc.allocation.*;
 import org.jitsi.videobridge.message.*;
+import org.jitsi.videobridge.util.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.json.simple.*;
 
@@ -93,6 +94,8 @@ public abstract class AbstractEndpoint
 
     protected final EventEmitter<EventHandler> eventEmitter = new EventEmitter<>();
 
+    private VideoType videoType = VideoType.CAMERA;
+
     /**
      * Initializes a new {@link AbstractEndpoint} instance.
      * @param conference the {@link Conference} which this endpoint is to be a
@@ -106,6 +109,17 @@ public abstract class AbstractEndpoint
         context.put("epId", id);
         logger = parentLogger.createChildLogger(this.getClass().getName(), context);
         this.id = Objects.requireNonNull(id, "id");
+    }
+
+    @NotNull
+    public VideoType getVideoType()
+    {
+        return videoType;
+    }
+
+    public void setVideoType(VideoType videoType)
+    {
+        this.videoType = videoType;
     }
 
     /**

--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -94,6 +94,10 @@ public abstract class AbstractEndpoint
 
     protected final EventEmitter<EventHandler> eventEmitter = new EventEmitter<>();
 
+    /**
+     * The latest {@link VideoType} signaled by the endpoint (defaulting to {@code CAMERA} if nothing has been
+     * signaled).
+     */
     private VideoType videoType = VideoType.CAMERA;
 
     /**
@@ -117,10 +121,16 @@ public abstract class AbstractEndpoint
      *
      * In other words, CAMERA or SCREENSHARE means that the endpoint has an available stream, which may be suspended.
      * NONE means that the endpoint has signaled that it has no available streams.
+     *
+     * Note that when the endpoint has not advertised any sources, the video type is necessarily {@code NONE}.
      */
     @NotNull
     public VideoType getVideoType()
     {
+        if (getMediaSources().length == 0)
+        {
+            return VideoType.NONE;
+        }
         return videoType;
     }
 
@@ -155,6 +165,7 @@ public abstract class AbstractEndpoint
     /**
      * Gets the list of media sources that belong to this endpoint.
      */
+    @NotNull
     abstract public MediaSourceDesc[] getMediaSources();
 
     /**

--- a/jvb/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
@@ -160,13 +160,13 @@ public class ConferenceSpeechActivity
     {
         synchronized (syncRoot)
         {
-            Map<Boolean, List<AbstractEndpoint>> bySendingVideo
+            Map<Boolean, List<AbstractEndpoint>> byVideoAvailable
                     = endpointsBySpeechActivity.stream()
-                        .collect(Collectors.groupingBy(AbstractEndpoint::isSendingVideo));
+                        .collect(Collectors.groupingBy(ep -> ep.getVideoType() != VideoType.NONE));
 
             List<AbstractEndpoint> newEndpointsInLastNOrder = new ArrayList<>(endpointsBySpeechActivity.size());
-            newEndpointsInLastNOrder.addAll(bySendingVideo.getOrDefault(true, Collections.emptyList()));
-            newEndpointsInLastNOrder.addAll(bySendingVideo.getOrDefault(false, Collections.emptyList()));
+            newEndpointsInLastNOrder.addAll(byVideoAvailable.getOrDefault(true, Collections.emptyList()));
+            newEndpointsInLastNOrder.addAll(byVideoAvailable.getOrDefault(false, Collections.emptyList()));
 
             if (!newEndpointsInLastNOrder.equals(endpointsInLastNOrder))
             {

--- a/jvb/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
@@ -125,6 +125,13 @@ public class EndpointMessageTransport
     }
 
     @Override
+    public BridgeChannelMessage videoType(VideoTypeMessage videoTypeMessage)
+    {
+        endpoint.setVideoType(videoTypeMessage.getVideoType());
+        return null;
+    }
+
+    @Override
     public void unhandledMessage(BridgeChannelMessage message)
     {
         logger.warn("Received a message with an unexpected type: " + message.getType());

--- a/jvb/src/main/java/org/jitsi/videobridge/octo/OctoEndpointMessageTransport.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/octo/OctoEndpointMessageTransport.java
@@ -202,4 +202,26 @@ class OctoEndpointMessageTransport
         conference.broadcastMessage(message, false /* sendToOcto */);
         return null;
     }
+
+    @Override
+    public BridgeChannelMessage videoType(VideoTypeMessage videoTypeMessage)
+    {
+        String endpointId = videoTypeMessage.getEndpointId();
+        if (endpointId == null)
+        {
+            logger.warn("Received a VideoTypeMessage with no endpoint ID specified.");
+            return null;
+        }
+
+        AbstractEndpoint endpoint = octoEndpoints.getConference().getEndpoint(endpointId);
+        if (!(endpoint instanceof OctoEndpoint))
+        {
+            logger.warn("Received a VideoTypeMessage for an invalid endpoint, id=" + endpointId + ", ep=" + endpoint);
+            return null;
+        }
+
+        endpoint.setVideoType(videoTypeMessage.getVideoType());
+
+        return null;
+    }
 }

--- a/jvb/src/main/java/org/jitsi/videobridge/octo/OctoTransceiver.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/octo/OctoTransceiver.java
@@ -144,6 +144,7 @@ public class OctoTransceiver implements Stoppable, NodeStatsProducer
     /**
      * @return the current list of media stream tracks.
      */
+    @NotNull
     MediaSourceDesc[] getMediaSources()
     {
         return mediaSources.getMediaSources();

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -72,7 +72,6 @@ import org.jitsi.videobridge.transport.dtls.DtlsTransport
 import org.jitsi.videobridge.transport.ice.IceTransport
 import org.jitsi.videobridge.util.ByteBufferPool
 import org.jitsi.videobridge.util.TaskPools
-import org.jitsi.videobridge.util.VideoType
 import org.jitsi.videobridge.util.looksLikeDtls
 import org.jitsi.videobridge.websocket.colibriWebSocketServiceSupplier
 import org.jitsi.videobridge.xmpp.MediaSourceFactory

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -72,6 +72,7 @@ import org.jitsi.videobridge.transport.dtls.DtlsTransport
 import org.jitsi.videobridge.transport.ice.IceTransport
 import org.jitsi.videobridge.util.ByteBufferPool
 import org.jitsi.videobridge.util.TaskPools
+import org.jitsi.videobridge.util.VideoType
 import org.jitsi.videobridge.util.looksLikeDtls
 import org.jitsi.videobridge.websocket.colibriWebSocketServiceSupplier
 import org.jitsi.videobridge.xmpp.MediaSourceFactory

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/util/VideoType.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/util/VideoType.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright @ 2021-Present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.util
+
+enum class VideoType {
+    CAMERA,
+    SCREENSHARE,
+    NONE
+}

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/util/VideoType.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/util/VideoType.kt
@@ -17,6 +17,6 @@ package org.jitsi.videobridge.util
 
 enum class VideoType {
     CAMERA,
-    SCREENSHARE,
+    DESKTOP,
     NONE
 }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/SpeechActivityTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/SpeechActivityTest.kt
@@ -22,6 +22,8 @@ import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import org.jitsi.videobridge.util.VideoType.CAMERA
+import org.jitsi.videobridge.util.VideoType.NONE
 
 class SpeechActivityTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
@@ -77,17 +79,17 @@ class SpeechActivityTest : ShouldSpec() {
 
             conferenceSpeechActivity.orderedEndpoints shouldContainExactly listOf(a, b, c, d)
 
-            every { a.isSendingVideo } returns false
+            every { a.videoType } returns NONE
             conferenceSpeechActivity.updateLastNEndpoints()
             conferenceSpeechActivity.dominantEndpoint shouldBe a
             conferenceSpeechActivity.orderedEndpoints shouldContainExactly listOf(b, c, d, a)
 
-            every { a.isSendingVideo } returns true
+            every { a.videoType } returns CAMERA
             conferenceSpeechActivity.updateLastNEndpoints()
             conferenceSpeechActivity.dominantEndpoint shouldBe a
             conferenceSpeechActivity.orderedEndpoints shouldContainExactly listOf(a, b, c, d)
 
-            every { b.isSendingVideo } returns false
+            every { b.videoType } returns NONE
             conferenceSpeechActivity.updateLastNEndpoints()
             conferenceSpeechActivity.dominantEndpoint shouldBe a
             conferenceSpeechActivity.orderedEndpoints shouldContainExactly listOf(a, c, d, b)
@@ -96,15 +98,15 @@ class SpeechActivityTest : ShouldSpec() {
             conferenceSpeechActivity.dominantEndpoint shouldBe b
             conferenceSpeechActivity.orderedEndpoints shouldContainExactly listOf(a, c, d, b)
 
-            every { b.isSendingVideo } returns true
+            every { b.videoType } returns CAMERA
             conferenceSpeechActivity.updateLastNEndpoints()
             conferenceSpeechActivity.dominantEndpoint shouldBe b
             conferenceSpeechActivity.orderedEndpoints shouldContainExactly listOf(b, a, c, d)
 
-            every { a.isSendingVideo } returns false
-            every { b.isSendingVideo } returns false
-            every { c.isSendingVideo } returns false
-            every { d.isSendingVideo } returns false
+            every { a.videoType } returns NONE
+            every { b.videoType } returns NONE
+            every { c.videoType } returns NONE
+            every { d.videoType } returns NONE
             conferenceSpeechActivity.updateLastNEndpoints()
             conferenceSpeechActivity.activeSpeakerChanged(a.id)
             conferenceSpeechActivity.dominantEndpoint shouldBe a
@@ -115,7 +117,7 @@ class SpeechActivityTest : ShouldSpec() {
     companion object {
         fun mockEndpoint(endpointId: String) = mockk<AbstractEndpoint>().apply {
             every { id } returns endpointId
-            every { isSendingVideo } returns true
+            every { videoType } returns CAMERA
         }
     }
 }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
@@ -29,6 +29,7 @@ import io.kotest.matchers.string.shouldNotInclude
 import io.kotest.matchers.types.shouldBeInstanceOf
 import org.jitsi.videobridge.cc.allocation.VideoConstraints
 import org.jitsi.videobridge.message.BridgeChannelMessage.Companion.parse
+import org.jitsi.videobridge.util.VideoType
 import org.json.simple.JSONArray
 import org.json.simple.JSONObject
 import org.json.simple.parser.JSONParser
@@ -230,6 +231,31 @@ class BridgeChannelMessageTest : ShouldSpec() {
             parsed as RemoveReceiverMessage
             parsed.bridgeId shouldBe "bridge1"
             parsed.endpointId shouldBe "abcdabcd"
+        }
+
+        context("serializing and parsing VideoType") {
+            val videoTypeMessage = VideoTypeMessage(VideoType.SCREENSHARE)
+            videoTypeMessage.videoType shouldBe VideoType.SCREENSHARE
+            parse(videoTypeMessage.toJson()).apply {
+                shouldBeInstanceOf<VideoTypeMessage>()
+                this as VideoTypeMessage
+                videoType shouldBe VideoType.SCREENSHARE
+            }
+
+            listOf("none", "NONE", "None", "nOnE").forEach {
+                val jsonString = """
+                    {
+                        "colibriClass" : "VideoTypeMessage",
+                        "videoType" : "$it"
+                    }
+                    """
+                parse(jsonString).apply {
+                    shouldBeInstanceOf<VideoTypeMessage>()
+                    this as VideoTypeMessage
+                    videoType shouldBe VideoType.NONE
+                }
+
+            }
         }
 
         context("Parsing ReceiverVideoConstraints") {

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
@@ -254,7 +254,6 @@ class BridgeChannelMessageTest : ShouldSpec() {
                     this as VideoTypeMessage
                     videoType shouldBe VideoType.NONE
                 }
-
             }
         }
 

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
@@ -234,12 +234,12 @@ class BridgeChannelMessageTest : ShouldSpec() {
         }
 
         context("serializing and parsing VideoType") {
-            val videoTypeMessage = VideoTypeMessage(VideoType.SCREENSHARE)
-            videoTypeMessage.videoType shouldBe VideoType.SCREENSHARE
+            val videoTypeMessage = VideoTypeMessage(VideoType.DESKTOP)
+            videoTypeMessage.videoType shouldBe VideoType.DESKTOP
             parse(videoTypeMessage.toJson()).apply {
                 shouldBeInstanceOf<VideoTypeMessage>()
                 this as VideoTypeMessage
-                videoType shouldBe VideoType.SCREENSHARE
+                videoType shouldBe VideoType.DESKTOP
             }
 
             listOf("none", "NONE", "None", "nOnE").forEach {


### PR DESCRIPTION
Allow endpoints to signal the type of video steam they have available, or the lack thereof. Use the signaled video type, instead of the bitrate of the incoming stream when prioritizing endpoints for LastN.

Fixes an issue where an endpoint's video being suspended causes the endpoint to be de-prioritized, and thus video is never unsuspended.

This is a draft, because I want to test some more and add more unit tests.