### PR TITLE
Add configurable filter for statistics sent to MUC.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/stats/MucStatsTransport.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/stats/MucStatsTransport.java
@@ -19,6 +19,7 @@ import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.signaling.api.*;
 import org.jitsi.videobridge.xmpp.*;
 import org.jitsi.xmpp.extensions.colibri.*;
+import java.util.List;
 
 /**
  * Implements a {@link StatsTransport} which publishes via Presence in an XMPP MUC.
@@ -49,7 +50,18 @@ public class MucStatsTransport
     {
         logger.debug(() -> "Publishing statistics through MUC: " + stats);
 
-        ColibriStatsExtension statsExt = Statistics.toXmppExtensionElement(stats);
+        ColibriStatsExtension statsExt;
+
+        if (xmppConnection.getConfig().getStatsFilterEnabled())
+        {
+            List<String> whitelist = xmppConnection.getConfig().getStatsWhitelist();
+            logger.debug(() -> "Statistics filter applied: " + whitelist);
+            statsExt = Statistics.toXmppExtensionElementFiltered(stats, whitelist);
+        }
+        else
+        {
+            statsExt = Statistics.toXmppExtensionElement(stats);
+        }
 
         if (JvbApiConfig.enabled())
         {

--- a/jvb/src/main/java/org/jitsi/videobridge/stats/Statistics.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/stats/Statistics.java
@@ -55,6 +55,27 @@ public abstract class Statistics
     }
 
     /**
+     * Formats statistics in <tt>ColibriStatsExtension</tt> object
+     * @param statistics the statistics instance
+     * @param whitelist which of the statistics to use
+     * @return the <tt>ColibriStatsExtension</tt> instance.
+     */
+    public static ColibriStatsExtension toXmppExtensionElementFiltered(
+            Statistics statistics, List<String> whitelist)
+    {
+        ColibriStatsExtension ext = new ColibriStatsExtension();
+        Map<String, Object> m = statistics.getStats();
+        whitelist.forEach(k -> {
+            Object v = m.get(k);
+            if (v != null)
+            {
+                ext.addStat(new ColibriStatsExtension.Stat(k, v));
+            }
+        });
+        return ext;
+    }
+
+    /**
      * The <tt>ReadWriteLock</tt> which synchronizes the access to and/or
      * modification of the state of this instance. Replaces
      * <tt>synchronized</tt> blocks in order to reduce the number of exclusive

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/config/XmppClientConnectionConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/config/XmppClientConnectionConfig.kt
@@ -49,7 +49,7 @@ class XmppClientConnectionConfig {
     }
 
     /**
-     * The interval at which presence updates (with updates stats/status) are published. Allow to be overriden by
+     * The interval at which presence updates (with updates stats/status) are published. Allow to be overridden by
      * legacy-style "stats-transports" config.
      */
     val presenceInterval: Duration = StatsCollector.config.transportConfigs.stream()
@@ -57,6 +57,20 @@ class XmppClientConnectionConfig {
         .map(StatsTransportConfig::interval)
         .findFirst()
         .orElse(presenceIntervalProperty)
+
+    /**
+     * Whether to filter the statistics.
+     */
+    val statsFilterEnabled: Boolean by config {
+        "videobridge.apis.xmpp-client.stats-filter.enabled".from(JitsiConfig.newConfig)
+    }
+
+    /**
+     * The set of statistics to send, when filtering is enabled.
+     */
+    val statsWhitelist: List<String> by config {
+        "videobridge.apis.xmpp-client.stats-filter.whitelist".from(JitsiConfig.newConfig)
+    }
 
     companion object {
         /**

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -64,6 +64,18 @@ videobridge {
       # The interval at which presence is published in the configured MUCs.
       presence-interval = ${videobridge.stats.interval}
 
+      # Controls which statistics are sent.
+      stats-filter {
+        # Whether to filter the statistics.
+        # If true, send whitelisted keys only. If false, send all statistics.
+        enabled = false
+
+        # Which statistics to send, when filter is enabled.
+        # Ignored if filter is disabled.
+        whitelist = ["current_timestamp", "graceful_shutdown", "octo_version",
+           "region", "relay_id", "stress_level", "version"]
+      }
+
       # The size of the Smack JID cache
       jid-cache-size = 1000
 

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -72,8 +72,8 @@ videobridge {
 
         # Which statistics to send, when filter is enabled.
         # Ignored if filter is disabled.
-        whitelist = ["current_timestamp", "graceful_shutdown", "octo_version",
-           "region", "relay_id", "stress_level", "version"]
+        whitelist = ["average_participant_stress", "current_timestamp", "graceful_shutdown",
+           "octo_version", "region", "relay_id", "stress_level", "version"]
       }
 
       # The size of the Smack JID cache


### PR DESCRIPTION
Filter is disabled by default.
If enabled, the default whitelist is the set of statistics currently in use.