### PR TITLE
Remove tossed-packets-energy from jvb statistics.

### DIFF
--- a/doc/statistics.md
+++ b/doc/statistics.md
@@ -86,8 +86,6 @@ milliseconds.
 * `stress_level` - current stress level on the bridge, with 0 indicating no load and 1 indicating the load is at full
 capacity (though values >1 are permitted).
 * `threads` - current number of JVM threads.
-* `tossedPacketsEnergy` - statistics about the energy level of packets which were discarded due to not coming from one
-of the loudest speakers in a conference.
 * `total_bytes_received` - total number of bytes received in RTP.
 * `total_bytes_received_octo` - total number of bytes received on the `octo` channel.
 * `total_bytes_sent` - total number of bytes sent in RTP.

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/Debug.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/Debug.java
@@ -129,6 +129,9 @@ public class Debug
                 // Always enabled (worth modeling as a 'feature' then?)
                 return true;
             }
+            case TOSSED_PACKET_STATS: {
+                return true;
+            }
             default: {
                 throw new NotFoundException();
             }
@@ -312,6 +315,9 @@ public class Debug
             }
             case ICE_STATS: {
                 return IceStatistics.Companion.getStats().toJson().toJSONString();
+            }
+            case TOSSED_PACKET_STATS: {
+                return videobridge.getStatistics().tossedPacketsEnergy.toJson().toJSONString();
             }
             default: {
                 throw new NotFoundException();

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/DebugFeatures.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/DebugFeatures.java
@@ -32,7 +32,8 @@ public enum DebugFeatures
     TASK_POOL_STATS("task-pool-stats"),
     NODE_TRACING("node-tracing"),
     ICE_STATS("ice-stats"),
-    XMPP_DELAY_STATS("xmpp-delay-stats");
+    XMPP_DELAY_STATS("xmpp-delay-stats"),
+    TOSSED_PACKET_STATS("tossed-packet-stats");
 
     private final String value;
 

--- a/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -544,7 +544,6 @@ public class VideobridgeStatistics
             unlockedSetStat(
                     TOTAL_PACKETS_RECEIVED, jvbStats.totalPacketsReceived.get());
             unlockedSetStat(TOTAL_PACKETS_SENT, jvbStats.totalPacketsSent.get());
-            unlockedSetStat("tossedPacketsEnergy", jvbStats.tossedPacketsEnergy.toJson());
 
             OctoRelayService.Stats octoRelayServiceStats
                 = octoRelayService == null ? null : octoRelayService.getStats();


### PR DESCRIPTION
Expose it through an HTTP API instead.
Bucket stats were not encoded as intended in presence message.
Also, bucket stats JSON encoding was an issue, see #1714.