### PR TITLE
fix: use dummy values for raddr and rport instead of dropping them.

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
@@ -482,7 +482,10 @@ private fun LocalCandidate.toCandidatePacketExtension(): CandidatePacketExtensio
     cpe.port = transportAddress.port
 
     relatedAddress?.let {
-        if (IceConfig.config.advertisePrivateCandidates || !it.isPrivateAddress()) {
+        if (!IceConfig.config.advertisePrivateCandidates && it.isPrivateAddress()) {
+            cpe.relAddr = "0.0.0.0"
+            cpe.relPort = 0
+        } else {
             cpe.relAddr = it.hostAddress
             cpe.relPort = it.port
         }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
@@ -484,7 +484,7 @@ private fun LocalCandidate.toCandidatePacketExtension(): CandidatePacketExtensio
     relatedAddress?.let {
         if (!IceConfig.config.advertisePrivateCandidates && it.isPrivateAddress()) {
             cpe.relAddr = "0.0.0.0"
-            cpe.relPort = 0
+            cpe.relPort = 9
         } else {
             cpe.relAddr = it.hostAddress
             cpe.relPort = it.port


### PR DESCRIPTION
Firefox can't handle ICE candidates where raddr or rport are missing. So we just use raddr=0.0.0.0 and rport=0 instead of dropping these values from the ICE candidate.