### PR TITLE
Update jicofo, smack to 4.4.5.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <kotlin.version>1.5.31</kotlin.version>
         <kotest.version>4.6.3</kotest.version>
         <junit.version>5.8.1</junit.version>
-        <jicoco.version>1.1-101-g2170967</jicoco.version>
+        <jicoco.version>1.1-103-g7b1cd54</jicoco.version>
         <jitsi.utils.version>1.0-112-gd92472a</jitsi.utils.version>
         <ktlint-maven-plugin.version>1.11.0</ktlint-maven-plugin.version>
         <maven-shade-plugin.version>3.2.2</maven-shade-plugin.version>


### PR DESCRIPTION
Fixes the deadlock previously observed in jibri, now also observed with jvb connected to multiple xmpp servers.