### PR TITLE
Shutting down

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -814,6 +814,7 @@ public class Conference
         }
 
         final Endpoint endpoint = new Endpoint(id, this, logger, iceControlling, sourceNames);
+        videobridge.endpointCreated();
 
         subscribeToEndpointEvents(endpoint);
 
@@ -1076,6 +1077,7 @@ public class Conference
         if (removedEndpoint != null)
         {
             endpointsChanged();
+            videobridge.endpointExpired();
         }
     }
 

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -683,6 +683,11 @@ public class Videobridge
         return shutdownManager.getState() == ShutdownState.GRACEFUL_SHUTDOWN;
     }
 
+    public ShutdownState getShutdownState()
+    {
+        return shutdownManager.getState();
+    }
+
     /**
      * Initiate a shutdown if there are no conferences left.
      */
@@ -707,7 +712,7 @@ public class Videobridge
                 // Make sure that enough time passes for the "graceful shutdown" mode to be announced in presence.
                 // Otherwise, other components may detect this as a bridge going down non-gracefully.
                 Duration delay
-                        = VideobridgeConfig.Companion.getGracefulShutdownDelay().minus(timeSinceShutdownRequested);
+                        = ShutdownConfig.config.getGracefulShutdownDelay().minus(timeSinceShutdownRequested);
                 if (delay.isNegative() || delay.isZero())
                 {
                     shutdownManager.doShutdown();

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -440,47 +440,6 @@ public class Videobridge
     }
 
     /**
-     * Handles a COLIBRI2 request synchronously. Exposed only for testing (jicofo).
-     * @param conferenceModifyIQ The COLIBRI request.
-     * @return The response in the form of an {@link IQ}. It is either an error or a {@link ColibriConferenceIQ}.
-     */
-    public IQ handleConferenceModifyIq(ConferenceModifyIQ conferenceModifyIQ)
-    {
-        Conference conference;
-        try
-        {
-            conference = getOrCreateConference(conferenceModifyIQ);
-        }
-        catch (ConferenceNotFoundException e)
-        {
-            return IQUtils.createError(
-                    conferenceModifyIQ,
-                    StanzaError.Condition.bad_request,
-                    "Conference not found for ID: " + conferenceModifyIQ.getMeetingId());
-        }
-        catch (ConferenceAlreadyExistsException e)
-        {
-            return IQUtils.createError(
-                    conferenceModifyIQ,
-                    StanzaError.Condition.bad_request,
-                    "Conference already exists for ID: " + conferenceModifyIQ.getMeetingId());
-        }
-        catch (InGracefulShutdownException e)
-        {
-            return ColibriConferenceIQ.createGracefulShutdownErrorResponse(conferenceModifyIQ);
-        }
-        catch (XmppStringprepException e)
-        {
-            return IQUtils.createError(
-                    conferenceModifyIQ,
-                    StanzaError.Condition.bad_request,
-                    "Invalid conference name (not a JID)");
-        }
-
-        return conference.handleConferenceModifyIQ(conferenceModifyIQ);
-    }
-
-    /**
      * Handles a COLIBRI request asynchronously.
      */
     private void handleColibriRequest(XmppConnection.ColibriRequest request)

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -601,7 +601,7 @@ public class Videobridge
             throws ConferenceNotFoundException, InGracefulShutdownException
     {
         String conferenceId = conferenceIq.getID();
-        if (conferenceId == null && isShutdownInProgress())
+        if (conferenceId == null && isInGracefulShutdown())
         {
             throw new InGracefulShutdownException();
         }
@@ -644,7 +644,7 @@ public class Videobridge
                     logger.warn("Will not create conference, conference already exists for meetingId=" + meetingId);
                     throw new ConferenceAlreadyExistsException();
                 }
-                if (isShutdownInProgress())
+                if (isInGracefulShutdown())
                 {
                     logger.warn("Will not create conference in shutdown mode.");
                     throw new InGracefulShutdownException();
@@ -757,7 +757,7 @@ public class Videobridge
      * @return {@code true} if this instance has entered graceful shutdown mode;
      * otherwise, {@code false}
      */
-    public boolean isShutdownInProgress()
+    public boolean isInGracefulShutdown()
     {
         return shutdownRequestedTime != null;
     }

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -118,7 +118,7 @@ public class Videobridge
      * Note that currently most code uses the system clock directly.
      */
     @NotNull
-    private Clock clock = Clock.systemUTC();
+    private final Clock clock;
 
     /**
      * A class that holds some instance statistics.
@@ -170,8 +170,10 @@ public class Videobridge
         @Nullable XmppConnection xmppConnection,
         @NotNull ShutdownServiceImpl shutdownService,
         @NotNull Version version,
-        @Nullable String releaseId)
+        @Nullable String releaseId,
+        @NotNull Clock clock)
     {
+        this.clock = clock;
         videobridgeExpireThread = new VideobridgeExpireThread(this);
         jvbLoadManager = new JvbLoadManager<>(
             PacketRateMeasurement.getLoadedThreshold(),
@@ -307,11 +309,6 @@ public class Videobridge
         });
 
         return conference;
-    }
-
-    protected void setClock(@NotNull Clock clock)
-    {
-        this.clock = clock;
     }
 
     /**

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -713,18 +713,10 @@ public class Videobridge
         else
         {
             logger.warn("Will shutdown in 1 second.");
-            new Thread(() -> {
-                try
-                {
-                    Thread.sleep(1000);
-                    logger.warn("JVB force shutdown - now");
-                    System.exit(0);
-                }
-                catch (InterruptedException e)
-                {
-                    throw new RuntimeException(e);
-                }
-            }, "ForceShutdownThread").start();
+            TaskPools.SCHEDULED_POOL.schedule(() -> {
+                logger.warn("JVB force shutdown - now");
+                System.exit(0);
+            }, 1, TimeUnit.SECONDS);
         }
     }
 

--- a/jvb/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/shim/ConferenceShim.java
@@ -351,7 +351,7 @@ public class ConferenceShim
     {
         ColibriConferenceIQ responseConferenceIQ = new ColibriConferenceIQ();
         conference.describeShallow(responseConferenceIQ);
-        responseConferenceIQ.setGracefulShutdown(conference.getVideobridge().isShutdownInProgress());
+        responseConferenceIQ.setGracefulShutdown(conference.getVideobridge().isInGracefulShutdown());
 
         initializeSignaledEndpoints(conferenceIQ);
 

--- a/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -26,6 +26,7 @@ import org.jitsi.videobridge.octo.*;
 import org.jitsi.videobridge.octo.config.*;
 import org.jitsi.videobridge.relay.*;
 import org.jitsi.videobridge.shim.*;
+import org.jitsi.videobridge.shutdown.*;
 import org.jitsi.videobridge.xmpp.*;
 import org.json.simple.*;
 
@@ -559,6 +560,10 @@ public class VideobridgeStatistics
             unlockedSetStat(
                     SHUTDOWN_IN_PROGRESS,
                     videobridge.isInGracefulShutdown());
+            if (videobridge.getShutdownState() == ShutdownState.SHUTTING_DOWN)
+            {
+                unlockedSetStat("shutting_down", true);
+            }
             unlockedSetStat(DRAIN, videobridge.getDrainMode());
             unlockedSetStat(TOTAL_DATA_CHANNEL_MESSAGES_RECEIVED,
                             jvbStats.totalDataChannelMessagesReceived.get());

--- a/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -558,7 +558,7 @@ public class VideobridgeStatistics
             unlockedSetStat(THREADS, threadCount);
             unlockedSetStat(
                     SHUTDOWN_IN_PROGRESS,
-                    videobridge.isShutdownInProgress());
+                    videobridge.isInGracefulShutdown());
             unlockedSetStat(DRAIN, videobridge.getDrainMode());
             unlockedSetStat(TOTAL_DATA_CHANNEL_MESSAGES_RECEIVED,
                             jvbStats.totalDataChannelMessagesReceived.get());

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
@@ -45,6 +45,7 @@ import org.jitsi.videobridge.websocket.ColibriWebSocketService
 import org.jitsi.videobridge.xmpp.XmppConnection
 import org.jitsi.videobridge.xmpp.config.XmppClientConnectionConfig
 import org.jxmpp.stringprep.XmppStringPrepUtil
+import java.time.Clock
 import kotlin.concurrent.thread
 import org.jitsi.videobridge.octo.singleton as octoRelayService
 import org.jitsi.videobridge.websocket.singleton as webSocketServiceSingleton
@@ -97,7 +98,7 @@ fun main(args: Array<String>) {
     val xmppConnection = XmppConnection().apply { start() }
     val shutdownService = ShutdownServiceImpl()
     val videobridge = Videobridge(
-        xmppConnection, shutdownService, versionService.currentVersion, VersionConfig.config.release
+        xmppConnection, shutdownService, versionService.currentVersion, VersionConfig.config.release, Clock.systemUTC()
     ).apply { start() }
     val healthChecker = videobridge.jvbHealthChecker
     val octoRelayService = octoRelayService().get()?.apply { start() }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/VideobridgeConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/VideobridgeConfig.kt
@@ -18,13 +18,9 @@ package org.jitsi.videobridge
 
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
-import java.time.Duration
 
 class VideobridgeConfig private constructor() {
     companion object {
-        val gracefulShutdownDelay: Duration by config {
-            "videobridge.graceful-shutdown-delay".from(JitsiConfig.newConfig)
-        }
         val initialDrainMode: Boolean by config {
             "videobridge.initial-drain-mode".from(JitsiConfig.newConfig)
         }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/shutdown/ShutdownConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/shutdown/ShutdownConfig.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright @ 2022 - Present, 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.videobridge.shutdown
+
+import org.jitsi.config.JitsiConfig
+import org.jitsi.metaconfig.config
+import java.time.Duration
+
+class ShutdownConfig {
+    private constructor()
+
+    val gracefulShutdownDelay: Duration by config {
+        "videobridge.graceful-shutdown-delay".from(JitsiConfig.newConfig)
+        "videobridge.shutdown.graceful-shutdown-delay".from(JitsiConfig.newConfig)
+    }
+    val gracefulShutdownMaxDuration: Duration by config {
+        "videobridge.shutdown.graceful-shutdown-max-duration".from(JitsiConfig.newConfig)
+    }
+    val gracefulShutdownMinParticipants: Int by config {
+        "videobridge.shutdown.graceful-shutdown-min-participants".from(JitsiConfig.newConfig)
+    }
+    val shuttingDownDelay: Duration by config {
+        "videobridge.shutdown.shutting-down-delay".from(JitsiConfig.newConfig)
+    }
+
+    companion object {
+        @JvmField
+        val config = ShutdownConfig()
+    }
+}

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/shutdown/ShutdownConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/shutdown/ShutdownConfig.kt
@@ -23,10 +23,6 @@ import java.time.Duration
 class ShutdownConfig {
     private constructor()
 
-    val gracefulShutdownDelay: Duration by config {
-        "videobridge.graceful-shutdown-delay".from(JitsiConfig.newConfig)
-        "videobridge.shutdown.graceful-shutdown-delay".from(JitsiConfig.newConfig)
-    }
     val gracefulShutdownMaxDuration: Duration by config {
         "videobridge.shutdown.graceful-shutdown-max-duration".from(JitsiConfig.newConfig)
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/shutdown/ShutdownManager.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/shutdown/ShutdownManager.kt
@@ -18,14 +18,28 @@ package org.jitsi.videobridge.shutdown
 import org.jitsi.meet.ShutdownService
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
+import org.jitsi.videobridge.shutdown.ShutdownConfig.Companion.config
 import org.jitsi.videobridge.shutdown.ShutdownState.GRACEFUL_SHUTDOWN
 import org.jitsi.videobridge.shutdown.ShutdownState.RUNNING
+import org.jitsi.videobridge.shutdown.ShutdownState.SHUTTING_DOWN
 import org.jitsi.videobridge.util.TaskPools
 import java.time.Clock
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 import kotlin.system.exitProcess
 
+/**
+ * Implements the graceful shutdown logic.
+ *
+ * When graceful shutdown is initiated the state changes to [GRACEFUL_SHUTDOWN], and this is advertised in presence.
+ * In this mode new conferences are rejected, but existing conferences continue to run and accept new participants. We
+ * stay in this state until either [config.gracefulShutdownMaxDuration] has passed, or the number of participants
+ * drops below [config.gracefulShutdownMinParticipants].
+ *
+ * Then the state transitions to [SHUTTING_DOWN], and this state is advertised in presence. We expect jicofo to
+ * actively move participants off this bridge. We stay in [SHUTTING_DOWN] for [config.shuttingDownDelay] before we
+ * actually perform the shutdown.
+ */
 class ShutdownManager(
     private val shutdownService: ShutdownService,
     private val clock: Clock,
@@ -44,13 +58,19 @@ class ShutdownManager(
 
     fun shutdown(graceful: Boolean) {
         logger.info("Received shutdown request, graceful=$graceful")
+
         if (graceful) {
             if (state == RUNNING) {
                 state = GRACEFUL_SHUTDOWN
                 shutdownRequestedTime = clock.instant()
                 logger.info("Entered graceful shutdown mode")
+                TaskPools.SCHEDULED_POOL.schedule(
+                    { changeToShuttingDown() },
+                    config.gracefulShutdownMaxDuration.toMillis(),
+                    TimeUnit.MILLISECONDS
+                )
             } else {
-                logger.info("Already in graceful shutdown mode.")
+                logger.info("Graceful shutdown already initiated mode.")
             }
         } else {
             // Give time for a response to be sent back if this was requested via HTTP/XMPP?
@@ -64,6 +84,20 @@ class ShutdownManager(
                 1, TimeUnit.SECONDS
             )
         }
+    }
+
+    private fun changeToShuttingDown() {
+        if (state == SHUTTING_DOWN) {
+            return
+        }
+
+        logger.info("Changing to SHUTTING_DOWN, will shut down in ${config.shuttingDownDelay}")
+        state = SHUTTING_DOWN
+        TaskPools.SCHEDULED_POOL.schedule(
+            { doShutdown() },
+            config.shuttingDownDelay.toMillis(),
+            TimeUnit.MILLISECONDS
+        )
     }
 
     fun doShutdown() {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/shutdown/ShutdownManager.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/shutdown/ShutdownManager.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright @ 2022 - Present, 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.shutdown
+
+import org.jitsi.meet.ShutdownService
+import org.jitsi.utils.logging2.Logger
+import org.jitsi.utils.logging2.createChildLogger
+import org.jitsi.videobridge.util.TaskPools
+import org.jitsi.videobridge.shutdown.ShutdownState.GRACEFUL_SHUTDOWN
+import org.jitsi.videobridge.shutdown.ShutdownState.RUNNING
+import java.time.Clock
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import kotlin.system.exitProcess
+
+class ShutdownManager(
+    private val shutdownService: ShutdownService,
+    private val clock: Clock,
+    parentLogger: Logger
+) {
+    val logger = createChildLogger(parentLogger)
+
+    /**
+     * The [clock] time at which graceful shutdown was requested, or null if it has never been requested.
+     */
+    var shutdownRequestedTime: Instant? = null
+        private set
+
+    var state: ShutdownState = RUNNING
+        private set
+
+    fun shutdown(graceful: Boolean) {
+        logger.info("Received shutdown request, graceful=$graceful")
+        if (graceful) {
+            if (state == RUNNING) {
+                state = GRACEFUL_SHUTDOWN
+                shutdownRequestedTime = clock.instant()
+                logger.info("Entered graceful shutdown mode")
+            } else {
+                logger.info("Already in graceful shutdown mode.")
+            }
+        } else {
+            // Give time for a response to be sent back if this was requested via HTTP/XMPP?
+            state = GRACEFUL_SHUTDOWN
+            logger.warn("Will shutdown in 1 second.")
+            TaskPools.SCHEDULED_POOL.schedule(
+                {
+                    logger.warn("JVB force shutdown - now")
+                    exitProcess(0)
+                },
+                1, TimeUnit.SECONDS
+            )
+        }
+    }
+
+    fun doShutdown() {
+        logger.info("Videobridge is shutting down NOW")
+        shutdownService.beginShutdown()
+    }
+}

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/shutdown/ShutdownManager.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/shutdown/ShutdownManager.kt
@@ -18,9 +18,9 @@ package org.jitsi.videobridge.shutdown
 import org.jitsi.meet.ShutdownService
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
-import org.jitsi.videobridge.util.TaskPools
 import org.jitsi.videobridge.shutdown.ShutdownState.GRACEFUL_SHUTDOWN
 import org.jitsi.videobridge.shutdown.ShutdownState.RUNNING
+import org.jitsi.videobridge.util.TaskPools
 import java.time.Clock
 import java.time.Instant
 import java.util.concurrent.TimeUnit

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/shutdown/ShutdownState.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/shutdown/ShutdownState.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright @ 2022 - Present, 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.shutdown
+
+enum class ShutdownState {
+    RUNNING,
+    GRACEFUL_SHUTDOWN
+}

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/shutdown/ShutdownState.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/shutdown/ShutdownState.kt
@@ -17,5 +17,6 @@ package org.jitsi.videobridge.shutdown
 
 enum class ShutdownState {
     RUNNING,
-    GRACEFUL_SHUTDOWN
+    GRACEFUL_SHUTDOWN,
+    SHUTTING_DOWN
 }

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -73,7 +73,7 @@ videobridge {
         # Which statistics to send, when filter is enabled.
         # Ignored if filter is disabled.
         whitelist = ["average_participant_stress", "colibri2", "current_timestamp", "drain", "graceful_shutdown",
-          "healthy", "region", "relay_id", "release", "stress_level", "version"]
+          "healthy", "region", "relay_id", "release", "shutting_down", "stress_level", "version"]
       }
 
       # The size of the Smack JID cache
@@ -355,8 +355,21 @@ videobridge {
     #release = "123"
   }
 
-  # The minimum amount of time to stay in graceful-shutdown mode before terminating.
-  graceful-shutdown-delay = 1 minute
+  shutdown {
+    # The minimum amount of time to stay in graceful-shutdown mode before terminating.
+    graceful-shutdown-delay = 1 minute
+
+    # The maximum amount of time to stay in GRACEFUL_SHUTDOWN before going into SHUTTING_DOWN. See ShutdownManager.
+    graceful-shutdown-max-duration = 1 hour
+
+    # The minimum numnber of participants required to stay in GRACEFUL_SHUTDOWN. If the number of participants falls
+    # below this threshold the bridge will transition to SHUTTING_DOWN. See ShutdownManager.
+    graceful-shutdown-min-participants = 10
+
+    # The amount of time to stay in SHUTTING_DOWN before acutally shutting down. Gives jicofo time to actively move
+    # participants off this bridge.
+    shutting-down-delay = 1 minutes
+  }
 
   # Whether to start the videobridge in drain mode.
   initial-drain-mode = false

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -356,9 +356,6 @@ videobridge {
   }
 
   shutdown {
-    # The minimum amount of time to stay in graceful-shutdown mode before terminating.
-    graceful-shutdown-delay = 1 minute
-
     # The maximum amount of time to stay in GRACEFUL_SHUTDOWN before going into SHUTTING_DOWN. See ShutdownManager.
     graceful-shutdown-max-duration = 1 hour
 

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/ConferenceTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/ConferenceTest.kt
@@ -31,7 +31,7 @@ import org.jitsi.videobridge.octo.singleton as octoRelayServiceProvider
  * This is a high-level test for [Conference] and related functionality.
  */
 class ConferenceTest : ConfigTest() {
-    private val videobridge = mockk<Videobridge> {
+    private val videobridge = mockk<Videobridge>(relaxed = true) {
         every { statistics } returns Videobridge.Statistics()
     }
 

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/VideobridgeTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/VideobridgeTest.kt
@@ -46,7 +46,7 @@ class VideobridgeTest : ShouldSpec() {
                 context("starting a graceful shutdown") {
                     videobridge.shutdown(true)
                     should("report that shutdown is in progress") {
-                        videobridge.isShutdownInProgress shouldBe true
+                        videobridge.isInGracefulShutdown shouldBe true
                     }
                     should("not have started the shutdown yet") {
                         verify(exactly = 0) { shutdownService.beginShutdown() }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/VideobridgeTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/VideobridgeTest.kt
@@ -35,7 +35,7 @@ class VideobridgeTest : ShouldSpec() {
 
     private val shutdownService: ShutdownServiceImpl = mockk(relaxed = true)
     private val clock = FakeClock()
-    private val videobridge = Videobridge(null, shutdownService, mockk(), null).apply { setClock(clock) }
+    private val videobridge = Videobridge(null, shutdownService, mockk(), null, clock)
     init {
         context("Debug state should be JSON") {
             videobridge.getDebugState(null, null, true).shouldBeValidJson()


### PR DESCRIPTION
Add a time limit to graceful-shutdown. An hour (by default) after entering graceful shutdown, the bridge will shut down. If during this time the number of endpoints drops below 10 (by default) the bridge will shutdown.

Before shutting down the bridge will enter the SHUTTING_DOWN state for 1 minute, which is advertised in presence and should serve as a trigger for jicofo to actively move participants away.