### PR TITLE
Add explicit dependencies on kotlin-reflect.

### DIFF
--- a/jvb-api/jvb-api-client/pom.xml
+++ b/jvb-api/jvb-api-client/pom.xml
@@ -69,6 +69,13 @@
             <artifactId>jackson-module-kotlin</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <!-- jackson-module-kotlin uses kotlin-reflect; avoid pulling
+             in an old version. -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>jitsi-utils</artifactId>

--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -170,6 +170,13 @@
       <artifactId>jackson-module-kotlin</artifactId>
       <version>${jackson.version}</version>
     </dependency>
+    <!-- jackson-module-kotlin uses kotlin-reflect; avoid pulling
+         in an old version. -->
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-reflect</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>


### PR DESCRIPTION
This avoids warnings about incompatible kotlin versions due to jackson-module-kotlin.