### PR TITLE
Disable config caching for all tests, use static fields for config objects.

### DIFF
--- a/jvb/lib/logging.properties
+++ b/jvb/lib/logging.properties
@@ -8,8 +8,6 @@ java.util.logging.ConsoleHandler.formatter = org.jitsi.utils.logging2.JitsiLogFo
 org.jitsi.utils.logging2.JitsiLogFormatter.programname=JVB
 .level=INFO
 
-org.jitsi.videobridge.xmpp.ComponentImpl.level=FINE
-
 # Syslog (uncomment handler to use)
 com.agafua.syslog.SyslogHandler.transport = udp
 com.agafua.syslog.SyslogHandler.facility = local0

--- a/jvb/src/main/java/org/jitsi/videobridge/VideobridgeExpireThread.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/VideobridgeExpireThread.java
@@ -22,6 +22,8 @@ import java.util.concurrent.*;
 import org.jitsi.utils.concurrent.*;
 import org.jitsi.utils.logging2.*;
 
+import static org.jitsi.videobridge.VideobridgeExpireThreadConfig.config;
+
 /**
  * Implements a <tt>Thread</tt> which expires the {@link AbstractEndpoint}s and
  * {@link Conference}s of a specific <tt>Videobridge</tt>.
@@ -64,8 +66,6 @@ public class VideobridgeExpireThread
      * instance.
      */
     private Videobridge videobridge;
-
-    public static final VideobridgeExpireThreadConfig config = new VideobridgeExpireThreadConfig();
 
     /**
      * Initializes a new {@link VideobridgeExpireThread} instance which is to

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.java
@@ -68,7 +68,7 @@ public class BandwidthAllocator<T extends MediaSourceContainer>
         // In any case, there are other triggers for re-allocation, so any suppression we do here will only last up to
         // a few seconds.
         long deltaBwe = Math.abs(currentBwe - previousBwe);
-        return deltaBwe > previousBwe * config.bweChangeThreshold();
+        return deltaBwe > previousBwe * BitrateControllerConfig.config.bweChangeThreshold();
 
         // If, on the other hand, the bwe has decreased, we require at least a 15% drop in order to update the bitrate
         // allocation. This is an ugly hack to prevent too many resolution/UI changes in case the bridge produces too
@@ -116,13 +116,11 @@ public class BandwidthAllocator<T extends MediaSourceContainer>
      */
     private final Supplier<Boolean> trustBwe;
 
-    private final BitrateControllerConfig config = new BitrateControllerConfig();
-
     /**
      * The allocations settings signalled by the receiver.
      */
     private AllocationSettings allocationSettings
-            = new AllocationSettings(new VideoConstraints(config.thumbnailMaxHeightPx()));
+            = new AllocationSettings(new VideoConstraints(BitrateControllerConfig.config.thumbnailMaxHeightPx()));
 
     /**
      * The last time {@link BandwidthAllocator#update()} was called.
@@ -513,7 +511,6 @@ public class BandwidthAllocator<T extends MediaSourceContainer>
                                 allocationSettings.getOnStageEndpoints().contains(endpoint.getId()),
                                 diagnosticContext,
                                 clock,
-                                config,
                                 logger));
             }
         }
@@ -545,7 +542,6 @@ public class BandwidthAllocator<T extends MediaSourceContainer>
                         allocationSettings.getOnStageSources().contains(source.getSourceName()),
                         diagnosticContext,
                         clock,
-                        config,
                         logger));
         }
 
@@ -557,7 +553,8 @@ public class BandwidthAllocator<T extends MediaSourceContainer>
      */
     void maybeUpdate()
     {
-        if (Duration.between(lastUpdateTime, clock.instant()).compareTo(config.maxTimeBetweenCalculations()) > 0)
+        if (Duration.between(lastUpdateTime, clock.instant())
+                .compareTo(BitrateControllerConfig.config.maxTimeBetweenCalculations()) > 0)
         {
             logger.debug("Forcing an update");
             TaskPools.CPU_POOL.execute(this::update);

--- a/jvb/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/shim/ContentShim.java
@@ -429,7 +429,7 @@ public class ContentShim
         else
         {
             channelShim.setExpire(
-                (int)VideobridgeExpireThread.config.getInactivityTimeout().getSeconds());
+                (int)VideobridgeExpireThreadConfig.config.getInactivityTimeout().getSeconds());
         }
 
         return true;

--- a/jvb/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocketServlet.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocketServlet.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.*;
 import org.jitsi.videobridge.relay.*;
-import org.jitsi.videobridge.websocket.config.*;
+import static org.jitsi.videobridge.websocket.config.WebsocketServiceConfig.config;
 
 import java.io.*;
 import java.util.*;
@@ -46,8 +46,6 @@ class ColibriWebSocketServlet
 
     @NotNull
     private final Videobridge videobridge;
-
-    @NotNull private final WebsocketServiceConfig config = new WebsocketServiceConfig();
 
     /**
      * Initializes a new {@link ColibriWebSocketServlet} instance.

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/EndpointConnectionStatusConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/EndpointConnectionStatusConfig.kt
@@ -20,7 +20,7 @@ import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import java.time.Duration
 
-class EndpointConnectionStatusConfig {
+class EndpointConnectionStatusConfig private constructor() {
     val firstTransferTimeout: Duration by config {
         "org.jitsi.videobridge.EndpointConnectionStatus.FIRST_TRANSFER_TIMEOUT"
             .from(JitsiConfig.legacyConfig)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/EndpointConnectionStatusConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/EndpointConnectionStatusConfig.kt
@@ -39,4 +39,9 @@ class EndpointConnectionStatusConfig {
         "videobridge.ep-connection-status.check-interval".from(JitsiConfig.newConfig)
             .convertFrom<Duration>(Duration::toMillis)
     }
+
+    companion object {
+        @JvmField
+        val config = EndpointConnectionStatusConfig()
+    }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/EndpointConnectionStatusMonitor.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/EndpointConnectionStatusMonitor.kt
@@ -20,6 +20,7 @@ import org.jitsi.nlj.util.NEVER
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.cdebug
 import org.jitsi.utils.logging2.createChildLogger
+import org.jitsi.videobridge.EndpointConnectionStatusConfig.Companion.config
 import org.jitsi.videobridge.message.EndpointConnectionStatusMessage
 import java.time.Clock
 import java.time.Duration
@@ -35,8 +36,6 @@ class EndpointConnectionStatusMonitor @JvmOverloads constructor(
     private val clock: Clock = Clock.systemUTC()
 ) {
     private val logger = createChildLogger(parentLogger)
-
-    private val config = EndpointConnectionStatusConfig()
 
     /**
      * Note that we intentionally do not prune this set when an endpoint expires, because if an endpoint expires and

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/EndpointMessageTransportConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/EndpointMessageTransportConfig.kt
@@ -20,7 +20,7 @@ import org.jitsi.config.JitsiConfig.Companion.newConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
 
-class EndpointMessageTransportConfig {
+class EndpointMessageTransportConfig private constructor() {
     val announceVersion: Boolean by config("videobridge.version.announce".from(newConfig))
     fun announceVersion() = announceVersion
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/LoudestConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/LoudestConfig.kt
@@ -20,7 +20,7 @@ import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
 import java.time.Duration
 
-class LoudestConfig {
+class LoudestConfig private constructor() {
     companion object {
         @JvmStatic
         val routeLoudestOnly: Boolean by config(

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
@@ -91,7 +91,7 @@ fun main(args: Array<String>) {
 
     startIce4j()
 
-    XmppStringPrepUtil.setMaxCacheSizes(XmppClientConnectionConfig.jidCacheSize)
+    XmppStringPrepUtil.setMaxCacheSizes(XmppClientConnectionConfig.config.jidCacheSize)
     PacketQueue.setEnableStatisticsDefault(true)
 
     val xmppConnection = XmppConnection().apply { start() }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
@@ -102,7 +102,7 @@ fun main(args: Array<String>) {
     val octoRelayService = octoRelayService().get()?.apply { start() }
     val statsCollector = StatsCollector(VideobridgeStatistics(videobridge, octoRelayService, xmppConnection)).apply {
         start()
-        addTransport(MucStatsTransport(xmppConnection), XmppClientConnectionConfig.config.presenceInterval.toMillis())
+        addTransport(MucStatsTransport(xmppConnection), xmppConnection.config.presenceInterval.toMillis())
     }
 
     val callstats = if (CallstatsConfig.config.enabled) {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
@@ -38,6 +38,7 @@ import org.jitsi.videobridge.rest.root.Application
 import org.jitsi.videobridge.stats.MucStatsTransport
 import org.jitsi.videobridge.stats.StatsCollector
 import org.jitsi.videobridge.stats.VideobridgeStatistics
+import org.jitsi.videobridge.stats.callstats.CallstatsConfig
 import org.jitsi.videobridge.stats.callstats.CallstatsService
 import org.jitsi.videobridge.util.TaskPools
 import org.jitsi.videobridge.version.JvbVersionService
@@ -101,14 +102,14 @@ fun main(args: Array<String>) {
     val octoRelayService = octoRelayService().get()?.apply { start() }
     val statsCollector = StatsCollector(VideobridgeStatistics(videobridge, octoRelayService, xmppConnection)).apply {
         start()
-        addTransport(MucStatsTransport(xmppConnection), xmppConnection.config.presenceInterval.toMillis())
+        addTransport(MucStatsTransport(xmppConnection), XmppClientConnectionConfig.config.presenceInterval.toMillis())
     }
 
-    val callstats = if (CallstatsService.config.enabled) {
+    val callstats = if (CallstatsConfig.config.enabled) {
         CallstatsService(videobridge.version).apply {
             start {
                 statsTransport?.let { statsTransport ->
-                    statsCollector.addTransport(statsTransport, CallstatsService.config.interval.toMillis())
+                    statsCollector.addTransport(statsTransport, CallstatsConfig.config.interval.toMillis())
                 } ?: throw IllegalStateException("Stats transport is null after the service is started")
 
                 videobridge.addEventHandler(videobridgeEventHandler)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/MultiStreamConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/MultiStreamConfig.kt
@@ -19,7 +19,7 @@ import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
 
-class MultiStreamConfig {
+class MultiStreamConfig private constructor() {
     val enabled: Boolean by config("videobridge.multi-stream.enabled".from(JitsiConfig.newConfig))
 
     companion object {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/TransportConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/TransportConfig.kt
@@ -19,7 +19,7 @@ import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
 
-class TransportConfig {
+class TransportConfig private constructor() {
     companion object {
         @JvmStatic
         val queueSize: Int by config("videobridge.transport.send.queue-size".from(JitsiConfig.newConfig))

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/VideobridgeConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/VideobridgeConfig.kt
@@ -20,7 +20,7 @@ import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import java.time.Duration
 
-class VideobridgeConfig {
+class VideobridgeConfig private constructor() {
     companion object {
         val gracefulShutdownDelay: Duration by config {
             "videobridge.graceful-shutdown-delay".from(JitsiConfig.newConfig)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/VideobridgeExpireThreadConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/VideobridgeExpireThreadConfig.kt
@@ -21,12 +21,17 @@ import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
 import java.time.Duration
 
-class VideobridgeExpireThreadConfig {
+class VideobridgeExpireThreadConfig private constructor() {
     val inactivityTimeout: Duration by config("videobridge.entity-expiration.timeout".from(JitsiConfig.newConfig))
 
     val interval: Duration by config {
         "org.jitsi.videobridge.EXPIRE_CHECK_SLEEP_SEC".from(JitsiConfig.legacyConfig)
             .convertFrom<Long>(Duration::ofSeconds)
         "videobridge.entity-expiration.check-interval".from(JitsiConfig.newConfig)
+    }
+
+    companion object {
+        @JvmField
+        val config = VideobridgeExpireThreadConfig()
     }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/BandwidthProbing.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/BandwidthProbing.kt
@@ -23,7 +23,7 @@ import org.jitsi.utils.concurrent.PeriodicRunnable
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
 import org.jitsi.videobridge.cc.allocation.BitrateControllerStatusSnapshot
-import org.jitsi.videobridge.cc.config.BandwidthProbingConfig
+import org.jitsi.videobridge.cc.config.BandwidthProbingConfig.Companion.config
 import org.json.simple.JSONObject
 import java.util.function.Supplier
 import kotlin.random.Random
@@ -133,7 +133,6 @@ class BandwidthProbing(
 
     companion object {
         private val timeSeriesLogger = TimeSeriesLogger.getTimeSeriesLogger(BandwidthProbing::class.java)
-        private val config = BandwidthProbingConfig()
     }
 
     interface ProbingDataSender {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/AllocationSettings.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/AllocationSettings.kt
@@ -18,7 +18,7 @@ package org.jitsi.videobridge.cc.allocation
 
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.videobridge.MultiStreamConfig
-import org.jitsi.videobridge.cc.config.BitrateControllerConfig
+import org.jitsi.videobridge.cc.config.BitrateControllerConfig.Companion.config
 import org.jitsi.videobridge.message.ReceiverVideoConstraintsMessage
 import java.util.stream.Collectors
 import kotlin.math.min
@@ -79,8 +79,6 @@ internal class AllocationSettingsWrapper {
     internal var lastN: Int = -1
 
     private var videoConstraints: Map<String, VideoConstraints> = emptyMap()
-
-    private val config = BitrateControllerConfig()
 
     private var defaultConstraints: VideoConstraints = VideoConstraints(config.thumbnailMaxHeightPx())
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BitrateController.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BitrateController.kt
@@ -27,7 +27,7 @@ import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.videobridge.MultiStreamConfig
-import org.jitsi.videobridge.cc.config.BitrateControllerConfig
+import org.jitsi.videobridge.cc.config.BitrateControllerConfig.Companion.config
 import org.jitsi.videobridge.message.ReceiverVideoConstraintsMessage
 import org.jitsi.videobridge.util.BooleanStateTimeTracker
 import org.json.simple.JSONObject
@@ -64,8 +64,6 @@ class BitrateController<T : MediaSourceContainer> @JvmOverloads constructor(
      * Keep track of the "forwarded" sources, i.e. the media sources for which we are forwarding *some* layer.
      */
     private var forwardedSources: Set<String> = emptySet()
-
-    private val config = BitrateControllerConfig()
 
     /**
      * Keep track of how much time we spend knowingly oversending (due to enableOnstageVideoSuspend being false)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
@@ -22,7 +22,7 @@ import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.LoggerImpl
-import org.jitsi.videobridge.cc.config.BitrateControllerConfig
+import org.jitsi.videobridge.cc.config.BitrateControllerConfig.Companion.config
 import java.lang.Integer.max
 import java.time.Clock
 
@@ -40,7 +40,6 @@ internal class SingleSourceAllocation(
     private val onStage: Boolean,
     diagnosticContext: DiagnosticContext,
     clock: Clock,
-    val config: BitrateControllerConfig = BitrateControllerConfig(),
     val logger: Logger = LoggerImpl(SingleSourceAllocation::class.qualifiedName)
 ) {
     /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation2.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation2.kt
@@ -24,7 +24,7 @@ import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.LoggerImpl
-import org.jitsi.videobridge.cc.config.BitrateControllerConfig
+import org.jitsi.videobridge.cc.config.BitrateControllerConfig.Companion.config
 import java.lang.Integer.max
 import java.time.Clock
 
@@ -44,7 +44,6 @@ internal class SingleSourceAllocation2(
     private val onStage: Boolean,
     diagnosticContext: DiagnosticContext,
     clock: Clock,
-    val config: BitrateControllerConfig = BitrateControllerConfig(),
     val logger: Logger = LoggerImpl(SingleSourceAllocation::class.qualifiedName)
 ) {
     /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/config/BandwidthProbingConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/config/BandwidthProbingConfig.kt
@@ -29,4 +29,9 @@ class BandwidthProbingConfig {
         "videobridge.cc.padding-period"
             .from(JitsiConfig.newConfig).convertFrom<Duration> { it.toMillis() }
     }
+
+    companion object {
+        @JvmField
+        val config = BandwidthProbingConfig()
+    }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/config/BandwidthProbingConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/config/BandwidthProbingConfig.kt
@@ -20,7 +20,7 @@ import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import java.time.Duration
 
-class BandwidthProbingConfig {
+class BandwidthProbingConfig private constructor() {
     /**
      * How often we check to send probing data
      */

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/config/BitrateControllerConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/config/BitrateControllerConfig.kt
@@ -115,4 +115,9 @@ class BitrateControllerConfig {
         "videobridge.cc.max-time-between-calculations".from(JitsiConfig.newConfig)
     )
     fun maxTimeBetweenCalculations() = maxTimeBetweenCalculations
+
+    companion object {
+        @JvmField
+        val config = BitrateControllerConfig()
+    }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/config/BitrateControllerConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/config/BitrateControllerConfig.kt
@@ -22,7 +22,7 @@ import org.jitsi.metaconfig.from
 import org.jitsi.nlj.util.Bandwidth
 import java.time.Duration
 
-class BitrateControllerConfig {
+class BitrateControllerConfig private constructor() {
     /**
      * The bandwidth estimation threshold.
      *

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/health/JvbHealthChecker.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/health/JvbHealthChecker.kt
@@ -19,11 +19,10 @@ package org.jitsi.videobridge.health
 import org.ice4j.ice.harvest.MappingCandidateHarvesters
 import org.jitsi.health.HealthCheckService
 import org.jitsi.health.HealthChecker
-import org.jitsi.videobridge.health.config.HealthConfig
+import org.jitsi.videobridge.health.config.HealthConfig.Companion.config
 import org.jitsi.videobridge.ice.Harvesters
 
 class JvbHealthChecker : HealthCheckService {
-    private val config = HealthConfig()
     private val healthChecker = HealthChecker(
         config.interval,
         config.timeout,

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/health/config/HealthConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/health/config/HealthConfig.kt
@@ -40,4 +40,9 @@ class HealthConfig {
         "org.jitsi.videobridge.health.STICKY_FAILURES".from(JitsiConfig.legacyConfig)
         "videobridge.health.sticky-failures".from(JitsiConfig.newConfig)
     }
+
+    companion object {
+        @JvmField
+        val config = HealthConfig()
+    }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/health/config/HealthConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/health/config/HealthConfig.kt
@@ -21,7 +21,7 @@ import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
 import java.time.Duration
 
-class HealthConfig {
+class HealthConfig private constructor() {
     val interval: Duration by config {
         "org.jitsi.videobridge.health.INTERVAL"
             .from(JitsiConfig.legacyConfig).convertFrom<Long>(Duration::ofMillis)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/ice/IceConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/ice/IceConfig.kt
@@ -23,7 +23,7 @@ import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
 import org.jitsi.metaconfig.optionalconfig
 
-class IceConfig {
+class IceConfig private constructor() {
     /**
      * Is ICE/TCP enabled.
      */

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/octo/config/OctoConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/octo/config/OctoConfig.kt
@@ -22,7 +22,7 @@ import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
 import org.jitsi.metaconfig.optionalconfig
 
-class OctoConfig {
+class OctoConfig private constructor() {
     val recvQueueSize: Int by config("videobridge.octo.recv-queue-size".from(JitsiConfig.newConfig))
 
     val sendQueueSize: Int by config("videobridge.octo.send-queue-size".from(JitsiConfig.newConfig))

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
@@ -78,8 +78,6 @@ class RelayMessageTransport(
      */
     private val sentMessagesCounts: MutableMap<String, AtomicLong> = ConcurrentHashMap()
 
-    private val multiStreamConfig = MultiStreamConfig()
-
     init { logger.addContext("relay-id", relay.id) }
 
     /**
@@ -183,7 +181,7 @@ class RelayMessageTransport(
     }
 
     override fun sourceVideoType(message: SourceVideoTypeMessage): BridgeChannelMessage? {
-        if (!multiStreamConfig.enabled) {
+        if (!MultiStreamConfig.config.enabled) {
             return null
         }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/rest/RestConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/rest/RestConfig.kt
@@ -20,7 +20,7 @@ import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.videobridge.Videobridge
 
-class RestConfig {
+class RestConfig private constructor() {
     private val colibriRestEnabled: Boolean by config {
         // If the value was passed via a command line arg, we set it as a system
         // variable at this path, which the new config will pick up

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/sctp/SctpConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/sctp/SctpConfig.kt
@@ -19,7 +19,7 @@ package org.jitsi.videobridge.sctp
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 
-class SctpConfig {
+class SctpConfig private constructor() {
     val enabled: Boolean by config { "videobridge.sctp.enabled".from(JitsiConfig.newConfig) }
 
     fun enabled() = enabled

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/signaling/api/JvbApiConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/signaling/api/JvbApiConfig.kt
@@ -20,7 +20,7 @@ import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
 
-class JvbApiConfig {
+class JvbApiConfig private constructor() {
     companion object {
         private val enabled: Boolean by config("videobridge.apis.jvb-api.enabled".from(JitsiConfig.newConfig))
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/StatsCollector.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/StatsCollector.kt
@@ -17,7 +17,7 @@ package org.jitsi.videobridge.stats
 
 import org.jitsi.utils.concurrent.PeriodicRunnableWithObject
 import org.jitsi.utils.concurrent.RecurringRunnableExecutor
-import org.jitsi.videobridge.stats.config.StatsManagerConfig
+import org.jitsi.videobridge.stats.config.StatsManagerConfig.Companion.config
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -147,10 +147,5 @@ class StatsCollector(
             val measurementInterval = period
             o.publishStatistics(statisticsRunnable.o, measurementInterval)
         }
-    }
-
-    companion object {
-        @JvmField
-        val config = StatsManagerConfig()
     }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/callstats/CallstatsService.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/callstats/CallstatsService.kt
@@ -26,6 +26,7 @@ import org.jitsi.utils.version.Version
 import org.jitsi.videobridge.Videobridge
 import org.jitsi.videobridge.stats.StatsCollector
 import org.jitsi.videobridge.stats.StatsTransport
+import org.jitsi.videobridge.stats.config.StatsManagerConfig
 import org.jitsi.videobridge.stats.config.StatsTransportConfig
 import java.time.Duration
 
@@ -181,7 +182,7 @@ class CallstatsConfig {
      *
      * For backwards compatibility, we read it from the stats manager "callstatsio" transport, if present.
      */
-    val interval: Duration = StatsCollector.config.transportConfigs.stream()
+    val interval: Duration = StatsManagerConfig.config.transportConfigs.stream()
         .filter { tc -> tc is StatsTransportConfig.CallStatsIoStatsTransportConfig }
         .map(StatsTransportConfig::interval)
         .findFirst()

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/callstats/CallstatsService.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/callstats/CallstatsService.kt
@@ -179,13 +179,15 @@ class CallstatsConfig {
      *
      * For backwards compatibility, we read it from the stats manager "callstatsio" transport, if present.
      */
-    val interval: Duration = StatsManagerConfig.config.transportConfigs.stream()
+    val interval: Duration
+        get() = StatsManagerConfig.config.transportConfigs.stream()
         .filter { tc -> tc is StatsTransportConfig.CallStatsIoStatsTransportConfig }
         .map(StatsTransportConfig::interval)
         .findFirst()
         .orElse(intervalProperty)
 
-    val enabled: Boolean = appId > 0
+    val enabled: Boolean
+        get() = appId > 0
 
     override fun toString() = "appId=$appId, appSecret is ${if (appSecret == null) "unset" else "set"}, keyId=$keyId," +
         " keyPath=$keyPath, bridgeId=$bridgeId, conferenceIdPrefix=$conferenceIdPrefix, interval=$interval"

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/callstats/CallstatsService.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/callstats/CallstatsService.kt
@@ -24,7 +24,6 @@ import org.jitsi.stats.media.StatsServiceFactory
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.utils.version.Version
 import org.jitsi.videobridge.Videobridge
-import org.jitsi.videobridge.stats.StatsCollector
 import org.jitsi.videobridge.stats.StatsTransport
 import org.jitsi.videobridge.stats.config.StatsManagerConfig
 import org.jitsi.videobridge.stats.config.StatsTransportConfig
@@ -57,6 +56,8 @@ class CallstatsService(
 
     val statsTransport: StatsTransport?
         get() = callstatsTransport
+
+    val config = CallstatsConfig.config
 
     fun start(
         /**
@@ -121,10 +122,6 @@ class CallstatsService(
 
     val videobridgeEventHandler: Videobridge.EventHandler?
         get() = conferenceManager
-
-    companion object {
-        val config = CallstatsConfig()
-    }
 }
 
 class CallstatsConfig {
@@ -192,4 +189,9 @@ class CallstatsConfig {
 
     override fun toString() = "appId=$appId, appSecret is ${if (appSecret == null) "unset" else "set"}, keyId=$keyId," +
         " keyPath=$keyPath, bridgeId=$bridgeId, conferenceIdPrefix=$conferenceIdPrefix, interval=$interval"
+
+    companion object {
+        @JvmField
+        val config = CallstatsConfig()
+    }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/callstats/CallstatsService.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/callstats/CallstatsService.kt
@@ -124,7 +124,7 @@ class CallstatsService(
         get() = conferenceManager
 }
 
-class CallstatsConfig {
+class CallstatsConfig private constructor() {
     /**
      * The callstats AppID.
      */

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/config/StatsManagerConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/config/StatsManagerConfig.kt
@@ -25,7 +25,7 @@ import org.jitsi.metaconfig.config
 import org.jitsi.videobridge.xmpp.XmppConnection
 import java.time.Duration
 
-class StatsManagerConfig {
+class StatsManagerConfig private constructor() {
     /**
      * The interval at which the stats are pushed
      */

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/config/StatsManagerConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/config/StatsManagerConfig.kt
@@ -97,6 +97,11 @@ class StatsManagerConfig {
             else -> null
         }
     }
+
+    companion object {
+        @JvmField
+        val config = StatsManagerConfig()
+    }
 }
 
 /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/websocket/ColibriWebSocketService.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/websocket/ColibriWebSocketService.kt
@@ -20,13 +20,11 @@ import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.servlet.ServletHolder
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.videobridge.Videobridge
-import org.jitsi.videobridge.websocket.config.WebsocketServiceConfig
+import org.jitsi.videobridge.websocket.config.WebsocketServiceConfig.Companion.config
 
 class ColibriWebSocketService(
     webserverIsTls: Boolean
 ) {
-    private val config = WebsocketServiceConfig()
-
     private val baseUrl: String?
     private val relayUrl: String? /* TODO: only enable this if secure octo is enabled? */
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/websocket/config/WebsocketServiceConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/websocket/config/WebsocketServiceConfig.kt
@@ -72,4 +72,9 @@ class WebsocketServiceConfig {
             "videobridge.websockets.server-id".from(JitsiConfig.newConfig)
         }
     }
+
+    companion object {
+        @JvmField
+        val config = WebsocketServiceConfig()
+    }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/websocket/config/WebsocketServiceConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/websocket/config/WebsocketServiceConfig.kt
@@ -20,7 +20,7 @@ import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.optionalconfig
 
-class WebsocketServiceConfig {
+class WebsocketServiceConfig private constructor() {
     /**
      * Whether [org.jitsi.videobridge.websocket.ColibriWebSocketService] is enabled
      */

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
@@ -20,7 +20,7 @@ import org.jitsi.nlj.stats.DelayStats
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.cdebug
 import org.jitsi.utils.logging2.createLogger
-import org.jitsi.videobridge.xmpp.config.XmppClientConnectionConfig.Companion.config
+import org.jitsi.videobridge.xmpp.config.XmppClientConnectionConfig
 import org.jitsi.xmpp.extensions.colibri.ColibriConferenceIQ
 import org.jitsi.xmpp.extensions.colibri.ForcefulShutdownIQ
 import org.jitsi.xmpp.extensions.colibri.GracefulShutdownIQ
@@ -53,6 +53,8 @@ class XmppConnection : IQListener {
     private val running = AtomicBoolean(false)
 
     var eventHandler: EventHandler? = null
+
+    val config = XmppClientConnectionConfig.config
 
     fun start() {
         if (running.compareAndSet(false, true)) {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
@@ -20,7 +20,7 @@ import org.jitsi.nlj.stats.DelayStats
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.cdebug
 import org.jitsi.utils.logging2.createLogger
-import org.jitsi.videobridge.xmpp.config.XmppClientConnectionConfig
+import org.jitsi.videobridge.xmpp.config.XmppClientConnectionConfig.Companion.config
 import org.jitsi.xmpp.extensions.colibri.ColibriConferenceIQ
 import org.jitsi.xmpp.extensions.colibri.ForcefulShutdownIQ
 import org.jitsi.xmpp.extensions.colibri.GracefulShutdownIQ
@@ -49,8 +49,6 @@ class XmppConnection : IQListener {
      * The [MucClientManager] which manages the XMPP user connections and the MUCs.
      */
     val mucClientManager = MucClientManager(FEATURES)
-
-    val config = XmppClientConnectionConfig()
 
     private val running = AtomicBoolean(false)
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/config/XmppClientConnectionConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/config/XmppClientConnectionConfig.kt
@@ -27,7 +27,7 @@ import org.jitsi.videobridge.stats.config.StatsTransportConfig
 import org.jitsi.xmpp.mucclient.MucClientConfiguration
 import java.time.Duration
 
-class XmppClientConnectionConfig {
+class XmppClientConnectionConfig private constructor() {
     val clientConfigs: List<MucClientConfiguration> by config {
         "org.jitsi.videobridge.xmpp.user."
             .from(JitsiConfig.legacyConfig)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/config/XmppClientConnectionConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/config/XmppClientConnectionConfig.kt
@@ -22,6 +22,7 @@ import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.ConfigException
 import org.jitsi.metaconfig.config
 import org.jitsi.videobridge.stats.StatsCollector
+import org.jitsi.videobridge.stats.config.StatsManagerConfig
 import org.jitsi.videobridge.stats.config.StatsTransportConfig
 import org.jitsi.xmpp.mucclient.MucClientConfiguration
 import java.time.Duration
@@ -52,7 +53,7 @@ class XmppClientConnectionConfig {
      * The interval at which presence updates (with updates stats/status) are published. Allow to be overridden by
      * legacy-style "stats-transports" config.
      */
-    val presenceInterval: Duration = StatsCollector.config.transportConfigs.stream()
+    val presenceInterval: Duration = StatsManagerConfig.config.transportConfigs.stream()
         .filter { tc -> tc is StatsTransportConfig.MucStatsTransportConfig }
         .map(StatsTransportConfig::interval)
         .findFirst()

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/config/XmppClientConnectionConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/config/XmppClientConnectionConfig.kt
@@ -72,13 +72,16 @@ class XmppClientConnectionConfig {
         "videobridge.apis.xmpp-client.stats-filter.whitelist".from(JitsiConfig.newConfig)
     }
 
+    /**
+     * The size to set for Smack's JID cache
+     */
+    val jidCacheSize: Int by config {
+        "videobridge.apis.xmpp-client.jid-cache-size".from(JitsiConfig.newConfig)
+    }
+
     companion object {
-        /**
-         * The size to set for Smack's JID cache
-         */
-        val jidCacheSize: Int by config {
-            "videobridge.apis.xmpp-client.jid-cache-size".from(JitsiConfig.newConfig)
-        }
+        @JvmField
+        val config = XmppClientConnectionConfig()
     }
 }
 

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/KotestProjectConfig.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/KotestProjectConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright @ 2018 - present 8x8, Inc.
+ * Copyright @ 2022 - present 8x8, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-package org.jitsi
+package org.jitsi.videobridge
 
-import io.kotest.core.spec.IsolationMode
-import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.core.config.AbstractProjectConfig
+import org.jitsi.metaconfig.MetaconfigSettings
 
-/**
- * A helper class for testing configuration properties
- */
-abstract class ConfigTest : ShouldSpec() {
-    override fun isolationMode() = IsolationMode.InstancePerLeaf
+class KotestProjectConfig : AbstractProjectConfig() {
+    override fun beforeAll() = super.beforeAll().also {
+        // The only purpose of config caching is performance. We always want caching disabled in tests (so we can
+        // freely modify the config without affecting other tests executing afterwards).
+        MetaconfigSettings.cacheEnabled = false
+    }
 }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/MediaSourceFactoryTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/MediaSourceFactoryTest.kt
@@ -18,11 +18,9 @@ package org.jitsi.videobridge
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
-import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import org.jitsi.config.setNewConfig
-import org.jitsi.metaconfig.MetaconfigSettings
 import org.jitsi.videobridge.xmpp.MediaSourceFactory
 import org.jitsi.xmpp.extensions.colibri.SourcePacketExtension
 
@@ -31,17 +29,6 @@ fun createSource(ssrc: Long) = SourcePacketExtension().apply { this.ssrc = ssrc 
 // TODO port MediaSourceFactoryTest.java to kotlin and unify with this class
 class MediaSourceFactoryTest : ShouldSpec() {
     override fun isolationMode() = IsolationMode.InstancePerLeaf
-
-    override fun beforeSpec(spec: Spec) {
-        super.beforeSpec(spec)
-        MetaconfigSettings.cacheEnabled = false // required for setNewConfig to be effective
-    }
-
-    override fun afterSpec(spec: Spec) {
-        super.afterSpec(spec)
-        MetaconfigSettings.cacheEnabled = true
-        setNewConfig("", true)
-    }
 
     init {
         context("MediaSourceFactory") {

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/MultiStreamConfigTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/MultiStreamConfigTest.kt
@@ -25,12 +25,12 @@ class MultiStreamConfigTest : ConfigTest() {
         context("multi-stream-config") {
             context("when enabled") {
                 withNewConfig(configWithMultiStreamEnabled) {
-                    MultiStreamConfig().enabled shouldBe true
+                    MultiStreamConfig.config.enabled shouldBe true
                 }
             }
             context("when disabled") {
                 withNewConfig(configWithMultiStreamDisabled) {
-                    MultiStreamConfig().enabled shouldBe false
+                    MultiStreamConfig.config.enabled shouldBe false
                 }
             }
         }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerNewTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerNewTest.kt
@@ -22,7 +22,6 @@ import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.shouldBe
 import org.jitsi.config.setNewConfig
-import org.jitsi.metaconfig.MetaconfigSettings
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.RtpEncodingDesc
@@ -52,13 +51,7 @@ class BitrateControllerNewTest : ShouldSpec() {
     private val C = bc.endpoints.find { it.id == "C" }!! as TestEndpoint2
     private val D = bc.endpoints.find { it.id == "D" }!! as TestEndpoint2
 
-    override fun beforeSpec(spec: Spec) {
-        super.beforeSpec(spec)
-
-        // Config caching must be disabled or otherwise the setNewConfig below will not be effective if the other tests
-        // have instantiated MultiStreamConfig instance.
-        MetaconfigSettings.cacheEnabled = false
-
+    override fun beforeSpec(spec: Spec) = super.beforeSpec(spec).also {
         // We disable the threshold, causing [BandwidthAllocator] to make a new decision every time BWE changes. This is
         // because these tests are designed to test the decisions themselves and not necessarily when they are made.
         setNewConfig(
@@ -68,10 +61,8 @@ class BitrateControllerNewTest : ShouldSpec() {
         )
     }
 
-    override fun afterSpec(spec: Spec) {
-        super.afterSpec(spec)
+    override fun afterSpec(spec: Spec) = super.afterSpec(spec).also {
         setNewConfig("", true)
-        MetaconfigSettings.cacheEnabled = true
     }
 
     init {

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/EffectiveConstraintsNewTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/EffectiveConstraintsNewTest.kt
@@ -48,7 +48,7 @@ class EffectiveConstraintsNewTest : ShouldSpec() {
         val s5 = testSource("e1", "s5", videoType = VideoType.DISABLED)
         val s6 = testSource("e1", "s6", videoType = VideoType.DISABLED)
 
-        val defaultConstraints = VideoConstraints(BitrateControllerConfig().thumbnailMaxHeightPx())
+        val defaultConstraints = VideoConstraints(BitrateControllerConfig.config.thumbnailMaxHeightPx())
 
         val sources = listOf(s1, s2, s3, s4, s5, s6)
         val zeroEffectiveConstraints = mutableMapOf(

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/EffectiveConstraintsTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/EffectiveConstraintsTest.kt
@@ -33,7 +33,7 @@ class EffectiveConstraintsTest : ShouldSpec() {
         val e5 = TestEndpoint("e5", videoType = VideoType.NONE)
         val e6 = TestEndpoint("e6", videoType = VideoType.NONE)
 
-        val defaultConstraints = VideoConstraints(BitrateControllerConfig().thumbnailMaxHeightPx())
+        val defaultConstraints = VideoConstraints(BitrateControllerConfig.config.thumbnailMaxHeightPx())
 
         val endpoints = listOf(e1, e2, e3, e4, e5, e6)
         val zeroEffectiveConstraints = mutableMapOf(

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/health/config/HealthConfigTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/health/config/HealthConfigTest.kt
@@ -29,7 +29,7 @@ class HealthConfigTest : ConfigTest() {
                 withLegacyConfig(legacyConfigWithHealthInterval) {
                     withNewConfig(newConfigWithHealthInterval) {
                         should("use the value from legacy config") {
-                            HealthConfig().interval shouldBe Duration.ofSeconds(1)
+                            HealthConfig.config.interval shouldBe Duration.ofSeconds(1)
                         }
                     }
                 }
@@ -37,7 +37,7 @@ class HealthConfigTest : ConfigTest() {
             context("when only new config defines a value") {
                 withNewConfig(newConfigWithHealthInterval) {
                     should("use the value from the new config") {
-                        HealthConfig().interval shouldBe Duration.ofSeconds(5)
+                        HealthConfig.config.interval shouldBe Duration.ofSeconds(5)
                     }
                 }
             }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/load_management/LastNReducerTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/load_management/LastNReducerTest.kt
@@ -24,6 +24,7 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import org.jitsi.config.setNewConfig
+import org.jitsi.config.withNewConfig
 import org.jitsi.videobridge.AbstractEndpoint
 import org.jitsi.videobridge.Conference
 import org.jitsi.videobridge.Endpoint
@@ -31,7 +32,7 @@ import org.jitsi.videobridge.JvbLastN
 import java.util.function.Supplier
 
 class LastNReducerTest : ShouldSpec() {
-    override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
 
     private val jvbLastN = spyk<JvbLastN>()
 
@@ -49,36 +50,35 @@ class LastNReducerTest : ShouldSpec() {
             val conf1 = createMockConference(4, 8, 12)
             val conf2 = createMockConference(2, 4, 10)
 
-            val reducer = withLastNConfig(
-                """
-                reduction-scale = .5
-                recover-scale = 2
-                """
-            ) {
-                LastNReducer(Supplier { listOf(conf1, conf2) }, jvbLastN)
-            }
-            context("running the reducer") {
-                reducer.reduceLoad()
-                should("set the right last-n value") {
-                    // The highest forwarded count was 12, and the reduction factor was .5, so
-                    // it should be set to 6
-                    verify(exactly = 1) { jvbLastN setProperty "jvbLastN" value 6 }
-                }
-            }
-            context("and no jvb last-n has been set") {
-                context("running recovery") {
-                    reducer.recover() shouldBe false
-                    should("not alter the last-n value") {
-                        verify(exactly = 0) { jvbLastN setProperty "jvbLastN" value any<Int>() }
+            withNewConfig("""
+                videobridge.load-management.load-reducers.last-n.reduction-scale = .5
+                videobridge.load-management.load-reducers.last-n.recover-scale = 2
+                """.trimIndent()) {
+
+                val reducer = LastNReducer(Supplier { listOf(conf1, conf2) }, jvbLastN)
+                context("running the reducer") {
+                    reducer.reduceLoad()
+                    should("set the right last-n value") {
+                        // The highest forwarded count was 12, and the reduction factor was .5, so
+                        // it should be set to 6
+                        verify(exactly = 1) { jvbLastN setProperty "jvbLastN" value 6 }
                     }
                 }
-            }
-            context("and a jvb last-n has been set") {
-                jvbLastN.jvbLastN = 4
-                context("running recovery") {
-                    reducer.recover() shouldBe true
-                    should("increase the jvb last-n value") {
-                        verify(exactly = 1) { jvbLastN setProperty "jvbLastN" value 8 }
+                context("and no jvb last-n has been set") {
+                    context("running recovery") {
+                        reducer.recover() shouldBe false
+                        should("not alter the last-n value") {
+                            verify(exactly = 0) { jvbLastN setProperty "jvbLastN" value any<Int>() }
+                        }
+                    }
+                }
+                context("and a jvb last-n has been set") {
+                    jvbLastN.jvbLastN = 4
+                    context("running recovery") {
+                        reducer.recover() shouldBe true
+                        should("increase the jvb last-n value") {
+                            verify(exactly = 1) { jvbLastN setProperty "jvbLastN" value 8 }
+                        }
                     }
                 }
             }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/octo/config/OctoConfigTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/octo/config/OctoConfigTest.kt
@@ -12,7 +12,7 @@ internal class OctoConfigTest : ConfigTest() {
                 withLegacyConfig(legacyConfigWithBindAddressAndBindPort) {
                     withNewConfig(newConfigOctoDisabled) {
                         should("be true") {
-                            OctoConfig().enabled shouldBe true
+                            OctoConfig.config.enabled shouldBe true
                         }
                     }
                 }
@@ -20,12 +20,12 @@ internal class OctoConfigTest : ConfigTest() {
             context("when bind address is set in legacy config but not bind port") {
                 withLegacyConfig(legacyConfigWithBindAddressNoBindPort) {
                     should("be false") {
-                        OctoConfig().enabled shouldBe false
+                        OctoConfig.config.enabled shouldBe false
                     }
                     context("and set as true in new config") {
                         withNewConfig(newConfigOctoEnabled) {
                             should("be false") {
-                                OctoConfig().enabled shouldBe false
+                                OctoConfig.config.enabled shouldBe false
                             }
                         }
                     }
@@ -35,7 +35,7 @@ internal class OctoConfigTest : ConfigTest() {
                 withLegacyConfig(legacyConfigWithBindPortNoBindAddress) {
                     withNewConfig(newConfigOctoEnabled) {
                         should("be false") {
-                            OctoConfig().enabled shouldBe false
+                            OctoConfig.config.enabled shouldBe false
                         }
                     }
                 }
@@ -43,7 +43,7 @@ internal class OctoConfigTest : ConfigTest() {
             context("when enabled is true in new config and bind address/bind port are not defined in old config") {
                 withNewConfig(newConfigOctoEnabled) {
                     should("be true") {
-                        OctoConfig().enabled shouldBe true
+                        OctoConfig.config.enabled shouldBe true
                     }
                 }
             }
@@ -52,7 +52,7 @@ internal class OctoConfigTest : ConfigTest() {
             context("when the value isn't set in legacy config") {
                 withNewConfig(newConfigBindAddress) {
                     should("be the value from new config") {
-                        OctoConfig().bindAddress shouldBe "127.0.0.1"
+                        OctoConfig.config.bindAddress shouldBe "127.0.0.1"
                     }
                 }
             }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/stats/callstats/CallstatsConfigTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/stats/callstats/CallstatsConfigTest.kt
@@ -26,8 +26,7 @@ internal class CallstatsConfigTest : ConfigTest() {
     init {
         context("Setting the API configuration") {
             context("Without config") {
-                val config = CallstatsConfig()
-                config.enabled shouldBe false
+                CallstatsConfig.config.enabled shouldBe false
             }
             context("With legacy config") {
                 withLegacyConfig(
@@ -39,13 +38,14 @@ internal class CallstatsConfigTest : ConfigTest() {
                     io.callstats.sdk.CallStats.conferenceIDPrefix=baz
                     """.trimIndent()
                 ) {
-                    val config = CallstatsConfig()
-                    config.appId shouldBe 1234
-                    config.enabled shouldBe true
-                    config.keyId shouldBe "foo"
-                    config.keyPath shouldBe "/tmp/ecpriv.jwk"
-                    config.bridgeId shouldBe "bar"
-                    config.conferenceIdPrefix shouldBe "baz"
+                    CallstatsConfig.config.apply {
+                        appId shouldBe 1234
+                        enabled shouldBe true
+                        keyId shouldBe "foo"
+                        keyPath shouldBe "/tmp/ecpriv.jwk"
+                        bridgeId shouldBe "bar"
+                        conferenceIdPrefix shouldBe "baz"
+                    }
                 }
             }
             context("With new config") {
@@ -61,19 +61,20 @@ internal class CallstatsConfigTest : ConfigTest() {
                     """.trimIndent(),
                     loadDefaults = true
                 ) {
-                    val config = CallstatsConfig()
-                    config.appId shouldBe 1234
-                    config.enabled shouldBe true
-                    config.keyId shouldBe "foo"
-                    config.keyPath shouldBe "/tmp/ecpriv.jwk"
-                    config.bridgeId shouldBe "bar"
-                    config.conferenceIdPrefix shouldBe "baz"
+                    CallstatsConfig.config.apply {
+                        appId shouldBe 1234
+                        enabled shouldBe true
+                        keyId shouldBe "foo"
+                        keyPath shouldBe "/tmp/ecpriv.jwk"
+                        bridgeId shouldBe "bar"
+                        conferenceIdPrefix shouldBe "baz"
+                    }
                 }
             }
         }
         context("Setting the interval") {
             context("Default value") {
-                CallstatsConfig().interval shouldBe 5.secs
+                CallstatsConfig.config.interval shouldBe 5.secs
             }
             context("With legacy config") {
                 withLegacyConfig(
@@ -82,7 +83,7 @@ internal class CallstatsConfigTest : ConfigTest() {
                     org.jitsi.videobridge.STATISTICS_TRANSPORT=callstats.io
                     """.trimIndent()
                 ) {
-                    CallstatsConfig().interval shouldBe 6.secs
+                    CallstatsConfig.config.interval shouldBe 6.secs
                 }
             }
             context("With new config (deprecated syntax)") {
@@ -98,12 +99,12 @@ internal class CallstatsConfigTest : ConfigTest() {
                     """.trimIndent(),
                     loadDefaults = true
                 ) {
-                    CallstatsConfig().interval shouldBe 7.secs
+                    CallstatsConfig.config.interval shouldBe 7.secs
                 }
             }
             context("With new config") {
                 withNewConfig("videobridge.stats.callstats.interval = 8 seconds", loadDefaults = true) {
-                    CallstatsConfig().interval shouldBe 8.secs
+                    CallstatsConfig.config.interval shouldBe 8.secs
                 }
             }
         }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/stats/config/StatsManagerConfigTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/stats/config/StatsManagerConfigTest.kt
@@ -31,14 +31,12 @@ internal class StatsManagerConfigTest : ConfigTest() {
             context("a stats transport config") {
                 context("with multiple, valid stats transports configured") {
                     withNewConfig(newConfigAllStatsTransports()) {
-                        val cfg = StatsManagerConfig()
-
-                        cfg.transportConfigs shouldHaveSize 2
-                        cfg.transportConfigs.forOne {
+                        StatsManagerConfig.config.transportConfigs shouldHaveSize 2
+                        StatsManagerConfig.config.transportConfigs.forOne {
                             it as StatsTransportConfig.MucStatsTransportConfig
                             it.interval shouldBe Duration.ofSeconds(5)
                         }
-                        cfg.transportConfigs.forOne {
+                        StatsManagerConfig.config.transportConfigs.forOne {
                             it as StatsTransportConfig.CallStatsIoStatsTransportConfig
                             it.interval shouldBe Duration.ofSeconds(5)
                         }
@@ -47,18 +45,17 @@ internal class StatsManagerConfigTest : ConfigTest() {
                 context("with an invalid stats transport configured") {
                     withNewConfig(newConfigInvalidStatsTransports()) {
                         should("ignore the invalid config and parse the valid transport correctly") {
-                            val cfg = StatsManagerConfig()
-
-                            cfg.transportConfigs shouldHaveSize 1
-                            cfg.transportConfigs.forOne { it as StatsTransportConfig.MucStatsTransportConfig }
+                            StatsManagerConfig.config.transportConfigs shouldHaveSize 1
+                            StatsManagerConfig.config.transportConfigs.forOne {
+                                it as StatsTransportConfig.MucStatsTransportConfig
+                            }
                         }
                     }
                 }
                 context("which has a custom interval") {
                     withNewConfig(newConfigOneStatsTransportCustomInterval()) {
                         should("reflect the custom interval") {
-                            val cfg = StatsManagerConfig()
-                            cfg.transportConfigs.forOne {
+                            StatsManagerConfig.config.transportConfigs.forOne {
                                 it as StatsTransportConfig.MucStatsTransportConfig
                                 it.interval shouldBe Duration.ofSeconds(10)
                             }
@@ -71,11 +68,13 @@ internal class StatsManagerConfigTest : ConfigTest() {
             withLegacyConfig(legacyConfigAllStatsTransports()) {
                 withNewConfig(newConfigOneStatsTransport()) {
                     should("use the values from the old config") {
-                        val cfg = StatsManagerConfig()
-
-                        cfg.transportConfigs shouldHaveSize 2
-                        cfg.transportConfigs.forOne { it as StatsTransportConfig.MucStatsTransportConfig }
-                        cfg.transportConfigs.forOne { it as StatsTransportConfig.CallStatsIoStatsTransportConfig }
+                        StatsManagerConfig.config.transportConfigs shouldHaveSize 2
+                        StatsManagerConfig.config.transportConfigs.forOne {
+                            it as StatsTransportConfig.MucStatsTransportConfig
+                        }
+                        StatsManagerConfig.config.transportConfigs.forOne {
+                            it as StatsTransportConfig.CallStatsIoStatsTransportConfig
+                        }
                     }
                 }
             }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/websocket/config/WebsocketServiceConfigTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/websocket/config/WebsocketServiceConfigTest.kt
@@ -17,20 +17,13 @@
 package org.jitsi.videobridge.websocket.config
 
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.test.TestCase
 import io.kotest.matchers.shouldBe
 import org.jitsi.ConfigTest
 import org.jitsi.config.withNewConfig
 import org.jitsi.metaconfig.ConfigException
+import org.jitsi.videobridge.websocket.config.WebsocketServiceConfig.Companion.config
 
 class WebsocketServiceConfigTest : ConfigTest() {
-    private lateinit var config: WebsocketServiceConfig
-
-    override fun beforeTest(testCase: TestCase) {
-        super.beforeTest(testCase)
-        config = WebsocketServiceConfig()
-    }
-
     init {
         context("when websockets are disabled") {
             withNewConfig("videobridge.websockets.enabled = false") {

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/xmpp/config/XmppClientConnectionConfigTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/xmpp/config/XmppClientConnectionConfigTest.kt
@@ -30,7 +30,7 @@ internal class XmppClientConnectionConfigTest : ConfigTest() {
             context("when defined in the legacy config") {
                 withLegacyConfig(legacyConfigSingleXmppConnection) {
                     should("parse things correctly") {
-                        val configs = XmppClientConnectionConfig().clientConfigs
+                        val configs = XmppClientConnectionConfig.Companion.config.clientConfigs
                         configs shouldHaveSize 1
                         with(configs[0]) {
                             this.id shouldBe "shard"
@@ -50,7 +50,7 @@ internal class XmppClientConnectionConfigTest : ConfigTest() {
             context("when multiple are defined in legacy and one is incomplete") {
                 withLegacyConfig(legacyConfigOneCompleteConnectionOneIncomplete) {
                     should("only parse the complete one") {
-                        val configs = XmppClientConnectionConfig().clientConfigs
+                        val configs = XmppClientConnectionConfig.Companion.config.clientConfigs
                         configs shouldHaveSize 1
                         with(configs[0]) {
                             this.id shouldBe "shard"
@@ -70,7 +70,7 @@ internal class XmppClientConnectionConfigTest : ConfigTest() {
             context("when defined in new config") {
                 withNewConfig(newConfigSingleXmppConnection) {
                     should("parse things correctly") {
-                        val configs = XmppClientConnectionConfig().clientConfigs
+                        val configs = XmppClientConnectionConfig.Companion.config.clientConfigs
                         configs shouldHaveSize 1
                         with(configs[0]) {
                             this.id shouldBe "shard"
@@ -90,7 +90,7 @@ internal class XmppClientConnectionConfigTest : ConfigTest() {
             context("when defined in new config with some incomplete") {
                 withNewConfig(newConfigOneCompleteConnectionOneIncompleteOneBroken) {
                     should("parse things correctly") {
-                        val configs = XmppClientConnectionConfig().clientConfigs
+                        val configs = XmppClientConnectionConfig.Companion.config.clientConfigs
                         configs shouldHaveSize 1
                         with(configs[0]) {
                             this.id shouldBe "shard"


### PR DESCRIPTION
- chore: Remove stale logging config.
- ref: Use withNewConfig in JvbLoadManagerTest.
- ref: Disable Metaconfig caching for all tests.
- ref: Use a single static instance of WebsocketServiceConfig.
- ref: Use only the static octo config field.
- ref: Use only the static health config field.
- ref: Use only the static field for VideobridgeExpireThreadConfig.
- ref: Use only the static field for XmppClientConnectionConfig.
- ref: Move the BandwidthProbingConfig instance.
- ref: Use only the static config instance for BitrateControllerConfig.
- ref: Use only the static field for EndpointConnectionStatusConfig.
- ref: Move the StatsManagerConfig instance.
- ref: Use only the static instance of CallstatsConfig.
- fix: Fix CallstatsConfig getters.
- ref: Make constructors of config classes private.
