### PR TITLE
Improves debuggability of bitrate allocations.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.java
@@ -157,6 +157,7 @@ public class BandwidthAllocator<T extends MediaSourceContainer>
         JSONObject debugState = new JSONObject();
         debugState.put("trustBwe", BitrateControllerConfig.trustBwe());
         debugState.put("bweBps", bweBps);
+        debugState.put("allocation", allocation.getDebugState());
         debugState.put("allocationSettings", allocationSettings.toJson());
         debugState.put("effectiveConstraints", effectiveConstraints);
         return debugState;
@@ -360,9 +361,15 @@ public class BandwidthAllocator<T extends MediaSourceContainer>
                     + getAvailableBandwidth() + " bps): " + String.join(",", suspendedIds));
         }
 
-        return new BandwidthAllocation(
-                sourceBitrateAllocations.stream().map(SingleSourceAllocation::getResult).collect(Collectors.toSet()),
-                oversending);
+        Set<SingleAllocation> allocations = new HashSet<>();
+
+        long targetBps = 0, idealBps = 0;
+        for (SingleSourceAllocation sourceBitrateAllocation : sourceBitrateAllocations) {
+            allocations.add(sourceBitrateAllocation.getResult());
+            targetBps += sourceBitrateAllocation.getTargetBitrate();
+            idealBps += sourceBitrateAllocation.getIdealBitrate();
+        }
+        return new BandwidthAllocation(allocations, oversending, idealBps, targetBps);
     }
 
     /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocation.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocation.kt
@@ -17,13 +17,16 @@ package org.jitsi.videobridge.cc.allocation
 
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.RtpLayerDesc
+import org.json.simple.JSONObject
 
 /**
  * The result of bandwidth allocation.
  */
 class BandwidthAllocation @JvmOverloads constructor(
     val allocations: Set<SingleAllocation>,
-    val oversending: Boolean = false
+    val oversending: Boolean = false,
+    val idealBps: Long = -1,
+    val targetBps: Long = -1,
 ) {
     val forwardedEndpoints: Set<String> =
         allocations.filter { it.isForwarded() }.map { it.endpoint.id }.toSet()
@@ -49,6 +52,12 @@ class BandwidthAllocation @JvmOverloads constructor(
     fun isForwarding(epId: String): Boolean = forwardedEndpoints.contains(epId)
 
     override fun toString(): String = "oversending=$oversending " + allocations.joinToString()
+
+    val debugState: JSONObject
+        get() = JSONObject().apply {
+            put("idealBps", idealBps)
+            put("targetBps", targetBps)
+        }
 }
 
 /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
@@ -141,6 +141,13 @@ internal class SingleSourceAllocation(
         get() = layers.getOrNull(targetIdx)
 
     /**
+     * Gets the ideal bitrate (in bps) for this endpoint allocation, i.e. the bitrate of the layer the bridge would
+     * forward if there were no (bandwidth) constraints.
+     */
+    val idealBitrate: Long
+        get() = layers.idealLayer?.bitrate?.toLong() ?: 0
+
+    /**
      * Exposed for testing only.
      */
     val preferredLayer: RtpLayerDesc?


### PR DESCRIPTION
In anticipation of using rtcstats for debugging quality related issues, I'm adding the ideal/target bitrates in the debug JSON (rtcstats pulls these).