### PR TITLE
chore: Remove the sentry and agafua-syslog runtime dependencies.

### DIFF
--- a/jvb/lib/logging.properties
+++ b/jvb/lib/logging.properties
@@ -18,8 +18,8 @@ com.agafua.syslog.SyslogHandler.hostname = localhost
 com.agafua.syslog.SyslogHandler.formatter = org.jitsi.utils.logging2.JitsiLogFormatter
 com.agafua.syslog.SyslogHandler.escapeNewlines = false
 
-# Sentry (uncomment handler to use)
-io.sentry.jul.SentryHandler.level=WARNING
+# Sentry (also add the sentry handler to "handlers" to use)
+# io.sentry.jul.SentryHandler.level=WARNING
 
 # time series logging
 java.util.logging.SimpleFormatter.format= %5$s%n

--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -181,19 +181,6 @@
       <artifactId>reflections</artifactId>
       <version>0.9.11</version>
     </dependency>
-    <!-- runtime -->
-    <dependency>
-      <groupId>rusv</groupId>
-      <artifactId>agafua-syslog</artifactId>
-      <version>0.4</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.sentry</groupId>
-      <artifactId>sentry</artifactId>
-      <version>5.3.0</version>
-      <scope>runtime</scope>
-    </dependency>
     <!-- test -->
     <dependency>
       <groupId>io.mockk</groupId>


### PR DESCRIPTION
This is to stop shipping non-essential jars and reduce potential exposure to vulnerabilities. Setting up sentry requires setting an environment variable (and potentially more changes?), so it should be easy to adapt to also include the sentry jar in the classpath.

cc @saghul @sapkra  