### PR TITLE
Preserve VP9 sequence numbers, picId, and tl0picIdx across suspensions

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionContext.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionContext.kt
@@ -106,7 +106,7 @@ class Vp9AdaptiveSourceProjectionContext(
                 val projection: Vp9FrameProjection
                 try {
                     projection = createProjection(
-                        frame = frame, initialPacket = packet,
+                        frame = frame, initialPacket = packet, isResumption = acceptResult.isResumption,
                         isReset = result.isReset, mark = acceptResult.mark, receivedMs = receivedMs
                     )
                 } catch (e: Exception) {
@@ -231,6 +231,7 @@ class Vp9AdaptiveSourceProjectionContext(
         frame: Vp9Frame,
         initialPacket: Vp9Packet,
         mark: Boolean,
+        isResumption: Boolean,
         isReset: Boolean,
         receivedMs: Long
     ): Vp9FrameProjection {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionContext.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionContext.kt
@@ -101,7 +101,7 @@ class Vp9AdaptiveSourceProjectionContext(
             val receivedMs = packetInfo.receivedTime
             val acceptResult = vp9QualityFilter
                 .acceptFrame(frame, incomingIndex, targetIndex, receivedMs)
-            frame.isAccepted = acceptResult.accept && checkDecodability(frame)
+            frame.isAccepted = acceptResult.accept
             if (frame.isAccepted) {
                 val projection: Vp9FrameProjection
                 try {
@@ -223,16 +223,6 @@ class Vp9AdaptiveSourceProjectionContext(
      */
     private fun findNextBaseTl0(frame: Vp9Frame) =
         vp9PictureMaps.get(frame.ssrc)?.findNextBaseTl0(frame)
-
-    /**
-     * For a frame that's been accepted by the quality filter, verify that
-     * it's decodable given the projection decisions about previous frames
-     * (in case the targetIndex has changed).
-     */
-    private fun checkDecodability(frame: Vp9Frame): Boolean {
-        /* TODO - use SS or flexible mode reference list */
-        return true
-    }
 
     /**
      * Create a projection for this frame.

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9Frame.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9Frame.kt
@@ -111,6 +111,11 @@ class Vp9Frame internal constructor(
     val pictureId: Int,
 
     /**
+     * The PictureID index (PictureID plus cycles) of this frame.
+     */
+    val index: Int,
+
+    /**
      * The VP9 TL0PICIDX of the incoming VP9 frame that this instance refers to
      * (RFC7741).
      */
@@ -179,7 +184,10 @@ class Vp9Frame internal constructor(
     val effectiveSpatialLayer: Int
         get() = if (spatialLayer >= 0) spatialLayer else 0
 
-    constructor(packet: Vp9Packet) : this(
+    // Validate that the index matches the pictureId
+    init { assert((index and 0x7fff) == pictureId) }
+
+    constructor(packet: Vp9Packet, index: Int) : this(
         ssrc = packet.ssrc,
         timestamp = packet.timestamp,
         earliestKnownSequenceNumber = packet.sequenceNumber,
@@ -194,6 +202,7 @@ class Vp9Frame internal constructor(
         usesInterLayerDependency = packet.usesInterLayerDependency,
         isInterPicturePredicted = packet.isInterPicturePredicted,
         pictureId = packet.pictureId,
+        index = index,
         tl0PICIDX = packet.TL0PICIDX,
         isKeyframe = packet.isKeyframe,
         numSpatialLayers = packet.scalabilityStructureNumSpatial

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9Picture.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9Picture.kt
@@ -29,13 +29,13 @@ import kotlin.collections.ArrayList
  *
  * @author Jonathan Lennox
  */
-class Vp9Picture(packet: Vp9Packet) {
+class Vp9Picture(packet: Vp9Packet, index: Int) {
     val frames = ArrayList<Vp9Frame?>()
 
     init {
         val sid = packet.effectiveSpatialLayerIndex
 
-        setFrameAtSid(Vp9Frame(packet), sid)
+        setFrameAtSid(Vp9Frame(packet, index), sid)
     }
 
     fun frame(sid: Int) = frames.getOrNull(sid)
@@ -83,6 +83,9 @@ class Vp9Picture(packet: Vp9Packet) {
     val pictureId: Int
         get() = firstFrame().pictureId
 
+    val index: Int
+        get() = firstFrame().index
+
     val tl0PICIDX: Int
         get() = firstFrame().tl0PICIDX
 
@@ -105,7 +108,7 @@ class Vp9Picture(packet: Vp9Packet) {
             return PacketInsertionResult(f, this, false)
         }
 
-        val newF = Vp9Frame(packet)
+        val newF = Vp9Frame(packet, index)
 
         setFrameAtSid(newF, sid)
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilter.kt
@@ -112,7 +112,7 @@ internal class Vp9QualityFilter(parentLogger: Logger) {
             getSidFromIndex(incomingIndex) == getSidFromIndex(externalTargetIndex)
         }
         val isResumption = (prevIndex == SUSPENDED_INDEX && currentIndex != SUSPENDED_INDEX)
-        if (isResumption) assert(accept) // Pretty sure this has to be true?
+        if (isResumption) assert(accept) // Every code path that can turn off SUSPENDED_INDEX also accepts
         return AcceptResult(accept = accept, isResumption = isResumption, mark = mark)
     }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilter.kt
@@ -101,6 +101,7 @@ internal class Vp9QualityFilter(parentLogger: Logger) {
         externalTargetIndex: Int,
         receivedMs: Long
     ): AcceptResult {
+        val prevIndex = currentIndex
         val accept = doAcceptFrame(frame, incomingIndex, externalTargetIndex, receivedMs)
         val mark = if (frame.isInterPicturePredicted) {
             getSidFromIndex(incomingIndex) == getSidFromIndex(currentIndex)
@@ -110,7 +111,9 @@ internal class Vp9QualityFilter(parentLogger: Logger) {
                I think this shouldn't be a problem? */
             getSidFromIndex(incomingIndex) == getSidFromIndex(externalTargetIndex)
         }
-        return AcceptResult(accept, mark)
+        val isResumption = (prevIndex == SUSPENDED_INDEX && currentIndex != SUSPENDED_INDEX)
+        if (isResumption) assert(accept) // Pretty sure this has to be true?
+        return AcceptResult(accept = accept, isResumption = isResumption, mark = mark)
     }
 
     private fun doAcceptFrame(
@@ -447,7 +450,8 @@ internal class Vp9QualityFilter(parentLogger: Logger) {
 
     data class AcceptResult(
         val accept: Boolean,
-        val mark: Boolean = false
+        val isResumption: Boolean,
+        val mark: Boolean
     )
 
     companion object {

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionTest.kt
@@ -53,7 +53,7 @@ class Vp9AdaptiveSourceProjectionTest {
         val generator = ScalableVp9PacketGenerator(1)
         val packetInfo = generator.nextPacket()
         val packet = packetInfo.packetAs<Vp9Packet>()
-        val targetIndex = getIndex(0, 0, 0)
+        val targetIndex = getIndex(eid = 0, sid = 0, tid = 0)
         Assert.assertTrue(
             context.accept(
                 packetInfo,
@@ -265,205 +265,205 @@ class Vp9AdaptiveSourceProjectionTest {
     @Test
     fun simpleNonScalableTest() {
         val generator = NonScalableVp9PacketGenerator()
-        runInOrderTest(generator, getIndex(0, 0, 0))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 0))
     }
 
     @Test
     fun simpleProjectionTest() {
         val generator = ScalableVp9PacketGenerator(1)
-        runInOrderTest(generator, getIndex(0, 0, 2))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 2))
     }
 
     @Test
     fun filteredProjectionTest() {
         val generator = ScalableVp9PacketGenerator(1)
-        runInOrderTest(generator, getIndex(0, 0, 0))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 0))
     }
 
     @Test
     fun largerFrameProjectionTest() {
         val generator = ScalableVp9PacketGenerator(3)
-        runInOrderTest(generator, getIndex(0, 0, 2))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 2))
     }
 
     @Test
     fun largerFrameFilteredTest() {
         val generator = ScalableVp9PacketGenerator(3)
-        runInOrderTest(generator, getIndex(0, 0, 0))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 0))
     }
 
     @Test
     fun hugeFrameTest() {
         val generator = ScalableVp9PacketGenerator(200)
-        runInOrderTest(generator, getIndex(0, 0, 0))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 0))
     }
 
     @Test
     fun simpleKsvcTest() {
         val generator = ScalableVp9PacketGenerator(1, 3)
-        runInOrderTest(generator, getIndex(0, 2, 2))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 2, tid = 2))
     }
 
     @Test
     fun filteredKsvcTest() {
         val generator = ScalableVp9PacketGenerator(1, 3)
-        runInOrderTest(generator, getIndex(0, 0, 2))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 2))
     }
 
     @Test
     fun temporalFilteredKsvcTest() {
         val generator = ScalableVp9PacketGenerator(1, 3)
-        runInOrderTest(generator, getIndex(0, 2, 0))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 2, tid = 0))
     }
 
     @Test
     fun spatialAndTemporalFilteredKsvcTest() {
         val generator = ScalableVp9PacketGenerator(1, 3)
-        runInOrderTest(generator, getIndex(0, 0, 0))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 0))
     }
 
     @Test
     fun largerKsvcTest() {
         val generator = ScalableVp9PacketGenerator(3, 3)
-        runInOrderTest(generator, getIndex(0, 2, 2))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 2, tid = 2))
     }
 
     @Test
     fun largerFilteredKsvcTest() {
         val generator = ScalableVp9PacketGenerator(3, 3)
-        runInOrderTest(generator, getIndex(0, 0, 2))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 2))
     }
 
     @Test
     fun largerTemporalFilteredKsvcTest() {
         val generator = ScalableVp9PacketGenerator(3, 3)
-        runInOrderTest(generator, getIndex(0, 2, 0))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 2, tid = 0))
     }
 
     @Test
     fun largerSpatialAndTemporalFilteredKsvcTest() {
         val generator = ScalableVp9PacketGenerator(3, 3)
-        runInOrderTest(generator, getIndex(0, 0, 0))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 0))
     }
 
     @Test
     fun simpleSvcTest() {
         val generator = ScalableVp9PacketGenerator(1, 3, false)
-        runInOrderTest(generator, getIndex(0, 2, 2))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 2, tid = 2))
     }
 
     @Test
     fun filteredSvcTest() {
         val generator = ScalableVp9PacketGenerator(1, 3, false)
-        runInOrderTest(generator, getIndex(0, 0, 2))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 2))
     }
 
     @Test
     fun temporalFilteredSvcTest() {
         val generator = ScalableVp9PacketGenerator(1, 3, false)
-        runInOrderTest(generator, getIndex(0, 2, 0))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 2, tid = 0))
     }
 
     @Test
     fun spatialAndTemporalFilteredSvcTest() {
         val generator = ScalableVp9PacketGenerator(1, 3, false)
-        runInOrderTest(generator, getIndex(0, 0, 0))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 0))
     }
 
     @Test
     fun largerSvcTest() {
         val generator = ScalableVp9PacketGenerator(3, 3, false)
-        runInOrderTest(generator, getIndex(0, 2, 2))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 2, tid = 2))
     }
 
     @Test
     fun largerFilteredSvcTest() {
         val generator = ScalableVp9PacketGenerator(3, 3, false)
-        runInOrderTest(generator, getIndex(0, 0, 2))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 2))
     }
 
     @Test
     fun largerTemporalFilteredSvcTest() {
         val generator = ScalableVp9PacketGenerator(3, 3, false)
-        runInOrderTest(generator, getIndex(0, 2, 0))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 2, tid = 0))
     }
 
     @Test
     fun largerSpatialAndTemporalFilteredSvcTest() {
         val generator = ScalableVp9PacketGenerator(3, 3, false)
-        runInOrderTest(generator, getIndex(0, 0, 0))
+        runInOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 0))
     }
 
     @Test
     fun simpleOutOfOrderTest() {
         val generator = ScalableVp9PacketGenerator(1)
-        runOutOfOrderTest(generator, getIndex(0, 0, 2))
+        runOutOfOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 2))
     }
 
     @Test
     fun largerOutOfOrderTest() {
         val generator = ScalableVp9PacketGenerator(3)
-        runOutOfOrderTest(generator, getIndex(0, 0, 2))
+        runOutOfOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 2))
     }
 
     @Test
     fun filteredOutOfOrderTest() {
         val generator = ScalableVp9PacketGenerator(1)
-        runOutOfOrderTest(generator, getIndex(0, 0, 0))
+        runOutOfOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 0))
     }
 
     @Test
     fun largerFilteredOutOfOrderTest() {
         val generator = ScalableVp9PacketGenerator(3)
-        runOutOfOrderTest(generator, getIndex(0, 0, 0))
+        runOutOfOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 0))
     }
 
     @Test
     fun simpleKsvcOutOfOrderTest() {
         val generator = ScalableVp9PacketGenerator(1, 3)
-        runOutOfOrderTest(generator, getIndex(0, 2, 2), 3)
+        runOutOfOrderTest(generator, getIndex(eid = 0, sid = 2, tid = 2), 3)
     }
 
     @Test
     fun largerKsvcOutOfOrderTest() {
         val generator = ScalableVp9PacketGenerator(3, 3)
-        runOutOfOrderTest(generator, getIndex(0, 2, 2), 7)
+        runOutOfOrderTest(generator, getIndex(eid = 0, sid = 2, tid = 2), 7)
     }
 
     @Test
     fun filteredKsvcOutOfOrderTest() {
         val generator = ScalableVp9PacketGenerator(1, 3)
-        runOutOfOrderTest(generator, getIndex(0, 0, 2), 3)
+        runOutOfOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 2), 3)
     }
 
     @Test
     fun largerFilteredKsvcOutOfOrderTest() {
         val generator = ScalableVp9PacketGenerator(3, 3)
-        runOutOfOrderTest(generator, getIndex(0, 0, 2), 7)
+        runOutOfOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 2), 7)
     }
 
     @Test
     fun simpleSvcOutOfOrderTest() {
         val generator = ScalableVp9PacketGenerator(1, 3, false)
-        runOutOfOrderTest(generator, getIndex(0, 2, 2), 3)
+        runOutOfOrderTest(generator, getIndex(eid = 0, sid = 2, tid = 2), 3)
     }
 
     @Test
     fun largerSvcOutOfOrderTest() {
         val generator = ScalableVp9PacketGenerator(3, 3, false)
-        runOutOfOrderTest(generator, getIndex(0, 2, 2), 7)
+        runOutOfOrderTest(generator, getIndex(eid = 0, sid = 2, tid = 2), 7)
     }
 
     @Test
     fun filteredSvcOutOfOrderTest() {
         val generator = ScalableVp9PacketGenerator(1, 3, false)
-        runOutOfOrderTest(generator, getIndex(0, 0, 2), 3)
+        runOutOfOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 2), 3)
     }
 
     @Test
     fun largerFilteredSvcOutOfOrderTest() {
         val generator = ScalableVp9PacketGenerator(3, 3, false)
-        runOutOfOrderTest(generator, getIndex(0, 0, 2), 7)
+        runOutOfOrderTest(generator, getIndex(eid = 0, sid = 0, tid = 2), 7)
     }
 
     @Test
@@ -478,7 +478,7 @@ class Vp9AdaptiveSourceProjectionTest {
         )
         val firstPacketInfo = generator.nextPacket()
         val firstPacket = firstPacketInfo.packetAs<Vp9Packet>()
-        val targetIndex = getIndex(0, 0, 2)
+        val targetIndex = getIndex(eid = 0, sid = 0, tid = 2)
         for (i in 0..2) {
             val packetInfo = generator.nextPacket()
             val packet = packetInfo.packetAs<Vp9Packet>()
@@ -521,7 +521,7 @@ class Vp9AdaptiveSourceProjectionTest {
         )
         val firstPacketInfo = generator.nextPacket()
         val firstPacket = firstPacketInfo.packetAs<Vp9Packet>()
-        val targetIndex = getIndex(0, 0, 2)
+        val targetIndex = getIndex(eid = 0, sid = 0, tid = 2)
         for (i in 0..3) {
             val packetInfo = generator.nextPacket()
             val packet = packetInfo.packetAs<Vp9Packet>()
@@ -574,7 +574,7 @@ class Vp9AdaptiveSourceProjectionTest {
         )
         val firstPacketInfo = generator.nextPacket()
         val firstPacket = firstPacketInfo.packetAs<Vp9Packet>()
-        val targetIndex = getIndex(0, 0, 2)
+        val targetIndex = getIndex(eid = 0, sid = 0, tid = 2)
         var lowestSeq = Integer.MAX_VALUE
         for (i in 0..10) {
             val packetInfo = generator.nextPacket()
@@ -625,7 +625,7 @@ class Vp9AdaptiveSourceProjectionTest {
             diagnosticContext, payloadType,
             initialState, logger
         )
-        val targetIndex = getIndex(1, 0, 2)
+        val targetIndex = getIndex(eid = 1, sid = 0, tid = 2)
         var expectedSeq = 10001
         var expectedTs: Long = 1003000
         for (i in 0..9999) {
@@ -671,7 +671,7 @@ class Vp9AdaptiveSourceProjectionTest {
         var expectedTs: Long = 1003000
         var expectedPicId = 0
         var expectedTl0PicIdx = 0
-        var targetIndex = getIndex(0, 0, 2)
+        var targetIndex = getIndex(eid = 0, sid = 0, tid = 2)
 
         /* Start by wanting spatial layer 0 */
         for (i in 0..899) {
@@ -721,7 +721,7 @@ class Vp9AdaptiveSourceProjectionTest {
         }
 
         /* Switch to wanting spatial layer 1, but don't send a keyframe. We should stay at the higher layer. */
-        targetIndex = getIndex(1, 0, 2)
+        targetIndex = getIndex(eid = 1, sid = 0, tid = 2)
         for (i in 0..89) {
             val srPacket1 = generator1.srPacket
             val packetInfo1 = generator1.nextPacket()
@@ -987,25 +987,25 @@ class Vp9AdaptiveSourceProjectionTest {
     @Test
     fun largeDropoutTest() {
         val generator = ScalableVp9PacketGenerator(1)
-        runLargeDropoutTest(generator, 2)
+        runLargeDropoutTest(generator, getIndex(eid = 0, sid = 0, tid = 2))
     }
 
     @Test
     fun filteredLargeDropoutTest() {
         val generator = ScalableVp9PacketGenerator(1)
-        runLargeDropoutTest(generator, 0)
+        runLargeDropoutTest(generator, getIndex(eid = 0, sid = 0, tid = 0))
     }
 
     @Test
     fun largeFrameDropoutTest() {
         val generator = ScalableVp9PacketGenerator(3)
-        runLargeDropoutTest(generator, 2)
+        runLargeDropoutTest(generator, getIndex(eid = 0, sid = 0, tid = 2))
     }
 
     @Test
     fun filteredLargeFrameDropoutTest() {
         val generator = ScalableVp9PacketGenerator(3)
-        runLargeDropoutTest(generator, 0)
+        runLargeDropoutTest(generator, getIndex(eid = 0, sid = 0, tid = 0))
     }
 
     private fun runSourceSuspensionTest(generator: Vp9PacketGenerator, targetIndex: Int) {
@@ -1172,25 +1172,25 @@ class Vp9AdaptiveSourceProjectionTest {
     @Test
     fun sourceSuspensionTest() {
         val generator = ScalableVp9PacketGenerator(1)
-        runSourceSuspensionTest(generator, 2)
+        runSourceSuspensionTest(generator, getIndex(eid = 0, sid = 0, tid = 2))
     }
 
     @Test
     fun filteredSourceSuspensionTest() {
         val generator = ScalableVp9PacketGenerator(1)
-        runSourceSuspensionTest(generator, 0)
+        runSourceSuspensionTest(generator, getIndex(eid = 0, sid = 0, tid = 0))
     }
 
     @Test
     fun largeFrameSourceSuspensionTest() {
         val generator = ScalableVp9PacketGenerator(3)
-        runSourceSuspensionTest(generator, 2)
+        runSourceSuspensionTest(generator, getIndex(eid = 0, sid = 0, tid = 2))
     }
 
     @Test
     fun filteredLargeFrameSourceSuspensionTest() {
         val generator = ScalableVp9PacketGenerator(3)
-        runSourceSuspensionTest(generator, 0)
+        runSourceSuspensionTest(generator, getIndex(eid = 0, sid = 0, tid = 0))
     }
 
     private abstract class Vp9PacketGenerator {

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionTest.kt
@@ -1030,6 +1030,7 @@ class Vp9AdaptiveSourceProjectionTest {
         var packet: Vp9Packet
 
         var lastPacketAccepted = false
+        var lastPidAccepted = -1
 
         for (i in 0..999) {
             packetInfo = generator.nextPacket()
@@ -1056,6 +1057,7 @@ class Vp9AdaptiveSourceProjectionTest {
                 Assert.assertEquals(expectedTl0PicIdx, packet.TL0PICIDX)
                 expectedSeq = RtpUtils.applySequenceNumberDelta(expectedSeq, 1)
                 lastPacketAccepted = true
+                lastPidAccepted = packet.pictureId
             } else {
                 Assert.assertFalse(accepted)
                 lastPacketAccepted = false
@@ -1128,6 +1130,7 @@ class Vp9AdaptiveSourceProjectionTest {
                     expectedTs = RtpUtils.applyTimestampDelta(expectedTs, 3000)
                 }
             }
+            expectedPicId = applyExtendedPictureIdDelta(lastPidAccepted, 1)
 
             for (i in 0..999) {
                 packetInfo = generator.nextPacket()
@@ -1154,6 +1157,7 @@ class Vp9AdaptiveSourceProjectionTest {
                     Assert.assertEquals(expectedTl0PicIdx, packet.TL0PICIDX)
                     expectedSeq = RtpUtils.applySequenceNumberDelta(expectedSeq, 1)
                     lastPacketAccepted = true
+                    lastPidAccepted = packet.pictureId
                 } else {
                     Assert.assertFalse(accepted)
                     lastPacketAccepted = false

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionTest.kt
@@ -927,8 +927,7 @@ class Vp9AdaptiveSourceProjectionTest {
                 expectedPicId = applyExtendedPictureIdDelta(expectedPicId, 1)
             }
         }
-        var gap = 64
-        while (gap < 65536) {
+        for (gap in 64..65536 step { it * 2 }) {
             for (i in 0 until gap) {
                 generator.nextPacket()
             }
@@ -982,7 +981,6 @@ class Vp9AdaptiveSourceProjectionTest {
                     expectedPicId = applyExtendedPictureIdDelta(expectedPicId, 1)
                 }
             }
-            gap *= 2
         }
     }
 
@@ -1067,9 +1065,9 @@ class Vp9AdaptiveSourceProjectionTest {
                 expectedPicId = applyExtendedPictureIdDelta(expectedPicId, 1)
             }
         }
-        var suspended = 64
-        while (suspended < 65536) {
-            /* If the last frame was accepted, finish the current frame. */
+        for (suspended in 64..65536 step { it * 2 }) {
+            /* If the last frame was accepted, finish the current frame if this generator is creating multi-packet
+                frames. */
             if (lastPacketAccepted) {
                 while (generator.packetOfFrame != 0) {
                     packetInfo = generator.nextPacket()
@@ -1118,6 +1116,7 @@ class Vp9AdaptiveSourceProjectionTest {
 
             /* Request a keyframe.  Will be sent as of the next frame. */
             generator.requestKeyframe()
+            /* If this generator is creating multi-packet frames, finish the previous frame. */
             while (generator.packetOfFrame != 0) {
                 packetInfo = generator.nextPacket()
                 packet = packetInfo.packetAs()
@@ -1167,7 +1166,6 @@ class Vp9AdaptiveSourceProjectionTest {
                     expectedPicId = applyExtendedPictureIdDelta(expectedPicId, 1)
                 }
             }
-            suspended *= 2
         }
     }
 
@@ -1510,3 +1508,6 @@ class Vp9AdaptiveSourceProjectionTest {
         }
     }
 }
+
+private infix fun IntRange.step(next: (Int) -> Int) =
+    generateSequence(first, next).takeWhile { if (first < last) it <= last else it >= last }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilterTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilterTest.kt
@@ -454,7 +454,8 @@ private class SingleLayerFrameGenerator : FrameGenerator() {
             usesInterLayerDependency = false,
             isInterPicturePredicted = (pictureCount > 0),
             pictureId = pictureCount,
-            tl0PICIDX = pictureCount,
+            index = pictureCount,
+            tl0PICIDX = pictureCount and 0xff,
             isKeyframe = (pictureCount == 0),
             numSpatialLayers = if (pictureCount == 0) 1 else -1
         )
@@ -496,7 +497,8 @@ private class TemporallyScaledFrameGenerator : FrameGenerator() {
             usesInterLayerDependency = false,
             isInterPicturePredicted = (pictureCount > 0),
             pictureId = pictureCount,
-            tl0PICIDX = tl0Count,
+            index = pictureCount,
+            tl0PICIDX = tl0Count and 0xff,
             isKeyframe = (pictureCount == 0),
             numSpatialLayers = if (pictureCount == 0) 1 else -1
         )
@@ -543,7 +545,8 @@ private class SVCFrameGenerator : FrameGenerator() {
             usesInterLayerDependency = sLayer > 0,
             isInterPicturePredicted = !keyframePicture,
             pictureId = pictureCount,
-            tl0PICIDX = tl0Count,
+            index = pictureCount,
+            tl0PICIDX = tl0Count and 0xff,
             isKeyframe = keyframePicture && sLayer == 0,
             numSpatialLayers = if (keyframePicture && sLayer == 0) 3 else -1
         )
@@ -595,7 +598,8 @@ private class KSVCFrameGenerator : FrameGenerator() {
             usesInterLayerDependency = keyframePicture && sLayer > 0,
             isInterPicturePredicted = !keyframePicture,
             pictureId = pictureCount,
-            tl0PICIDX = tl0Count,
+            index = pictureCount,
+            tl0PICIDX = tl0Count and 0xff,
             isKeyframe = keyframePicture && sLayer == 0,
             numSpatialLayers = if (keyframePicture && sLayer == 0) 3 else -1
         )
@@ -647,7 +651,8 @@ private class SimulcastFrameGenerator : FrameGenerator() {
             usesInterLayerDependency = false,
             isInterPicturePredicted = !keyframePicture,
             pictureId = pictureCount,
-            tl0PICIDX = tl0Count,
+            index = pictureCount,
+            tl0PICIDX = tl0Count and 0xff,
             isKeyframe = keyframePicture,
             numSpatialLayers = if (keyframePicture) 1 else -1
         )


### PR DESCRIPTION
Otherwise Chrome's decoder can get confused, and decode the video incorrectly.