### PR TITLE
Bump JMT:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-media-transform</artifactId>
-                <version>1.0-254-gee3be46</version>
+                <version>1.0-257-gc80afce</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
* Fix screenshares after vp9->vp8 switch.
* Make BWE and Overuse parameters configurable.
* Use reference equality for comparing buffers.