### PR TITLE
fix: Increase default health check timeout.

### DIFF
--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -10,8 +10,9 @@ videobridge {
     # The interval between health checks
     interval=1 minute
 
-    # The timeout for a health check
-    timeout=30 seconds
+    # The timeout for a health check. This needs to be higher than [interval], otherwise health checks timeout because
+    # none were scheduled.
+    timeout=90 seconds
 
     # If performing a health check takes longer than this, it is considered unsuccessful.
     max-check-duration=3 seconds


### PR DESCRIPTION
When timeout<interval health checks timeout simply because none were
scheduled in the timeout window.