### PR TITLE
Refactor colibri shims

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -343,14 +343,6 @@ public abstract class AbstractEndpoint
     public abstract void requestKeyframe();
 
     /**
-     * Recreates this {@link AbstractEndpoint}'s media sources based
-     * on the sources (and source groups) described in its video channel.
-     */
-    public void recreateMediaSources()
-    {
-    }
-
-    /**
      * Describes this endpoint's transport in the given channel bundle XML
      * element.
      *

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -27,11 +27,15 @@ import org.jitsi.utils.logging.*;
 import org.jitsi.utils.logging2.Logger;
 import org.jitsi.utils.logging2.LoggerImpl;
 import org.jitsi.utils.logging2.*;
+import org.jitsi.utils.queue.*;
 import org.jitsi.videobridge.message.*;
 import org.jitsi.videobridge.octo.*;
 import org.jitsi.videobridge.shim.*;
 import org.jitsi.videobridge.util.*;
+import org.jitsi.videobridge.xmpp.*;
 import org.jitsi.xmpp.extensions.colibri.*;
+import org.jitsi.xmpp.util.*;
+import org.jivesoftware.smack.packet.*;
 import org.json.simple.*;
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.impl.*;
@@ -159,6 +163,8 @@ public class Conference
      */
     private final ConferenceShim shim;
 
+    private final PacketQueue<XmppConnection.ColibriRequest> colibriQueue;
+
     //TODO not public
     final public EncodingsManager encodingsManager = new EncodingsManager();
 
@@ -223,6 +229,41 @@ public class Conference
         this.gid = gid;
         this.conferenceName = conferenceName;
         this.shim = new ConferenceShim(this, logger);
+        colibriQueue = new PacketQueue<>(
+                Integer.MAX_VALUE,
+                true,
+                "colibri-queue",
+                request ->
+                {
+                    try
+                    {
+                        long start = System.currentTimeMillis();
+                        IQ response = shim.handleColibriConferenceIQ(request.getRequest());
+                        long end = System.currentTimeMillis();
+                        long processingDelay = end - start;
+                        long totalDelay = end - request.getReceiveTime();
+                        request.getProcessingDelayStats().addDelay(processingDelay);
+                        request.getTotalDelayStats().addDelay(totalDelay);
+                        if (processingDelay > 100)
+                        {
+                            logger.warn("Took " + processingDelay + " ms to process an IQ (total delay "
+                                    + totalDelay + " ms): " + request.getRequest().toXML());
+                        }
+                        request.getCallback().invoke(response);
+                    }
+                    catch (Throwable e)
+                    {
+                        logger.warn("Failed to handle colibri request: ", e);
+                        request.getCallback().invoke(
+                                IQUtils.createError(
+                                        request.getRequest(),
+                                        StanzaError.Condition.internal_server_error,
+                                        e.getMessage()));
+                    }
+                    return true;
+                },
+                TaskPools.IO_POOL
+        );
 
         speechActivity = new ConferenceSpeechActivity(new SpeechActivityListener());
         updateLastNEndpointsFuture = TaskPools.SCHEDULED_POOL.scheduleAtFixedRate(() -> {
@@ -244,6 +285,11 @@ public class Conference
         videobridgeStatistics.totalConferencesCreated.incrementAndGet();
         epConnectionStatusMonitor = new EndpointConnectionStatusMonitor(this, TaskPools.SCHEDULED_POOL, logger);
         epConnectionStatusMonitor.start();
+    }
+
+    public void enqueueColibriRequest(XmppConnection.ColibriRequest request)
+    {
+        colibriQueue.add(request);
     }
 
     /**
@@ -545,7 +591,7 @@ public class Conference
 
         logger.info("Expiring.");
 
-        shim.close();
+        colibriQueue.close();
 
         epConnectionStatusMonitor.stop();
 

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -100,6 +100,19 @@ public class Conference
      */
     private final AtomicBoolean expired = new AtomicBoolean(false);
 
+    public long getLocalAudioSsrc()
+    {
+        return localAudioSsrc;
+    }
+
+    public long getLocalVideoSsrc()
+    {
+        return localVideoSsrc;
+    }
+
+    private final long localAudioSsrc = Videobridge.RANDOM.nextLong() & 0xffff_ffffL;
+    private final long localVideoSsrc = Videobridge.RANDOM.nextLong() & 0xffff_ffffL;
+
     /**
      * The locally unique identifier of this conference (i.e. unique across the
      * conferences on this bridge). It is locally generated and exposed via

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -414,7 +414,7 @@ public class Videobridge
         }
 
         // It is now the responsibility of Conference to send a response.
-        conference.getShim().enqueueColibriRequest(request);
+        conference.enqueueColibriRequest(request);
     }
 
     private @NotNull Conference getOrCreateConference(ColibriConferenceIQ conferenceIq)

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/conferences/Conferences.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/conferences/Conferences.java
@@ -168,8 +168,7 @@ public class Conferences
 
     private String getVideobridgeIqResponseAsJson(ColibriConferenceIQ request)
     {
-        IQ responseIq = videobridge
-                .handleColibriConferenceIQ(request);
+        IQ responseIq = videobridge.handleColibriConferenceIQ(request);
 
         if (responseIq.getError() != null)
         {

--- a/jvb/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/shim/ChannelShim.java
@@ -160,7 +160,13 @@ public class ChannelShim
         this.contentShim = contentShim;
         this.creationTimestampMs = System.currentTimeMillis();
         this.logger = parentLogger.createChildLogger(ChannelShim.class.getName());
-        endpoint.addChannel(this);
+        EndpointShim endpointShim = endpoint.getEndpointShim();
+        if (endpointShim == null)
+        {
+            endpointShim = new EndpointShim(endpoint);
+            endpoint.setEndpointShim(endpointShim);
+        }
+        endpointShim.addChannel(this);
     }
 
     /**
@@ -192,7 +198,11 @@ public class ChannelShim
         if (expire == 0)
         {
             expired = true;
-            endpoint.removeChannel(this);
+            EndpointShim endpointShim = endpoint.getEndpointShim();
+            if (endpointShim != null)
+            {
+                endpointShim.removeChannel(this);
+            }
             contentShim.removeChannel(this);
         }
     }
@@ -404,8 +414,16 @@ public class ChannelShim
         if (!Objects.equals(this.direction, direction))
         {
             this.direction = direction;
-            this.endpoint.updateAcceptedMediaTypes();
-            this.endpoint.updateForceMute();
+            EndpointShim endpointShim = endpoint.getEndpointShim();
+            if (endpointShim != null)
+            {
+                endpointShim.updateAcceptedMediaTypes();
+                endpointShim.updateForceMute();
+            }
+            else
+            {
+                logger.error("Can not set direction, no endpoint shim.");
+            }
         }
     }
 

--- a/jvb/src/main/java/org/jitsi/videobridge/shim/ColibriUtil.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/shim/ColibriUtil.java
@@ -149,14 +149,15 @@ public class ColibriUtil
             // video channel is signaled.
             if (MediaType.VIDEO.equals(contentShim.getMediaType()) && !channelSources.isEmpty())
             {
-                List<ChannelShim> videoChannels = contentShim.getChannelShims().stream()
-                        .filter(c -> c.getMediaType() == MediaType.VIDEO)
-                        .filter(c -> c.getEndpoint() == channelShim.getEndpoint())
-                        .collect(Collectors.toList());
+                EndpointShim endpointShim = channelShim.getEndpoint().getEndpointShim();
+                if (endpointShim == null)
+                {
+                    throw new IqProcessingException(StanzaError.Condition.internal_server_error, "No endpointShim");
+                }
 
                 List<SourcePacketExtension> sources = new ArrayList<>();
                 List<SourceGroupPacketExtension> sourceGroups = new ArrayList<>();
-                videoChannels.forEach(channel ->
+                endpointShim.getVideoChannels().forEach(channel ->
                 {
                     Collection<SourcePacketExtension> s = channel.getSources();
                     if (s != null)

--- a/jvb/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
@@ -68,13 +68,9 @@ public class ContentShim
     private final Map<String, ChannelShim> channels = new ConcurrentHashMap<>();
 
     /**
-     * TODO(brian): this used to be called 'initialLocalSSRC' in the content.
-     * 'Initial' presumably because it could be changed in the event of a
-     * collision (I think by the other lib?). Since we send it out in the
-     * initial offer, assuming it's up to the other side not to conflict with us
-     * and therefore it won't need to be changed.
+     * The local SSRC for this content's media type.
      */
-    private final long localSsrc = Videobridge.RANDOM.nextLong() & 0xffff_ffffL;
+    private final long localSsrc;
 
     /**
      * Initializes a new {@link ContentShim} instance.
@@ -85,6 +81,18 @@ public class ContentShim
     {
         this.mediaType = mediaType;
         this.conference = conference;
+        if (mediaType == MediaType.AUDIO)
+        {
+            localSsrc = conference.getLocalAudioSsrc();
+        }
+        else if (mediaType == MediaType.VIDEO)
+        {
+            localSsrc = conference.getLocalVideoSsrc();
+        }
+        else
+        {
+            localSsrc = -1L;
+        }
         this.logger = parentLogger.createChildLogger(
                 ContentShim.class.getName(),
                 JMap.of("type", mediaType.toString())
@@ -136,7 +144,6 @@ public class ContentShim
                 this,
                 logger
             );
-            channelShim.getEndpoint().setLocalSsrc(mediaType, localSsrc);
             channels.put(channelId, channelShim);
             return channelShim;
         }

--- a/jvb/src/main/java/org/jitsi/videobridge/shim/EndpointShim.kt
+++ b/jvb/src/main/java/org/jitsi/videobridge/shim/EndpointShim.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright @ 2021 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.shim
+
+import org.jitsi.nlj.util.NEVER
+import org.jitsi.utils.MediaType
+import org.jitsi.videobridge.Endpoint
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Represents an endpoint siglaned via colibri1. In colibri1 an endpoint is represented by a set
+ * of channels with the same "endpoint-id" attribute.
+ */
+class EndpointShim(
+    private val endpoint: Endpoint
+) {
+    /**
+     * The set of [ChannelShim]s associated with this endpoint. This
+     * allows us to expire the endpoint once all of its 'channels' have been
+     * removed. The set of channels shims allows to determine if endpoint
+     * can accept audio or video.
+     */
+    private val channelShims = mutableSetOf<ChannelShim>()
+
+    val maxExpireTimeFromChannelShims: Duration
+        get() = channelShims
+            .map(ChannelShim::getExpire)
+            .map { Duration.ofSeconds(it.toLong()) }
+            .maxOrNull() ?: Duration.ZERO
+
+    fun updateForceMute() {
+        var audioForceMuted = false
+        var videoForceMuted = false
+        channelShims.forEach { channelShim ->
+            if (!channelShim.allowIncomingMedia()) {
+                when (channelShim.mediaType) {
+                    MediaType.AUDIO -> audioForceMuted = true
+                    MediaType.VIDEO -> videoForceMuted = true
+                    else -> Unit
+                }
+            }
+        }
+        endpoint.updateForceMute(audioForceMuted, videoForceMuted)
+    }
+
+    /**
+     * Adds [channelShim] channel to this endpoint.
+     */
+    fun addChannel(channelShim: ChannelShim) {
+        if (channelShims.add(channelShim)) {
+            updateAcceptedMediaTypes()
+        }
+    }
+
+    /**
+     * Removes a specific [ChannelShim] from this endpoint.
+     */
+    fun removeChannel(channelShim: ChannelShim) {
+        if (channelShims.remove(channelShim)) {
+            if (channelShims.isEmpty()) {
+                endpoint.expire()
+            } else {
+                updateAcceptedMediaTypes()
+            }
+        }
+    }
+
+    /**
+     * Update media direction of the [ChannelShim]s associated
+     * with this Endpoint.
+     *
+     * When media direction is set to 'sendrecv' JVB will
+     * accept incoming media from endpoint and forward it to
+     * other endpoints in a conference. Other endpoint's media
+     * will also be forwarded to current endpoint.
+     * When media direction is set to 'sendonly' JVB will
+     * NOT accept incoming media from this endpoint (not yet implemented), but
+     * media from other endpoints will be forwarded to this endpoint.
+     * When media direction is set to 'recvonly' JVB will
+     * accept incoming media from this endpoint, but will not forward
+     * other endpoint's media to this endpoint.
+     * When media direction is set to 'inactive' JVB will
+     * neither accept incoming media nor forward media from other endpoints.
+     *
+     * @param type media type.
+     * @param direction desired media direction:
+     *                       'sendrecv', 'sendonly', 'recvonly', 'inactive'
+     */
+    @Suppress("unused") // Used by plugins (Yuri)
+    fun updateMediaDirection(type: MediaType, direction: String) {
+        when (direction) {
+            "sendrecv", "sendonly", "recvonly", "inactive" -> {
+                channelShims.firstOrNull { it.mediaType == type }?.setDirection(direction)
+            }
+            else -> {
+                throw IllegalArgumentException("Media direction unknown: $direction")
+            }
+        }
+    }
+
+    /**
+     * Update accepted media types based on [ChannelShim] permission to receive media
+     */
+    fun updateAcceptedMediaTypes() {
+        var acceptAudio = false
+        var acceptVideo = false
+        channelShims.forEach { channelShim ->
+            // The endpoint accepts audio packets (in the sense of accepting
+            // packets from other endpoints being forwarded to it) if it has
+            // an audio channel whose direction allows sending packets.
+            if (channelShim.allowsSendingMedia()) {
+                when (channelShim.mediaType) {
+                    MediaType.AUDIO -> acceptAudio = true
+                    MediaType.VIDEO -> acceptVideo = true
+                    else -> Unit
+                }
+            }
+        }
+        endpoint.updateAcceptedMediaTypes(acceptAudio, acceptVideo)
+    }
+
+    fun expire() {
+        val channelShimsCopy = channelShims.toSet()
+        channelShims.clear()
+        channelShimsCopy.forEach { channelShim ->
+            if (!channelShim.isExpired) {
+                channelShim.expire = 0
+            }
+        }
+    }
+
+    /**
+     * Return the timestamp of the most recently created [ChannelShim] on this endpoint
+     */
+    fun getMostRecentChannelCreatedTime(): Instant {
+        return channelShims
+            .map(ChannelShim::getCreationTimestamp)
+            .maxOrNull() ?: NEVER
+    }
+}

--- a/jvb/src/main/java/org/jitsi/videobridge/shim/EndpointShim.kt
+++ b/jvb/src/main/java/org/jitsi/videobridge/shim/EndpointShim.kt
@@ -36,6 +36,9 @@ class EndpointShim(
      */
     private val channelShims = mutableSetOf<ChannelShim>()
 
+    val videoChannels: List<ChannelShim>
+        get() = channelShims.filter { it.mediaType == MediaType.VIDEO }
+
     val maxExpireTimeFromChannelShims: Duration
         get() = channelShims
             .map(ChannelShim::getExpire)

--- a/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -253,8 +253,6 @@ public class VideobridgeStatistics
 
         for (Conference conference : videobridge.getConferences())
         {
-            ConferenceShim conferenceShim = conference.getShim();
-            //TODO: can/should we do everything here via the shim only?
             conferences++;
             if (conference.isP2p())
             {
@@ -291,15 +289,13 @@ public class VideobridgeStatistics
             int conferenceAudioSenders = 0;
             int conferenceVideoSenders = 0;
 
-            for (ContentShim contentShim : conferenceShim.getContents())
-            {
-                if (MediaType.VIDEO.equals(contentShim.getMediaType()))
-                {
-                    videoChannels += contentShim.getChannelCount();
-                }
-            }
             for (Endpoint endpoint : conference.getLocalEndpoints())
             {
+                if (endpoint.getAcceptVideo())
+                {
+                    videoChannels++;
+                }
+
                 if (endpoint.isOversending())
                 {
                     numOversending++;

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -270,6 +270,8 @@ class Endpoint @JvmOverloads constructor(
             override fun trace(f: () -> Unit) = f.invoke()
         })
         addEndpointConnectionStatsListener(rttListener)
+        setLocalSsrc(MediaType.AUDIO, conference.localAudioSsrc)
+        setLocalSsrc(MediaType.VIDEO, conference.localVideoSsrc)
     }
 
     private val bandwidthProbing = BandwidthProbing(
@@ -894,11 +896,6 @@ class Endpoint @JvmOverloads constructor(
     }
 
     fun getLastN(): Int = bitrateController.lastN
-
-    /**
-     * Set the local SSRC for [mediaType] to [ssrc] for this endpoint.
-     */
-    fun setLocalSsrc(mediaType: MediaType, ssrc: Long) = transceiver.setLocalSsrc(mediaType, ssrc)
 
     /**
      * Returns true if this endpoint's transport is 'fully' connected (both ICE and DTLS), false otherwise

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -928,7 +928,7 @@ class Endpoint @JvmOverloads constructor(
         super.expire()
 
         try {
-            endpointShim?.let { it.expire() }
+            endpointShim?.expire()
             endpointShim = null
             updateStatsOnExpire()
             transceiver.stop()

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -68,6 +68,7 @@ import org.jitsi.videobridge.rest.root.debug.EndpointDebugFeatures
 import org.jitsi.videobridge.sctp.SctpConfig
 import org.jitsi.videobridge.sctp.SctpManager
 import org.jitsi.videobridge.shim.ChannelShim
+import org.jitsi.videobridge.shim.EndpointShim
 import org.jitsi.videobridge.stats.DoubleAverage
 import org.jitsi.videobridge.transport.dtls.DtlsTransport
 import org.jitsi.videobridge.transport.ice.IceTransport
@@ -75,7 +76,6 @@ import org.jitsi.videobridge.util.ByteBufferPool
 import org.jitsi.videobridge.util.TaskPools
 import org.jitsi.videobridge.util.looksLikeDtls
 import org.jitsi.videobridge.websocket.colibriWebSocketServiceSupplier
-import org.jitsi.videobridge.xmpp.MediaSourceFactory
 import org.jitsi.xmpp.extensions.colibri.ColibriConferenceIQ
 import org.jitsi.xmpp.extensions.colibri.WebSocketPacketExtension
 import org.jitsi.xmpp.extensions.jingle.DtlsFingerprintPacketExtension
@@ -147,12 +147,9 @@ class Endpoint @JvmOverloads constructor(
     private var sctpSocket: Optional<SctpServerSocket> = Optional.empty()
 
     /**
-     * The set of [ChannelShim]s associated with this endpoint. This
-     * allows us to expire the endpoint once all of its 'channels' have been
-     * removed. The set of channels shims allows to determine if endpoint
-     * can accept audio or video.
+     * The colibri1 shim for this endpoint, if used. It needs to be notified when this endpoint expires.
      */
-    private val channelShims = mutableSetOf<ChannelShim>()
+    var endpointShim: EndpointShim? = null
 
     /**
      * Whether this endpoint should accept audio packets. We set this according
@@ -391,19 +388,7 @@ class Endpoint @JvmOverloads constructor(
         }
     }
 
-    fun updateForceMute() {
-        var audioForceMuted = false
-        var videoForceMuted = false
-        channelShims.forEach { channelShim ->
-            if (!channelShim.allowIncomingMedia()) {
-                when (channelShim.mediaType) {
-                    MediaType.AUDIO -> audioForceMuted = true
-                    MediaType.VIDEO -> videoForceMuted = true
-                    else -> Unit
-                }
-            }
-        }
-
+    fun updateForceMute(audioForceMuted: Boolean, videoForceMuted: Boolean) {
         transceiver.forceMuteAudio(audioForceMuted)
         transceiver.forceMuteVideo(videoForceMuted)
     }
@@ -480,28 +465,6 @@ class Endpoint @JvmOverloads constructor(
      * Sends a specific msg to this endpoint over its bridge channel
      */
     override fun sendMessage(msg: BridgeChannelMessage) = messageTransport.sendMessage(msg)
-
-    /**
-     * Adds [channelShim] channel to this endpoint.
-     */
-    fun addChannel(channelShim: ChannelShim) {
-        if (channelShims.add(channelShim)) {
-            updateAcceptedMediaTypes()
-        }
-    }
-
-    /**
-     * Removes a specific [ChannelShim] from this endpoint.
-     */
-    fun removeChannel(channelShim: ChannelShim) {
-        if (channelShims.remove(channelShim)) {
-            if (channelShims.isEmpty()) {
-                expire()
-            } else {
-                updateAcceptedMediaTypes()
-            }
-        }
-    }
 
     // TODO: this should be part of an EndpointMessageTransport.EventHandler interface
     fun endpointMessageTransportConnected() =
@@ -732,56 +695,9 @@ class Endpoint @JvmOverloads constructor(
     }
 
     /**
-     * Update media direction of the [ChannelShim]s associated
-     * with this Endpoint.
-     *
-     * When media direction is set to 'sendrecv' JVB will
-     * accept incoming media from endpoint and forward it to
-     * other endpoints in a conference. Other endpoint's media
-     * will also be forwarded to current endpoint.
-     * When media direction is set to 'sendonly' JVB will
-     * NOT accept incoming media from this endpoint (not yet implemented), but
-     * media from other endpoints will be forwarded to this endpoint.
-     * When media direction is set to 'recvonly' JVB will
-     * accept incoming media from this endpoint, but will not forward
-     * other endpoint's media to this endpoint.
-     * When media direction is set to 'inactive' JVB will
-     * neither accept incoming media nor forward media from other endpoints.
-     *
-     * @param type media type.
-     * @param direction desired media direction:
-     *                       'sendrecv', 'sendonly', 'recvonly', 'inactive'
-     */
-    @Suppress("unused") // Used by plugins (Yuri)
-    fun updateMediaDirection(type: MediaType, direction: String) {
-        when (direction) {
-            "sendrecv", "sendonly", "recvonly", "inactive" -> {
-                channelShims.firstOrNull { it.mediaType == type }?.setDirection(direction)
-            }
-            else -> {
-                throw IllegalArgumentException("Media direction unknown: $direction")
-            }
-        }
-    }
-
-    /**
      * Update accepted media types based on [ChannelShim] permission to receive media
      */
-    fun updateAcceptedMediaTypes() {
-        var acceptAudio = false
-        var acceptVideo = false
-        channelShims.forEach { channelShim ->
-            // The endpoint accepts audio packets (in the sense of accepting
-            // packets from other endpoints being forwarded to it) if it has
-            // an audio channel whose direction allows sending packets.
-            if (channelShim.allowsSendingMedia()) {
-                when (channelShim.mediaType) {
-                    MediaType.AUDIO -> acceptAudio = true
-                    MediaType.VIDEO -> acceptVideo = true
-                    else -> Unit
-                }
-            }
-        }
+    fun updateAcceptedMediaTypes(acceptAudio: Boolean, acceptVideo: Boolean) {
         this.acceptAudio = acceptAudio
         this.acceptVideo = acceptVideo
     }
@@ -799,9 +715,7 @@ class Endpoint @JvmOverloads constructor(
      * Return the timestamp of the most recently created [ChannelShim] on this endpoint
      */
     fun getMostRecentChannelCreatedTime(): Instant {
-        return channelShims
-            .map(ChannelShim::getCreationTimestamp)
-            .maxOrNull() ?: NEVER
+        return endpointShim?.getMostRecentChannelCreatedTime() ?: creationTime
     }
 
     override fun receivesSsrc(ssrc: Long): Boolean = transceiver.receivesSsrc(ssrc)
@@ -863,10 +777,9 @@ class Endpoint @JvmOverloads constructor(
             return true
         }
 
-        val maxExpireTimeFromChannelShims = channelShims
-            .map(ChannelShim::getExpire)
-            .map { Duration.ofSeconds(it.toLong()) }
-            .maxOrNull() ?: Duration.ZERO
+        // Use a default expire timeout of 60 seconds when colibri1 is not used
+        val maxExpireTimeFromChannelShims = endpointShim?.maxExpireTimeFromChannelShims
+            ?: Duration.ofSeconds(60)
 
         val lastActivity = lastIncomingActivity
         val now = clock.instant()
@@ -1015,13 +928,8 @@ class Endpoint @JvmOverloads constructor(
         super.expire()
 
         try {
-            val channelShimsCopy = channelShims.toSet()
-            channelShims.clear()
-            channelShimsCopy.forEach { channelShim ->
-                if (!channelShim.isExpired) {
-                    channelShim.expire = 0
-                }
-            }
+            endpointShim?.let { it.expire() }
+            endpointShim = null
             updateStatsOnExpire()
             transceiver.stop()
             logger.cdebug { transceiver.getNodeStats().prettyPrint(0) }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -296,7 +296,7 @@ class Endpoint @JvmOverloads constructor(
 
     override var mediaSources: Array<MediaSourceDesc>
         get() = transceiver.getMediaSources()
-        private set(value) {
+        set(value) {
             val wasEmpty = transceiver.getMediaSources().isEmpty()
             if (transceiver.setMediaSources(value)) {
                 eventEmitter.fireEvent { sourcesChanged() }
@@ -759,28 +759,6 @@ class Endpoint @JvmOverloads constructor(
             else -> {
                 throw IllegalArgumentException("Media direction unknown: $direction")
             }
-        }
-    }
-
-    /**
-     * Re-creates this endpoint's media sources based on the sources
-     * and source groups that have been signaled.
-     */
-    override fun recreateMediaSources() {
-        val videoChannels = channelShims.filter { c -> c.mediaType == MediaType.VIDEO }
-
-        val sources = videoChannels
-            .mapNotNull(ChannelShim::getSources)
-            .flatten()
-            .toList()
-
-        val sourceGroups = videoChannels
-            .mapNotNull(ChannelShim::getSourceGroups)
-            .flatten()
-            .toList()
-
-        if (sources.isNotEmpty() || sourceGroups.isNotEmpty()) {
-            mediaSources = MediaSourceFactory.createMediaSources(sources, sourceGroups)
         }
     }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -159,14 +159,16 @@ class Endpoint @JvmOverloads constructor(
      * to whether the endpoint has an audio Colibri channel whose direction
      * allows sending.
      */
-    private var acceptAudio = false
+    var acceptAudio = false
+        private set
 
     /**
      * Whether this endpoint should accept video packets. We set this according
      * to whether the endpoint has a video Colibri channel whose direction
      * allows sending.
      */
-    private var acceptVideo = false
+    var acceptVideo = false
+        private set
 
     /**
      * The queue we put outgoing SRTP packets onto so they can be sent


### PR DESCRIPTION
Move more of the quirky colibri1 logic to the shim layer.

- ref: Move Endpoint.channelShims to EndpointShim.
- ref: Move local SSRC generation from the shim to Conference.
- ref: Inline recreateMediaSources (move logic to the shim).
- ref: Move the colibri queue from ConferenceShim to Conference.
- ref: Do not use the shim to count video channels.
