### PR TITLE
feat(multi-stream): endpoint ID compatibility

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -791,10 +791,11 @@ public class Conference
      * @param iceControlling {@code true} if the ICE agent of this endpoint's
      * transport will be initialized to serve as a controlling ICE agent;
      * otherwise, {@code false}
+     * @param sourceNames whether this endpoint signaled the source names support.
      * @return an <tt>Endpoint</tt> participating in this <tt>Conference</tt>
      */
     @NotNull
-    public Endpoint createLocalEndpoint(String id, boolean iceControlling)
+    public Endpoint createLocalEndpoint(String id, boolean iceControlling, boolean sourceNames)
     {
         final AbstractEndpoint existingEndpoint = getEndpoint(id);
         if (existingEndpoint instanceof OctoEndpoint)
@@ -812,7 +813,7 @@ public class Conference
             throw new IllegalArgumentException("Local endpoint with ID = " + id + "already created");
         }
 
-        final Endpoint endpoint = new Endpoint(id, this, logger, iceControlling);
+        final Endpoint endpoint = new Endpoint(id, this, logger, iceControlling, sourceNames);
 
         subscribeToEndpointEvents(endpoint);
 

--- a/jvb/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
@@ -34,6 +34,7 @@ import java.util.stream.*;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.jitsi.videobridge.VersionConfig.config;
+import static org.jitsi.videobridge.util.MultiStreamCompatibilityKt.endpointIdToSourceName;
 
 /**
  * Handles the functionality related to sending and receiving COLIBRI messages
@@ -128,6 +129,17 @@ public class EndpointMessageTransport
     @Override
     public BridgeChannelMessage videoType(VideoTypeMessage videoTypeMessage)
     {
+        if (MultiStreamConfig.config.getEnabled()) {
+            sourceVideoType(
+                new SourceVideoTypeMessage(
+                    videoTypeMessage.getVideoType(),
+                    endpointIdToSourceName(endpoint.getId()),
+                    videoTypeMessage.getEndpointId())
+            );
+
+            return null;
+        }
+
         endpoint.setVideoType(videoTypeMessage.getVideoType());
 
         Conference conference = endpoint.getConference();

--- a/jvb/src/main/java/org/jitsi/videobridge/octo/OctoEndpointMessageTransport.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/octo/OctoEndpointMessageTransport.java
@@ -219,6 +219,14 @@ class OctoEndpointMessageTransport
             return null;
         }
 
+        // Multi-stream mode is not supported in Octo v1
+        // TODO commented out work in progress that's old code before source name capability was added
+        /*if (MultiStreamConfig.config.getEnabled()) {
+            getLogger().error(
+                    "OctoV1: unexpected videoType message while in the multi-stream mode, eId=" + endpointId);
+            return null;
+        }*/
+
         AbstractEndpoint endpoint = octoEndpoints.getConference().getEndpoint(endpointId);
         if (!(endpoint instanceof OctoEndpoint))
         {

--- a/jvb/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -306,7 +306,11 @@ public class ConferenceShim
             return;
         }
 
-        conference.createLocalEndpoint(endpointId, iceControlling);
+        conference.createLocalEndpoint(
+                endpointId,
+                iceControlling,
+                false /* no multi-stream in colibri V1 */
+        );
     }
 
     /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -22,6 +22,7 @@ import org.jitsi.nlj.PacketHandler
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.Transceiver
 import org.jitsi.nlj.TransceiverEventHandler
+import org.jitsi.nlj.VideoType
 import org.jitsi.nlj.format.PayloadType
 import org.jitsi.nlj.rtp.AudioRtpPacket
 import org.jitsi.nlj.rtp.RtpExtension
@@ -86,7 +87,7 @@ import java.nio.ByteBuffer
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
-import java.util.Optional
+import java.util.*
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
@@ -104,6 +105,7 @@ class Endpoint @JvmOverloads constructor(
      * as a controlling ICE agent, false otherwise
      */
     iceControlling: Boolean,
+    private val isUsingSourceNames: Boolean,
     private val clock: Clock = Clock.systemUTC()
 ) : AbstractEndpoint(conference, id, parentLogger), PotentialPacketHandler, EncodingsManager.EncodingsUpdateListener {
     /**
@@ -207,7 +209,8 @@ class Endpoint @JvmOverloads constructor(
         },
         Supplier { getOrderedEndpoints() },
         diagnosticContext,
-        logger
+        logger,
+        isUsingSourceNames
     )
 
     /**
@@ -285,6 +288,8 @@ class Endpoint @JvmOverloads constructor(
         setupDtlsTransport()
 
         conference.videobridge.statistics.totalEndpoints.incrementAndGet()
+
+        logger.info("$id source names: $isUsingSourceNames")
     }
 
     override var mediaSources: Array<MediaSourceDesc>
@@ -545,10 +550,14 @@ class Endpoint @JvmOverloads constructor(
         if (findMediaSourceDesc(sourceName) == null) {
             logger.warn { "Suppressing sending a SenderVideoConstraints message, endpoint has no such source." }
         } else {
-            val senderSourceConstraintsMessage =
-                SenderSourceConstraintsMessage(sourceName, maxVideoConstraints.maxHeight)
-            logger.cdebug { "Sender constraints changed: ${senderSourceConstraintsMessage.toJson()}" }
-            sendMessage(senderSourceConstraintsMessage)
+            if (isUsingSourceNames) {
+                val senderSourceConstraintsMessage =
+                    SenderSourceConstraintsMessage(sourceName, maxVideoConstraints.maxHeight)
+                logger.cdebug { "Sender constraints changed: ${senderSourceConstraintsMessage.toJson()}" }
+                sendMessage(senderSourceConstraintsMessage)
+            } else {
+                sendVideoConstraints(maxReceiverVideoConstraintsMap[sourceName]!!)
+            }
         }
     }
 
@@ -687,6 +696,10 @@ class Endpoint @JvmOverloads constructor(
      */
     @Deprecated("", ReplaceWith("sendForwardedSourcesMessage"), DeprecationLevel.WARNING)
     fun sendForwardedEndpointsMessage(forwardedEndpoints: Collection<String>) {
+        if (MultiStreamConfig.config.enabled && isUsingSourceNames) {
+            return
+        }
+
         val msg = ForwardedEndpointsMessage(forwardedEndpoints)
         TaskPools.IO_POOL.execute {
             try {
@@ -704,6 +717,10 @@ class Endpoint @JvmOverloads constructor(
      * @param forwardedSources the collection of forwarded media sources (by name).
      */
     fun sendForwardedSourcesMessage(forwardedSources: Collection<String>) {
+        if (!isUsingSourceNames) {
+            return
+        }
+
         val msg = ForwardedSourcesMessage(forwardedSources)
         TaskPools.IO_POOL.execute {
             try {
@@ -810,8 +827,9 @@ class Endpoint @JvmOverloads constructor(
 
     fun setMaxFrameHeight(maxFrameHeight: Int) = bitrateController.setMaxFrameHeight(maxFrameHeight)
 
-    fun setBandwidthAllocationSettings(message: ReceiverVideoConstraintsMessage) =
+    fun setBandwidthAllocationSettings(message: ReceiverVideoConstraintsMessage) {
         bitrateController.setBandwidthAllocationSettings(message)
+    }
 
     override fun send(packetInfo: PacketInfo) {
         when (val packet = packetInfo.packet) {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/AllocationSettings.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/AllocationSettings.kt
@@ -20,6 +20,7 @@ import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.videobridge.MultiStreamConfig
 import org.jitsi.videobridge.cc.config.BitrateControllerConfig.Companion.config
 import org.jitsi.videobridge.message.ReceiverVideoConstraintsMessage
+import org.jitsi.videobridge.util.endpointIdToSourceName
 import java.util.stream.Collectors
 import kotlin.math.min
 
@@ -59,7 +60,7 @@ data class AllocationSettings @JvmOverloads constructor(
  * Maintains an [AllocationSettings] instance and allows fields to be set individually, with an indication of whether
  * the overall state changed.
  */
-internal class AllocationSettingsWrapper {
+internal class AllocationSettingsWrapper(private val useSourceNames: Boolean) {
     /**
      * The last selected endpoints set signaled by the receiving endpoint.
      */
@@ -148,29 +149,47 @@ internal class AllocationSettingsWrapper {
             }
         }
         if (MultiStreamConfig.config.enabled) {
-            message.selectedSources?.let {
-                if (selectedSources != it) {
-                    selectedSources = it
+            if (useSourceNames) {
+                message.selectedSources?.let {
+                    if (selectedSources != it) {
+                        selectedSources = it
+                        changed = true
+                    }
+                }
+                message.onStageSources?.let {
+                    if (onStageSources != it) {
+                        onStageSources = it
+                        changed = true
+                    }
+                }
+            } else {
+                message.selectedEndpoints?.let {
+                    val newSelectedSources = it.map { endpoint -> endpointIdToSourceName(endpoint) }
+                    if (selectedSources != newSelectedSources) {
+                        selectedSources = newSelectedSources
+                        changed = true
+                    }
+                }
+                message.onStageEndpoints?.let {
+                    val newOnStageSources = it.map { endpoint -> endpointIdToSourceName(endpoint) }
+                    if (onStageSources != newOnStageSources) {
+                        onStageSources = newOnStageSources
+                        changed = true
+                    }
+                }
+            }
+        } else {
+            message.selectedEndpoints?.let {
+                if (selectedEndpoints != it) {
+                    selectedEndpoints = it
                     changed = true
                 }
             }
-            message.onStageSources?.let {
-                if (onStageSources != it) {
-                    onStageSources = it
+            message.onStageEndpoints?.let {
+                if (onStageEndpoints != it) {
+                    onStageEndpoints = it
                     changed = true
                 }
-            }
-        }
-        message.selectedEndpoints?.let {
-            if (selectedEndpoints != it) {
-                selectedEndpoints = it
-                changed = true
-            }
-        }
-        message.onStageEndpoints?.let {
-            if (onStageEndpoints != it) {
-                onStageEndpoints = it
-                changed = true
             }
         }
         message.defaultConstraints?.let {
@@ -180,8 +199,18 @@ internal class AllocationSettingsWrapper {
             }
         }
         message.constraints?.let {
-            if (this.videoConstraints != it) {
-                this.videoConstraints = it
+            var newConstraints = it
+
+            // Convert endpoint IDs to source names
+            if (MultiStreamConfig.config.enabled && !useSourceNames) {
+                newConstraints = HashMap(it.size)
+                it.entries.stream().forEach {
+                    entry -> newConstraints[endpointIdToSourceName(entry.key)] = entry.value
+                }
+            }
+
+            if (this.videoConstraints != newConstraints) {
+                this.videoConstraints = newConstraints
                 changed = true
             }
         }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/colibri2/Colibri2ConferenceHandler.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/colibri2/Colibri2ConferenceHandler.kt
@@ -140,7 +140,7 @@ class Colibri2ConferenceHandler(
                 Condition.bad_request,
                 "Attempt to create endpoint ${c2endpoint.id} with no <transport>"
             )
-            val sourceNames = c2endpoint.capabilities.find { c -> Capability.CAP_SOURCE_NAME_SUPPORT == c.name } != null
+            val sourceNames = c2endpoint.hasCapability(Capability.CAP_SOURCE_NAME_SUPPORT)
             conference.createLocalEndpoint(c2endpoint.id, transport.iceControlling, sourceNames).apply {
                 transport.sctp?.let { sctp ->
                     if (!SctpConfig.config.enabled) {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/colibri2/Colibri2ConferenceHandler.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/colibri2/Colibri2ConferenceHandler.kt
@@ -18,6 +18,7 @@ import org.jitsi.videobridge.shim.IqProcessingException
 import org.jitsi.videobridge.util.PayloadTypeUtil.Companion.create
 import org.jitsi.videobridge.xmpp.MediaSourceFactory
 import org.jitsi.xmpp.extensions.colibri.SourcePacketExtension
+import org.jitsi.xmpp.extensions.colibri2.Capability
 import org.jitsi.xmpp.extensions.colibri2.Colibri2Endpoint
 import org.jitsi.xmpp.extensions.colibri2.Colibri2Relay
 import org.jitsi.xmpp.extensions.colibri2.ConferenceModifiedIQ
@@ -139,7 +140,8 @@ class Colibri2ConferenceHandler(
                 Condition.bad_request,
                 "Attempt to create endpoint ${c2endpoint.id} with no <transport>"
             )
-            conference.createLocalEndpoint(c2endpoint.id, transport.iceControlling).apply {
+            val sourceNames = c2endpoint.capabilities.find { c -> Capability.CAP_SOURCE_NAME_SUPPORT == c.name } != null
+            conference.createLocalEndpoint(c2endpoint.id, transport.iceControlling, sourceNames).apply {
                 transport.sctp?.let { sctp ->
                     if (!SctpConfig.config.enabled) {
                         throw IqProcessingException(

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/message/BridgeChannelMessage.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/message/BridgeChannelMessage.kt
@@ -351,6 +351,7 @@ class EndpointConnectionStatusMessage(
 /**
  * A message sent from the bridge to a client, indicating the set of endpoints that are currently being forwarded.
  */
+@Deprecated("Use ForwardedSourcesMessage", ReplaceWith("ForwardedSourcesMessage"), DeprecationLevel.WARNING)
 class ForwardedEndpointsMessage(
     @get:JsonProperty("lastNEndpoints")
     /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
@@ -170,6 +170,11 @@ class RelayMessageTransport(
             return null
         }
 
+        if (MultiStreamConfig.config.enabled) {
+            logger.error("Relay: unexpected video type message while in the multi-stream mode, eId=$epId")
+            return null
+        }
+
         val ep = relay.getEndpoint(epId)
 
         if (ep == null) {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/util/MultiStreamCompatibility.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/util/MultiStreamCompatibility.kt
@@ -1,0 +1,6 @@
+package org.jitsi.videobridge.util
+
+fun endpointIdToSourceName(endpointId: String): String {
+    return "$endpointId-v0"
+}
+

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/ConferenceTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/ConferenceTest.kt
@@ -44,7 +44,7 @@ class ConferenceTest : ConfigTest() {
         context("Adding local endpoints should work") {
             with(Conference(videobridge, "id", name, Conference.GID_NOT_SET, null, false, false)) {
                 endpointCount shouldBe 0
-                createLocalEndpoint("abcdabcd", true)
+                createLocalEndpoint("abcdabcd", true, false) // TODO cover the case when it's true
                 endpointCount shouldBe 1
                 debugState.shouldBeValidJson()
             }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/AllocationSettingsTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/AllocationSettingsTest.kt
@@ -23,7 +23,8 @@ class AllocationSettingsTest : ShouldSpec() {
     init {
         context("computeVideoConstraints") {
             context("Stage view behavior") {
-                val allocationSettings = AllocationSettingsWrapper()
+                // TODO write a test for sourceNames=true
+                val allocationSettings = AllocationSettingsWrapper(false)
                 allocationSettings.setMaxFrameHeight(720)
                 allocationSettings.setSelectedEndpoints(listOf("A"))
 
@@ -37,7 +38,8 @@ class AllocationSettingsTest : ShouldSpec() {
                 )
             }
             context("Tile view behavior") {
-                val allocationSettings = AllocationSettingsWrapper()
+                // TODO write a test for sourceNames=true
+                val allocationSettings = AllocationSettingsWrapper(false)
                 allocationSettings.setMaxFrameHeight(180)
                 allocationSettings.setSelectedEndpoints(listOf("A", "B", "C", "D"))
 

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerNewTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerNewTest.kt
@@ -1363,6 +1363,7 @@ class BitrateControllerWrapper2(initialEndpoints: List<MediaSourceContainer>, va
         Supplier { endpoints },
         DiagnosticContext(),
         logger,
+        true, // TODO merge BitrateControllerNewTest with old and use this flag
         clock
     )
 

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerPerfTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerPerfTest.kt
@@ -75,7 +75,8 @@ class BitrateControllerPerfTest : StringSpec() {
         Supplier { endpoints.toList() },
         DiagnosticContext(),
         createLogger(),
-        clock
+        false, // TODO cover the case for true?
+        clock,
     ).apply {
         // The BC only starts working 10 seconds after it first received media, so fake that.
         transformRtp(PacketInfo(VideoRtpPacket(ByteArray(100), 0, 100)))

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerTest.kt
@@ -1428,6 +1428,7 @@ class BitrateControllerWrapper(initialEndpoints: List<MediaSourceContainer>, val
         Supplier { endpoints },
         DiagnosticContext(),
         logger,
+        false, // TODO merge this test with BitrateControllerNewTest and use this flag
         clock
     )
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-xmpp-extensions</artifactId>
-                <version>1.0-44-g707c6af</version>
+                <version>1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Jicofo will forward source name capability for
each Colibri2 Endpoint. In Colibri V1 "use source
names" is always false for now.

Based on the info on whether the client uses source
names or not, will use different signaling messages
for talking to this client. All operations under
the hood are happening on source names.