### PR TITLE
ref: use execute instead of submit

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -390,7 +390,7 @@ public class Conference
      */
     private void lastNEndpointsChangedAsync()
     {
-        TaskPools.IO_POOL.submit(() ->
+        TaskPools.IO_POOL.execute(() ->
         {
             try
             {

--- a/jvb/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
@@ -158,7 +158,7 @@ public class ConferenceSpeechActivity
             endpointListChanged = updateLastNEndpoints();
         }
 
-        TaskPools.IO_POOL.submit(() -> {
+        TaskPools.IO_POOL.execute(() -> {
             listener.recentSpeakersChanged(recentSpeakers.getRecentSpeakers(), true);
             if (endpointListChanged)
             {
@@ -319,7 +319,7 @@ public class ConferenceSpeechActivity
             {
                 return;
             }
-            TaskPools.IO_POOL.submit(() -> {
+            TaskPools.IO_POOL.execute(() -> {
                 if (finalRecentSpeakersChanged)
                 {
                     listener.recentSpeakersChanged(recentSpeakers.getRecentSpeakers(), dominantSpeakerChanged);
@@ -341,7 +341,7 @@ public class ConferenceSpeechActivity
         }
         if (endpointsListChanged)
         {
-            TaskPools.IO_POOL.submit(() -> {
+            TaskPools.IO_POOL.execute(() -> {
                 try
                 {
                     listener.lastNEndpointsChanged();

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.java
@@ -400,7 +400,7 @@ public class BandwidthAllocator<T extends MediaSourceContainer>
                 .compareTo(BitrateControllerConfig.maxTimeBetweenCalculations()) > 0)
         {
             logger.debug("Forcing an update");
-            TaskPools.CPU_POOL.submit((Runnable) this::update);
+            TaskPools.CPU_POOL.execute(this::update);
         }
     }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -340,8 +340,8 @@ class Endpoint @JvmOverloads constructor(
                         outgoingSrtpPacketQueue.add(packetInfo)
                     }
                 })
-                TaskPools.IO_POOL.submit(iceTransport::startReadingData)
-                TaskPools.IO_POOL.submit(dtlsTransport::startDtlsHandshake)
+                TaskPools.IO_POOL.execute(iceTransport::startReadingData)
+                TaskPools.IO_POOL.execute(dtlsTransport::startDtlsHandshake)
             }
 
             override fun failed() {
@@ -607,7 +607,7 @@ class Endpoint @JvmOverloads constructor(
     }
 
     fun acceptSctpConnection(sctpServerSocket: SctpServerSocket) {
-        TaskPools.IO_POOL.submit {
+        TaskPools.IO_POOL.execute {
             // We don't want to block the thread calling
             // onDtlsHandshakeComplete so run the socket acceptance in an IO
             // pool thread
@@ -675,7 +675,7 @@ class Endpoint @JvmOverloads constructor(
      */
     fun sendForwardedEndpointsMessage(forwardedEndpoints: Collection<String>) {
         val msg = ForwardedEndpointsMessage(forwardedEndpoints)
-        TaskPools.IO_POOL.submit {
+        TaskPools.IO_POOL.execute {
             try {
                 sendMessage(msg)
             } catch (t: Throwable) {
@@ -1167,7 +1167,7 @@ class Endpoint @JvmOverloads constructor(
 
             // Submit this to the pool since we wait on the lock and process any
             // cached packets here as well
-            TaskPools.IO_POOL.submit {
+            TaskPools.IO_POOL.execute {
                 // We grab the lock here so that we can set the SCTP manager and
                 // process any previously-cached packets as an atomic operation.
                 // It also prevents another thread from coming in via
@@ -1216,7 +1216,7 @@ class Endpoint @JvmOverloads constructor(
         fun setSctpManager(sctpManager: SctpManager) {
             // Submit this to the pool since we wait on the lock and process any
             // cached packets here as well
-            TaskPools.IO_POOL.submit {
+            TaskPools.IO_POOL.execute {
                 // We grab the lock here so that we can set the SCTP manager and
                 // process any previously-cached packets as an atomic operation.
                 // It also prevents another thread from coming in via

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayService.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayService.kt
@@ -88,7 +88,7 @@ class OctoRelayService {
     }
 
     fun start() {
-        TaskPools.IO_POOL.submit { udpTransport.startReadingData() }
+        TaskPools.IO_POOL.execute { udpTransport.startReadingData() }
     }
 
     fun stop() {


### PR DESCRIPTION
Replaces submit usages with submit. The problem with submit is that it returns a Future which should be handled, but is not. Any exception inside submit will be swallowed. The credit for fixing this one goes to Ben Kempe from Vowel.