### PR TITLE
Remove use of powermock and easymock from the testing framework.

### DIFF
--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -196,39 +196,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>3.3.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <version>4.0.2</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.powermock/powermock-core -->
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>2.0.6</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-easymock -->
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-easymock</artifactId>
-      <version>2.0.6</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4 -->
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>2.0.6</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.jersey.test-framework</groupId>
       <artifactId>jersey-test-framework-core</artifactId>
       <version>${jersey.version}</version>

--- a/jvb/src/test/java/org/jitsi/videobridge/xmpp/MediaSourceFactoryTest.java
+++ b/jvb/src/test/java/org/jitsi/videobridge/xmpp/MediaSourceFactoryTest.java
@@ -20,15 +20,11 @@ import org.jitsi.nlj.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jitsi.xmpp.extensions.jingle.*;
 import org.junit.*;
-import org.junit.runner.*;
-import org.powermock.modules.junit4.*;
 
 import java.util.*;
 
 import static org.junit.Assert.*;
-import static org.powermock.api.easymock.PowerMock.*;
 
-@RunWith(PowerMockRunner.class)
 public class MediaSourceFactoryTest
 {
     private SourceGroupPacketExtension createGroup(
@@ -55,18 +51,10 @@ public class MediaSourceFactoryTest
         return spe;
     }
 
-    @After
-    public void tearDown()
-    {
-        verifyAll();
-    }
-
     // 1 video stream -> 1 source, 1 layer
     @Test
     public void createMediaSource()
     {
-        replayAll();
-
         long videoSsrc = 12345;
 
         SourcePacketExtension videoSource = createSource(videoSsrc);
@@ -85,8 +73,6 @@ public class MediaSourceFactoryTest
     @Test
     public void createMediaSources1()
     {
-        replayAll();
-
         long videoSsrc = 12345;
         long rtxSsrc = 54321;
 
@@ -111,8 +97,6 @@ public class MediaSourceFactoryTest
     @Test
     public void createMediaSources2()
     {
-        replayAll();
-
         long videoSsrc1 = 12345;
         long videoSsrc2 = 23456;
         long videoSsrc3 = 34567;
@@ -159,8 +143,6 @@ public class MediaSourceFactoryTest
     @Test
     public void createMediaSources3()
     {
-        replayAll();
-
         long videoSsrc1 = 12345;
         long videoSsrc2 = 23456;
         long videoSsrc3 = 34567;
@@ -205,8 +187,6 @@ public class MediaSourceFactoryTest
     @Test
     public void createMediaSources4()
     {
-        replayAll();
-
         long videoSsrc1 = 12345;
         long videoSsrc2 = 23456;
         long videoSsrc3 = 34567;
@@ -264,8 +244,6 @@ public class MediaSourceFactoryTest
     @Test
     public void testEmptySimGroup()
     {
-        replayAll();
-
         long videoSsrc1 = 12345;
 
         SourcePacketExtension videoSource1 = createSource(videoSsrc1);
@@ -289,8 +267,6 @@ public class MediaSourceFactoryTest
     @Test
     public void testEmptySource()
     {
-        replayAll();
-
         SourcePacketExtension videoSource1 = createSource(null);
 
         MediaSourceDesc[] sources =


### PR DESCRIPTION
There were relics of them in MediaSourceFactoryTest, but they weren't actually doing anything anymore.