### PR TITLE
Support complex topologies of bridge relays

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -419,18 +419,22 @@ public class Conference
 
     /**
      * Sends a message that originated from a relay, forwarding it to local endpoints
-     * and to those relays with different mesh-id values than the source relay
+     * (if {@param sendToEndpoints} is true) and to those relays with different mesh-id values than the source relay
      *
      * @param msg the message to be sent
      * @param meshId the ID of the mesh from which the message was received.
      */
     public void sendMessageFromRelay(
         BridgeChannelMessage msg,
+        boolean sendToEndpoints,
         @Nullable String meshId)
     {
-        for (Endpoint endpoint : getLocalEndpoints())
+        if (sendToEndpoints)
         {
-            endpoint.sendMessage(msg);
+            for (Endpoint endpoint : getLocalEndpoints())
+            {
+                endpoint.sendMessage(msg);
+            }
         }
 
         for (Relay relay: relaysById.values())
@@ -441,10 +445,7 @@ public class Conference
             }
         }
 
-        if (tentacle != null && meshId != null)
-        {
-            tentacle.sendMessage(msg);
-        }
+        /* Never need to send to tentacle, meshId != null cannot be true for Colibri1. */
     }
 
     /**

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -824,7 +824,7 @@ public class Conference
     }
 
     @NotNull
-    public Relay createRelay(String id, boolean iceControlling, boolean useUniquePort)
+    public Relay createRelay(String id, @Nullable String meshId, boolean iceControlling, boolean useUniquePort)
     {
         final Relay existingRelay = getRelay(id);
         if (existingRelay != null)
@@ -832,7 +832,7 @@ public class Conference
             throw new IllegalArgumentException("Relay with ID = " + id + "already created");
         }
 
-        final Relay relay = new Relay(id, this, logger, iceControlling, useUniquePort);
+        final Relay relay = new Relay(id, this, logger, meshId, iceControlling, useUniquePort);
 
         relaysById.put(id, relay);
 

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -418,6 +418,36 @@ public class Conference
     }
 
     /**
+     * Sends a message that originated from a relay, forwarding it to local endpoints
+     * and to those relays with different mesh-id values than the source relay
+     *
+     * @param msg the message to be sent
+     * @param meshId the ID of the mesh from which the message was received.
+     */
+    public void sendMessageFromRelay(
+        BridgeChannelMessage msg,
+        @Nullable String meshId)
+    {
+        for (Endpoint endpoint : getLocalEndpoints())
+        {
+            endpoint.sendMessage(msg);
+        }
+
+        for (Relay relay: relaysById.values())
+        {
+            if (!Objects.equals(meshId, relay.getMeshId()))
+            {
+                relay.sendMessage(msg);
+            }
+        }
+
+        if (tentacle != null && meshId != null)
+        {
+            tentacle.sendMessage(msg);
+        }
+    }
+
+    /**
      * Used to send a message to a subset of endpoints in the call, primary use
      * case being a message that has originated from an endpoint (as opposed to
      * a message originating from the bridge and being sent to all endpoints in

--- a/jvb/src/main/java/org/jitsi/videobridge/octo/OctoPacketInfo.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/octo/OctoPacketInfo.java
@@ -24,8 +24,21 @@ import org.jitsi.rtp.*;
  */
 public class OctoPacketInfo extends PacketInfo
 {
+    @Nullable private final String meshId;
     public OctoPacketInfo(@NotNull Packet packet)
     {
         super(packet);
+        meshId = null;
+    }
+
+    public OctoPacketInfo(@NotNull Packet packet, @Nullable String meshId)
+    {
+        super(packet);
+        this.meshId = meshId;
+    }
+
+    public String getMeshId()
+    {
+        return meshId;
     }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/colibri2/Colibri2ConferenceHandler.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/colibri2/Colibri2ConferenceHandler.kt
@@ -318,7 +318,12 @@ class Colibri2ConferenceHandler(
                 "Attempt to create relay ${c2relay.id} with no <transport>"
             )
 
-            relay = conference.createRelay(c2relay.id, transport.iceControlling, transport.useUniquePort)
+            relay = conference.createRelay(
+                c2relay.id,
+                c2relay.meshId,
+                transport.iceControlling,
+                transport.useUniquePort
+            )
         } else {
             relay = conference.getRelay(c2relay.id) ?: throw IqProcessingException(
                 // TODO: this should be Condition.item_not_found but this conflicts with some error codes from the Muc.

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
@@ -106,9 +106,13 @@ class Relay @JvmOverloads constructor(
     val conference: Conference,
     parentLogger: Logger,
     /**
-     * True if the ICE agent for this [Relay] will be initialized to serve as a controlling ICE agent, false otherwise.
+     * The ID of the mesh to which this [Relay] connection belongs.
+     * (Note that a bridge can be a member of more than one mesh, but each relay link will belong to only one.)
      */
     val meshId: String?,
+    /**
+     * True if the ICE agent for this [Relay] will be initialized to serve as a controlling ICE agent, false otherwise.
+     */
     iceControlling: Boolean,
     useUniquePort: Boolean,
     clock: Clock = Clock.systemUTC()

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
@@ -519,18 +519,20 @@ class Relay @JvmOverloads constructor(
     fun relayMessageTransportConnected() {
         relayedEndpoints.values.forEach { e -> e.relayMessageTransportConnected() }
         if (MultiStreamConfig.config.enabled) {
-            conference.localEndpoints.forEach { e ->
-                e.mediaSources.forEach { msd: MediaSourceDesc ->
-                    val sourceName = msd.sourceName!! // Source names are mandatory/enforced in multi stream mode
-                    val videoType = msd.videoType
-                    // Do not send the initial value for CAMERA, because it's the default
-                    if (VideoType.CAMERA != videoType) {
-                        val videoTypeMsg = SourceVideoTypeMessage(
-                            videoType,
-                            sourceName,
-                            e.id
-                        )
-                        sendMessage(videoTypeMsg)
+            conference.endpoints.forEach { e ->
+                if (e is Endpoint || (e is RelayedEndpoint && e.relay.meshId != meshId)) {
+                    e.mediaSources.forEach { msd: MediaSourceDesc ->
+                        val sourceName = msd.sourceName!! // Source names are mandatory/enforced in multi stream mode
+                        val videoType = msd.videoType
+                        // Do not send the initial value for CAMERA, because it's the default
+                        if (VideoType.CAMERA != videoType) {
+                            val videoTypeMsg = SourceVideoTypeMessage(
+                                videoType,
+                                sourceName,
+                                e.id
+                            )
+                            sendMessage(videoTypeMsg)
+                        }
                     }
                 }
             }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
@@ -195,6 +195,8 @@ class RelayMessageTransport(
 
         ep.setVideoType(message.videoType)
 
+        relay.conference.sendMessageFromRelay(message, relay.meshId)
+
         return null
     }
 
@@ -217,6 +219,8 @@ class RelayMessageTransport(
         }
 
         ep.setVideoType(message.sourceName, message.videoType)
+
+        relay.conference.sendMessageFromRelay(message, relay.meshId)
 
         return null
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
@@ -436,6 +436,7 @@ class RelayMessageTransport(
             return null
         }
         conference.localEndpoints.filter { it.wantsStatsFrom(from) }.forEach { it.sendMessage(message) }
+        conference.relays.filter { it.meshId != relay.meshId }.forEach { it.sendMessage(message) }
         return null
     }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
@@ -195,7 +195,7 @@ class RelayMessageTransport(
 
         ep.setVideoType(message.videoType)
 
-        relay.conference.sendMessageFromRelay(message, relay.meshId)
+        relay.conference.sendMessageFromRelay(message, false, relay.meshId)
 
         return null
     }
@@ -220,7 +220,7 @@ class RelayMessageTransport(
 
         ep.setVideoType(message.sourceName, message.videoType)
 
-        relay.conference.sendMessageFromRelay(message, relay.meshId)
+        relay.conference.sendMessageFromRelay(message, false, relay.meshId)
 
         return null
     }
@@ -400,7 +400,7 @@ class RelayMessageTransport(
             return null
         }
         if (message.isBroadcast()) {
-            conference.sendMessageFromRelay(message, relay.meshId)
+            conference.sendMessageFromRelay(message, true, relay.meshId)
         } else {
             // 1:1 message
             val to = message.to
@@ -448,7 +448,7 @@ class RelayMessageTransport(
             logger.warn("Unable to send EndpointConnectionStatusMessage, conference is expired")
             return null
         }
-        conference.sendMessageFromRelay(message, relay.meshId)
+        conference.sendMessageFromRelay(message, true, relay.meshId)
         return null
     }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
@@ -395,21 +395,19 @@ class RelayMessageTransport(
             logger.warn("Unable to send EndpointMessage, conference is expired")
             return null
         }
-        val targets = if (message.isBroadcast()) {
-            // Broadcast message
-            conference.localEndpoints
+        if (message.isBroadcast()) {
+            conference.sendMessageFromRelay(message, relay.meshId)
         } else {
             // 1:1 message
             val to = message.to
             val targetEndpoint = conference.getLocalEndpoint(to)
-            if (targetEndpoint != null) {
-                listOf(targetEndpoint)
-            } else {
+            if (targetEndpoint == null) {
                 logger.warn("Unable to find endpoint to send EndpointMessage to: $to")
                 return null
             }
+
+            conference.sendMessage(message, listOf(targetEndpoint), false /* sendToOcto */)
         }
-        conference.sendMessage(message, targets, false /* sendToOcto */)
         return null
     }
 
@@ -446,7 +444,7 @@ class RelayMessageTransport(
             logger.warn("Unable to send EndpointConnectionStatusMessage, conference is expired")
             return null
         }
-        conference.broadcastMessage(message, false /* sendToOcto */)
+        conference.sendMessageFromRelay(message, relay.meshId)
         return null
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-xmpp-extensions</artifactId>
-                <version>1.0-46-gcb3884c</version>
+                <version>1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-xmpp-extensions</artifactId>
-                <version>1.0-SNAPSHOT</version>
+                <version>1.0-47-gc7154e0</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
This allows bridges to be arranged in a tree of full meshes, rather than in a single full-mesh, as currently.  Media packets received from one relay mesh are forwarded to other ones.

Each connection to another relay is identified by a `mesh-id` value, indicating the mesh of relays of which that connection is a part.  It is responsibility of the entity setting up connections between relays (e.g., jicofo) to ensure the topologies are set up correctly.  (This code is not yet written.)

Depends on https://github.com/jitsi/jitsi-xmpp-extensions/pull/70.