### PR TITLE
log4j2.xml: Mitigate CVE-2021-44228

### DIFF
--- a/config/log4j2.xml
+++ b/config/log4j2.xml
@@ -6,7 +6,7 @@
     <Appenders>
         <RollingFile name="RollingFile" fileName="${log-path}/cs.log"
                  filePattern="${log-path}/$${date:yyyy-MM}/cs-%d{MM-dd-yyyy}-%i.log.gz">
-			<PatternLayout pattern="%d %-5p (%F:%L) - %m%n"/>
+			<PatternLayout pattern="%d %-5p (%F:%L) - %m{nolookups}%n"/>
       		<Policies>
         		<TimeBasedTriggeringPolicy />
         		<SizeBasedTriggeringPolicy size="250 MB"/>
@@ -14,7 +14,7 @@
     	</RollingFile>
     	<!-- 
     	<Console name="STDOUT" target="SYSTEM_OUT">
-      		<PatternLayout pattern="%d %-5p (%F:%L) - %m%n"/>
+      		<PatternLayout pattern="%d %-5p (%F:%L) - %m{nolookups}%n"/>
     	</Console>
     	 -->
     </Appenders>


### PR DESCRIPTION
Relates to #1773.

This is one of a few possible mitigations for the log4j2 RCE. This avoids the need to immediately update the dependency, though that should happen afterwards.

If we can get a rebuild if the packages and the container with this fix merged folks can get to deploying the update in case they don't have an easy way of directly managing `log4j2.xml` themselves right now.