### PR TITLE
fix: Read relayId from config directly.

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayService.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/octo/OctoRelayService.kt
@@ -49,7 +49,6 @@ class OctoRelayService {
         }
 
         val address = config.bindAddress
-        val publicAddress = config.publicAddress
         val port = config.bindPort
 
         try {
@@ -71,7 +70,7 @@ class OctoRelayService {
         }
         logger.info("Created Octo UDP transport")
 
-        bridgeOctoTransport = BridgeOctoTransport("$publicAddress:$port", logger)
+        bridgeOctoTransport = BridgeOctoTransport(config.relayId, logger)
 
         // Wire the data coming from the UdpTransport to the OctoTransport
         udpTransport.incomingDataHandler = object : UdpTransport.IncomingDataHandler {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/octo/config/OctoConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/octo/config/OctoConfig.kt
@@ -59,11 +59,17 @@ class OctoConfig private constructor() {
         "videobridge.octo.region".from(JitsiConfig.newConfig)
     }
 
+    /**
+     * This is deprecated and only used in octo v1.
+     */
     val bindAddress: String by config {
         "bind address from legacy config" { legacyBindAddress!! }
         "videobridge.octo.bind-address".from(JitsiConfig.newConfig)
     }
 
+    /**
+     * This is deprecated and only used in octo v1.
+     */
     val bindPort: Int by config {
         "bind port from legacy config" { legacyBindPort!! }
         "videobridge.octo.bind-port".from(JitsiConfig.newConfig)
@@ -73,11 +79,17 @@ class OctoConfig private constructor() {
      * If publicAddress doesn't have a value, default to the value of bindAddress.
      * Note: we can't use a substitution in reference.conf because that won't take into account
      * reading a value from the legacy config file
+     * This is deprecated and only used in octo v1.
      */
     val publicAddress: String by config {
         "org.jitsi.videobridge.octo.PUBLIC_ADDRESS".from(JitsiConfig.legacyConfig)
         "videobridge.octo.public-address".from(JitsiConfig.newConfig)
         "bindAddress" { bindAddress }
+    }
+
+    val relayId: String by config {
+        "videobridge.octo.relay-id".from(JitsiConfig.newConfig)
+        "default" { "$publicAddress:$bindPort" }
     }
 
     companion object {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayedEndpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayedEndpoint.kt
@@ -43,6 +43,7 @@ import org.jitsi.videobridge.Conference
 import org.jitsi.videobridge.cc.allocation.VideoConstraints
 import org.jitsi.videobridge.message.AddReceiverMessage
 import org.jitsi.videobridge.octo.OctoPacketInfo
+import org.jitsi.videobridge.octo.config.OctoConfig
 import org.jitsi.videobridge.util.TaskPools
 import org.json.simple.JSONObject
 import java.time.Instant
@@ -139,7 +140,7 @@ class RelayedEndpoint(
     override fun sendVideoConstraints(maxVideoConstraints: VideoConstraints) {
         relay.sendMessage(
             AddReceiverMessage(
-                conference.tentacle.bridgeId, /* TODO: store local bridge ID somewhere better */
+                OctoConfig.config.relayId,
                 id,
                 null, /* source name  - used in multi-stream */
                 maxVideoConstraints
@@ -150,7 +151,7 @@ class RelayedEndpoint(
     override fun sendVideoConstraintsV2(sourceName: String, maxVideoConstraints: VideoConstraints) {
         relay.sendMessage(
             AddReceiverMessage(
-                conference.tentacle.bridgeId, /* TODO: store local bridge ID somewhere better */
+                OctoConfig.config.relayId,
                 null, // Endpoint ID - will be removed
                 sourceName,
                 maxVideoConstraints

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -150,6 +150,9 @@ videobridge {
     # will be part of the Octo relayId
     #public-address=198.51.100.1
 
+    # The unique identifier of the jitsi-videobridge instance as an octo relay. Defaults to public-address:bind-port.
+    #relay-id="jvb-1234"
+
     # The size of the incoming octo queue. This queue is per-remote-endpoint,
     # so it matches what we use for local endpoints
     recv-queue-size=1024


### PR DESCRIPTION
Accessing conference.tentacle initializes the octo v1 tentacle. Reported
by @paweldomas.