### PR TITLE
Add /colibri/muc-client/list endpoint

### DIFF
--- a/doc/rest-muc-client.md
+++ b/doc/rest-muc-client.md
@@ -17,7 +17,7 @@ A new XMPP client connection (i.e. a MucClient) can be added by posting a JSON w
 
 If a configuration with the specified ID already exists, the request will succeed (return 200), but the configuration will NOT be updated. If you need to update an existing configuration, you need to remove it first and then re-add it.
 
-# Removing an XMPP client connection.
+# Removing an XMPP client connection
 An XMPP client connection (i.e. a MucClient) can be removed by posting a JSON which contains its ID to `/colibri/muc-client/remove`:
 ```
 {
@@ -26,3 +26,7 @@ An XMPP client connection (i.e. a MucClient) can be removed by posting a JSON wh
 ```
 
 The request will be successful (return 200) if an XMPP client connection was removed. 
+
+
+# Listing XMPP client connections
+IDs of previously added XMPP client connections can be listed using a GET call to `/colibri/muc-client/list`.

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClient.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClient.java
@@ -75,10 +75,10 @@ public class MucClient
         return Response.status(HttpServletResponse.SC_BAD_REQUEST).build();
     }
 
-    @Path("/ids")
+    @Path("/list")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String getIds()
+    public String listMucClientIDs()
     {
         return xmppConnection.getMucClientIds();
     }

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClient.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClient.java
@@ -74,4 +74,12 @@ public class MucClient
         }
         return Response.status(HttpServletResponse.SC_BAD_REQUEST).build();
     }
+
+    @Path("/ids")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public String getIds()
+    {
+        return xmppConnection.getMucClientIds();
+    }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
@@ -135,10 +135,7 @@ class XmppConnection : IQListener {
      * @return JSON string of the list of ids
      */
     fun getMucClientIds(): String {
-        val jsonArray = JSONArray()
-        mucClientManager.getMucClientIds().forEach { id -> jsonArray.add(id) }
-
-        return jsonArray.toJSONString()
+        return JSONArray().apply { addAll(mucClientManager.mucClientIds) }.toJSONString()
     }
 
     /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
@@ -33,6 +33,7 @@ import org.jivesoftware.smack.packet.ExtensionElement
 import org.jivesoftware.smack.packet.IQ
 import org.jivesoftware.smack.packet.XMPPError
 import org.jivesoftware.smackx.iqversion.packet.Version
+import org.json.simple.JSONArray
 import org.json.simple.JSONObject
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -127,6 +128,17 @@ class XmppConnection : IQListener {
         // exists as success. Note however, that the existing client's
         // configuration was NOT modified.
         return true
+    }
+
+    /**
+     * Returns ids of [MucClient] that have been added.
+     * @return JSON string of the list of ids
+     */
+    fun getMucClientIds(): String {
+        val jsonArray = JSONArray()
+        mucClientManager.getMucClientIds().forEach { id -> jsonArray.add(id) }
+
+        return jsonArray.toJSONString()
     }
 
     /**

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClientTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClientTest.kt
@@ -121,7 +121,7 @@ class MucClientTest : JerseyTest() {
         }
         every { xmppConnection.getMucClientIds() } returns fakeIds.toJSONString()
 
-        val resp = target("$baseUrl/ids").request().get()
+        val resp = target("$baseUrl/list").request().get()
         resp.readEntity(String::class.java) shouldBe "[\"id1\"]"
     }
 

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClientTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClientTest.kt
@@ -26,6 +26,7 @@ import org.glassfish.jersey.test.JerseyTest
 import org.glassfish.jersey.test.TestProperties
 import org.jitsi.videobridge.rest.MockBinder
 import org.jitsi.videobridge.xmpp.XmppConnection
+import org.json.simple.JSONArray
 import org.json.simple.JSONObject
 import org.junit.Test
 import javax.ws.rs.client.Entity
@@ -91,25 +92,37 @@ class MucClientTest : JerseyTest() {
     fun testRemoveMuc() {
         val jsonConfigSlot = slot<JSONObject>()
 
-        every { xmppConnection.addMucClient(capture(jsonConfigSlot)) } returns true
+        every { xmppConnection.removeMucClient(capture(jsonConfigSlot)) } returns true
 
         val json = JSONObject().apply {
             put("id", "id")
         }
 
-        val resp = target("$baseUrl/add").request().post(Entity.json(json.toJSONString()))
+        val resp = target("$baseUrl/remove").request().post(Entity.json(json.toJSONString()))
         resp.status shouldBe HttpStatus.OK_200
         jsonConfigSlot.captured shouldBe json
     }
 
     @Test
     fun testRemoveMucFailure() {
-        every { xmppConnection.addMucClient(any()) } returns false
+        every { xmppConnection.removeMucClient(any()) } returns false
 
         val json = JSONObject().apply {
             put("id", "id")
         }
-        val resp = target("$baseUrl/add").request().post(Entity.json(json.toJSONString()))
+        val resp = target("$baseUrl/remove").request().post(Entity.json(json.toJSONString()))
         resp.status shouldBe HttpStatus.BAD_REQUEST_400
     }
+
+    @Test
+    fun testGetIds() {
+        val fakeIds = JSONArray().apply {
+            add("id1")
+        }
+        every { xmppConnection.getMucClientIds() } returns fakeIds.toJSONString()
+
+        val resp = target("$baseUrl/ids").request().get()
+        resp.readEntity(String::class.java) shouldBe "[\"id1\"]"
+    }
+
 }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClientTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClientTest.kt
@@ -124,5 +124,4 @@ class MucClientTest : JerseyTest() {
         val resp = target("$baseUrl/list").request().get()
         resp.readEntity(String::class.java) shouldBe "[\"id1\"]"
     }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <jetty.version>9.4.40.v20210413</jetty.version>
         <kotlin.version>1.3.72</kotlin.version>
         <kotest.version>4.1.3</kotest.version>
-        <jicoco.version>1.1-84-g1d06d1f</jicoco.version>
+        <jicoco.version>1.1-89-g9ca691c</jicoco.version>
         <jitsi.utils.version>1.0-93-ge6aba2e</jitsi.utils.version>
         <maven-shade-plugin.version>3.2.2</maven-shade-plugin.version>
         <spotbugs.version>4.1.4</spotbugs.version>


### PR DESCRIPTION
This allows listing of ids of previously added XMPP clients.

Ref: https://community.jitsi.org/t/list-added-muc-clients-on-videobridge/100268/6?u=shawn

Depends on the following jicoco changes: https://github.com/jitsi/jicoco/pull/148