### PR TITLE
Fix: Expire RelayedEndpoint when removing it.

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
@@ -619,9 +619,7 @@ class Relay @JvmOverloads constructor(
                 endpointsBySsrc.keys.removeAll(ep.ssrcs)
             }
         }
-        if (ep != null) {
-            conference.endpointExpired(ep)
-        }
+        ep?.expire()
     }
 
     private fun getOrCreateRelaySender(endpointId: String): RelayEndpointSender {
@@ -861,7 +859,7 @@ class Relay @JvmOverloads constructor(
         expired = true
         logger.info("Expiring.")
         synchronized(endpointsLock) {
-            relayedEndpoints.values.forEach { conference.endpointExpired(it) }
+            relayedEndpoints.values.forEach { it.expire() }
         }
         senders.values.forEach { it.expire() }
         conference.relayExpired(this)


### PR DESCRIPTION
Fixes memory leak in JVB.