### PR TITLE
ref: log not found errors on warning level

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -445,7 +445,13 @@ public class ConferenceShim
             }
             catch (IqProcessingException e)
             {
-                logger.error("Error processing channels: " + e.toString());
+                // Item not found conditions are assumed to be less critical, as they often happen in case a request
+                // arrives late for an expired endpoint.
+                if (XMPPError.Condition.item_not_found.equals(e.getCondition())) {
+                    logger.warn("Error processing channels: " + e);
+                } else {
+                    logger.error("Error processing channels: " + e);
+                }
                 return IQUtils.createError(conferenceIQ, e.getCondition(), e.getMessage());
             }
 

--- a/jvb/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
@@ -291,7 +291,7 @@ public class ContentShim
                     return null;
                 }
                 throw new IqProcessingException(
-                        XMPPError.Condition.internal_server_error,
+                        XMPPError.Condition.item_not_found,
                         "Error finding channel " + channelId);
             }
         }


### PR DESCRIPTION
Not found errors, especially those for endpoint channels, can often
happen when request is made for an endpoint that has expired
on the bridge (due to being disconnected for too long).