### PR TITLE
change default value of always-route-dominant to true

### DIFF
--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -299,7 +299,7 @@ videobridge {
 
       # Whether to route dominant speaker when it is not among the current loudest speakers.
       # Ignored if route-loudest-only = false.
-      always-route-dominant = false
+      always-route-dominant = true
 
       # Time after which speaker is removed from loudest list if
       # no new audio packets have been received from that speaker.


### PR DESCRIPTION
this should be a safer default, with less risk of discarding important packets.
