### PR TITLE
Update jicoco; don't use spyk() for FakeScheduledExecutorService.

### DIFF
--- a/jvb-api/jvb-api-client/pom.xml
+++ b/jvb-api/jvb-api-client/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>io.mockk</groupId>
             <artifactId>mockk</artifactId>
-            <version>1.10.2</version>
+            <version>1.12.4</version>
             <scope>test</scope>
         </dependency>
         <!-- We include the server libs in test, as it's currently the only way

--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -203,7 +203,7 @@
     <dependency>
       <groupId>io.mockk</groupId>
       <artifactId>mockk</artifactId>
-      <version>1.12.1</version>
+      <version>1.12.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/EndpointConnectionStatusMonitorTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/EndpointConnectionStatusMonitorTest.kt
@@ -26,7 +26,6 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.spyk
 import org.jitsi.nlj.util.NEVER
 import org.jitsi.test.concurrent.FakeScheduledExecutorService
 import org.jitsi.utils.logging2.LoggerImpl
@@ -37,7 +36,7 @@ import org.jitsi.videobridge.message.EndpointConnectionStatusMessage
 class EndpointConnectionStatusMonitorTest : ShouldSpec({
     isolationMode = IsolationMode.InstancePerLeaf
 
-    val executor: FakeScheduledExecutorService = spyk()
+    val executor = FakeScheduledExecutorService()
     val localEp1: Endpoint = mockk {
         every { id } returns "1"
     }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/VideobridgeTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/VideobridgeTest.kt
@@ -22,7 +22,6 @@ import io.kotest.core.test.TestResult
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.mockk
-import io.mockk.spyk
 import io.mockk.verify
 import org.jitsi.config.withNewConfig
 import org.jitsi.shutdown.ShutdownServiceImpl
@@ -40,11 +39,11 @@ class VideobridgeTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode = IsolationMode.InstancePerLeaf
 
     private val shutdownService: ShutdownServiceImpl = mockk(relaxed = true)
-    private val mockExecutor = spyk<FakeScheduledExecutorService>()
-    private val videobridge = Videobridge(null, shutdownService, mockk(), null, mockExecutor.clock)
+    private val fakeExecutor = FakeScheduledExecutorService()
+    private val videobridge = Videobridge(null, shutdownService, mockk(), null, fakeExecutor.clock)
 
     override fun beforeAny(testCase: TestCase) = super.beforeAny(testCase).also {
-        TaskPools.SCHEDULED_POOL = mockExecutor
+        TaskPools.SCHEDULED_POOL = fakeExecutor
     }
 
     override fun afterAny(testCase: TestCase, result: TestResult) = super.afterAny(testCase, result).also {
@@ -77,18 +76,18 @@ class VideobridgeTest : ShouldSpec() {
                         context("When the number of participants drops below the threshold") {
                             repeat(10) { videobridge.endpointExpired() }
                             videobridge.shutdownState shouldBe ShutdownState.SHUTTING_DOWN
-                            mockExecutor.clock.elapse(ShutdownConfig.config.shuttingDownDelay)
-                            mockExecutor.run()
+                            fakeExecutor.clock.elapse(ShutdownConfig.config.shuttingDownDelay)
+                            fakeExecutor.run()
                             verify(exactly = 1) { shutdownService.beginShutdown() }
                         }
                         context("When the graceful shutdown period expires") {
                             should("go to SHUTTING_DOWN") {
-                                mockExecutor.clock.elapse(ShutdownConfig.config.gracefulShutdownMaxDuration)
-                                mockExecutor.run()
+                                fakeExecutor.clock.elapse(ShutdownConfig.config.gracefulShutdownMaxDuration)
+                                fakeExecutor.run()
                                 videobridge.shutdownState shouldBe ShutdownState.SHUTTING_DOWN
                                 should("and then shut down after shuttingDownDelay") {
-                                    mockExecutor.clock.elapse(ShutdownConfig.config.shuttingDownDelay)
-                                    mockExecutor.run()
+                                    fakeExecutor.clock.elapse(ShutdownConfig.config.shuttingDownDelay)
+                                    fakeExecutor.run()
                                     verify(exactly = 1) { shutdownService.beginShutdown() }
                                 }
                             }

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <kotlin.version>1.5.31</kotlin.version>
         <kotest.version>4.6.3</kotest.version>
         <junit.version>5.8.1</junit.version>
-        <jicoco.version>1.1-109-gd47a5e0</jicoco.version>
+        <jicoco.version>1.1-110-g42c01d9</jicoco.version>
         <jitsi.utils.version>1.0-115-gb93957d</jitsi.utils.version>
         <ktlint-maven-plugin.version>1.11.0</ktlint-maven-plugin.version>
         <maven-shade-plugin.version>3.2.2</maven-shade-plugin.version>


### PR DESCRIPTION
Makes unit tests substantially faster and use less memory.

Also update mockk.