### PR TITLE
Fix timestamp handling in generic projection.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/cc/GenericAdaptiveSourceProjectionContext.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/GenericAdaptiveSourceProjectionContext.java
@@ -215,7 +215,7 @@ class GenericAdaptiveSourceProjectionContext
             }
 
             if (RtpUtils.isNewerTimestampThan(
-                destinationSequenceNumber, maxDestinationTimestamp))
+                destinationTimestamp, maxDestinationTimestamp))
             {
                 maxDestinationTimestamp = destinationTimestamp;
             }
@@ -247,7 +247,7 @@ class GenericAdaptiveSourceProjectionContext
         }
 
         if (RtpUtils.isNewerTimestampThan(
-            maxDestinationSequenceNumber, sourceTimestamp))
+            maxDestinationTimestamp, sourceTimestamp))
         {
             long destinationTimestamp =
                     RtpUtils.applyTimestampDelta(maxDestinationTimestamp, 3000);


### PR DESCRIPTION
Timestamps were compared to sequence numbers in a couple of places.