### PR TITLE
fix: Include feedback sources with every "create endpoint" response

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/colibri2/Colibri2ConferenceHandler.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/colibri2/Colibri2ConferenceHandler.kt
@@ -81,8 +81,10 @@ class Colibri2ConferenceHandler(
             responseBuilder.addRelay(handleColibri2Relay(r))
         }
 
-        /* Report feedback sources if we haven't reported them yet. */
-        if (conferenceModifyIQ.create) {
+        // Include feedback sources with any "create conference" or "create endpoint" request. This allows async
+        // handling of responses in jicofo without potentially losing the feedback sources.
+        // TODO: perhaps colibri clients should be required to process responses in order?
+        if (conferenceModifyIQ.create || conferenceModifyIQ.endpoints.any { it.create }) {
             responseBuilder.setSources(buildFeedbackSources())
         }
 


### PR DESCRIPTION
Jicofo handles responses async and may process the second "create
endpoint" response first, resulting in feedback sources not being
signaled to the endpoint.