### PR TITLE
Fix: switch up to HD quickly when switching to a layer-suspended source. (Bump JMT.)

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.java
@@ -95,7 +95,7 @@ class SingleSourceAllocation
         }
 
         long nowMs = clock.instant().toEpochMilli();
-        boolean noActiveLayers = source.getRtpLayers().stream().noneMatch(l -> l.getBitrate(nowMs) > 0);
+        boolean noActiveLayers = source.getRtpLayers().stream().allMatch(l -> l.hasZeroBitrate(nowMs));
         List<LayerSnapshot> ratesList = new ArrayList<>();
         // Initialize the list of layers to be considered. These are the layers that satisfy the constraints, with
         // a couple of exceptions (see comments below).

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-media-transform</artifactId>
-                <version>1.0-227-g40b0367</version>
+                <version>1.0-229-gfa5ea3f</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Use new lighter-weight "RtpLayerDesc#hasZeroBitrate" method to compute noActiveLayers in bandwidth allocation.