### PR TITLE
Use ThreadLocalRandom.current() in PartitionedByteBufferPool.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/util/PartitionedByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/PartitionedByteBufferPool.java
@@ -58,11 +58,6 @@ class PartitionedByteBufferPool
     private static final Logger logger = new LoggerImpl(PartitionedByteBufferPool.class.getName());
 
     /**
-     * Used to select a partition at random.
-     */
-    private static final Random random = new Random();
-
-    /**
      * The partitions.
      */
     private final Partition[] partitions = new Partition[NUM_PARTITIONS];
@@ -105,7 +100,7 @@ class PartitionedByteBufferPool
      */
     private Partition getPartition()
     {
-        return partitions[random.nextInt(NUM_PARTITIONS)];
+        return partitions[ThreadLocalRandom.current().nextInt(NUM_PARTITIONS)];
     }
 
     /**


### PR DESCRIPTION
The Java 8 documentation says "the concurrent use of the same java.util.Random
instance across threads may encounter contention and consequent poor
performance. Consider instead using ThreadLocalRandom in multithreaded designs."

Indeed, in a profile, PartitionedByteBufferPool.getPartition() was 1% of total JVB time.