### PR TITLE
Restrict the random port used for WebsocketClientTest to the 49152-65535.

### DIFF
--- a/jvb-api/jvb-api-client/src/test/kotlin/org/jitsi/videobridge/api/util/WebSocketClientTest.kt
+++ b/jvb-api/jvb-api-client/src/test/kotlin/org/jitsi/videobridge/api/util/WebSocketClientTest.kt
@@ -38,7 +38,7 @@ import kotlin.time.seconds
 class WebSocketClientTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
-    private val wsPort = Random.nextInt(1024, 65535).also {
+    private val wsPort = Random.nextInt(49152, 65535).also {
         println("Server running on port $it")
     }
 


### PR DESCRIPTION
This should be less likely to conflict with an existing listener on the testing machine.