### PR TITLE
Fix: bump versions of some dependencies.

### DIFF
--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -185,7 +185,7 @@
     <dependency>
       <groupId>io.sentry</groupId>
       <artifactId>sentry</artifactId>
-      <version>1.7.30</version>
+      <version>4.3.0</version>
       <scope>runtime</scope>
     </dependency>
     <!-- test -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,14 +23,14 @@
     <packaging>pom</packaging>
 
     <properties>
-        <jetty.version>9.4.35.v20201120</jetty.version>
+        <jetty.version>9.4.40.v20210413</jetty.version>
         <kotlin.version>1.3.72</kotlin.version>
         <kotest.version>4.1.3</kotest.version>
         <jicoco.version>1.1-80-g6411afd</jicoco.version>
         <jitsi.utils.version>1.0-88-g9bdd2a7</jitsi.utils.version>
         <maven-shade-plugin.version>3.2.2</maven-shade-plugin.version>
         <spotbugs.version>4.1.4</spotbugs.version>
-        <jersey.version>2.32</jersey.version>
+        <jersey.version>2.34</jersey.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-media-transform</artifactId>
-                <version>1.0-234-gf48db15</version>
+                <version>1.0-235-g4abfaf3</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Including jmt, to bump bouncycastle dependency.

Moves to the latest versions of: Bouncycastle, Jersey, Jetty, io.sentry, Jackson.