### PR TITLE
feat: allocate multiple streams per endpoint

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/Layers.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/Layers.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright @ 2021 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.cc.allocation
+
+import org.jitsi.nlj.RtpLayerDesc
+
+/**
+ * Saves the bitrate of a specific [RtpLayerDesc] at a specific point in time.
+ */
+data class LayerSnapshot(val layer: RtpLayerDesc, val bitrate: Double)
+
+/**
+ * An immutable representation of the layers to be considered when allocating bandwidth for an endpoint. The order is
+ * ascending by preference (and not necessarily bitrate).
+ */
+data class Layers(
+    val layers: List<LayerSnapshot>,
+    /** The index of the "preferred" layer, i.e. the layer up to which we allocate eagerly. */
+    val preferredIndex: Int,
+    /**
+     * The index of the layer which will be selected if oversending is enabled. If set to -1, oversending is disabled.
+     */
+    val oversendIndex: Int
+) : List<LayerSnapshot> by layers {
+    val preferredLayer = layers.getOrNull(preferredIndex)
+    val oversendLayer = layers.getOrNull(oversendIndex)
+    val idealLayer = layers.lastOrNull()
+
+    companion object {
+        val noLayers = Layers(emptyList(), -1, -1)
+    }
+}
+
+/**
+ * Checks if the [Layers] instance effectively describes a single layer. When the temporal layer fields are used but
+ * all frames belong to the base layer we see multiple entries in [this.layers], but they represent the same set of
+ * frames.
+ */
+fun Layers.hasOnlyOneLayer(): Boolean = layers.isNotEmpty() &&
+    layers.all { it.layer.height == layers[0].layer.height && it.bitrate == layers[0].bitrate }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation2.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation2.kt
@@ -32,7 +32,7 @@ import java.time.Clock
  *
  * @author George Politis
  */
-internal class SingleSourceAllocation(
+internal class SingleSourceAllocation2(
     val endpoint: MediaSourceContainer,
     /** The constraints to use while allocating bandwidth to this endpoint. */
     val constraints: VideoConstraints,
@@ -191,11 +191,11 @@ internal class SingleSourceAllocation(
 
     override fun toString(): String {
         return (
-            "[id=" + endpoint.id +
-                " constraints=" + constraints +
-                " ratedPreferredIdx=" + layers.preferredIndex +
-                " ratedTargetIdx=" + targetIdx
-            )
+                "[id=" + endpoint.id +
+                        " constraints=" + constraints +
+                        " ratedPreferredIdx=" + layers.preferredIndex +
+                        " ratedTargetIdx=" + targetIdx
+                )
     }
 
     /**


### PR DESCRIPTION
Extract Layers data structures into a separate file.

Creates SingleSourceAllocation2.kt which is to be used
by the multi-stream support flow. Eventually this will
be merged later once all changes are identified and
should we still agree it makes sense to merge (as opposed
to keeping separate and deleting old classes once deprecated).

Branches off the multi stream feature flag for the allocation
algorithm in the BandwidthAllocator.java.