### PR TITLE
fix: cache video type separately

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -162,19 +162,17 @@ public abstract class AbstractEndpoint
                 conference.getSpeechActivity().endpointVideoAvailabilityChanged();
             }
         }
-        else
-        {
-            videoTypeCache.put(sourceName, videoType);
-        }
+
+        videoTypeCache.put(sourceName, videoType);
     }
 
     protected void applyVideoTypeCache(MediaSourceDesc[] mediaSourceDescs)
     {
-        // Video types are signaled over JVB data channel vs MediaStreamDesc over Colibri, so the two channels need
-        // to be synchronized. Sync cached video type which arrived before media source description was created.
+        // Video types are signaled over JVB data channel while MediaStreamDesc over Colibri. The two channels need
+        // to be synchronized.
         for (MediaSourceDesc mediaSourceDesc : mediaSourceDescs)
         {
-            VideoType videoType = videoTypeCache.remove(mediaSourceDesc.getSourceName());
+            VideoType videoType = videoTypeCache.get(mediaSourceDesc.getSourceName());
             if (videoType != null)
             {
                 mediaSourceDesc.setVideoType(videoType);

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -296,6 +296,9 @@ class Endpoint @JvmOverloads constructor(
     override var mediaSources: Array<MediaSourceDesc>
         get() = transceiver.getMediaSources()
         set(value) {
+            if (MultiStreamConfig.config.enabled) {
+                applyVideoTypeCache(value)
+            }
             val wasEmpty = transceiver.getMediaSources().isEmpty()
             if (transceiver.setMediaSources(value)) {
                 eventEmitter.fireEvent { sourcesChanged() }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayedEndpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayedEndpoint.kt
@@ -178,6 +178,9 @@ class RelayedEndpoint(
     override var mediaSources: Array<MediaSourceDesc>
         get() = _mediaSources.getMediaSources()
         set(value) {
+            if (MultiStreamConfig.config.enabled) {
+                applyVideoTypeCache(value)
+            }
             val changed = _mediaSources.setMediaSources(value)
             if (changed) {
                 val setMediaSourcesEvent = SetMediaSourcesEvent(mediaSources)


### PR DESCRIPTION
The video types are signaled over data channel while the MediaSourceDesc goes over Colibri. It can happen that
the client sends video type messages before the MediaSourceDesc arrives over Colibri.