### PR TITLE
Improve JVB loss statistics

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiver.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiver.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj
 
+import org.jitsi.nlj.rtp.LossListener
 import org.jitsi.nlj.srtp.SrtpTransformers
 import org.jitsi.nlj.stats.EndpointConnectionStats
 import org.jitsi.nlj.stats.RtpReceiverStats
@@ -49,6 +50,8 @@ abstract class RtpReceiver :
 
     abstract fun isReceivingAudio(): Boolean
     abstract fun isReceivingVideo(): Boolean
+
+    abstract fun addLossListener(lossListener: LossListener)
 
     abstract fun setFeature(feature: Features, enabled: Boolean)
     abstract fun isFeatureEnabled(feature: Features): Boolean

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -23,6 +23,7 @@ import org.jitsi.nlj.rtcp.RembHandler
 import org.jitsi.nlj.rtcp.RtcpEventNotifier
 import org.jitsi.nlj.rtcp.RtcpRrGenerator
 import org.jitsi.nlj.rtp.AudioRtpPacket
+import org.jitsi.nlj.rtp.LossListener
 import org.jitsi.nlj.rtp.VideoRtpPacket
 import org.jitsi.nlj.rtp.bandwidthestimation.BandwidthEstimator
 import org.jitsi.nlj.srtp.SrtpTransformers
@@ -146,6 +147,9 @@ class RtpReceiverImpl @JvmOverloads constructor(
 
     override fun isReceivingAudio() = audioBitrateCalculator.active
     override fun isReceivingVideo() = videoBitrateCalculator.active
+    override fun addLossListener(lossListener: LossListener) {
+        /* TODO */
+    }
 
     companion object {
         val queueErrorCounter = CountingErrorHandler()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -148,7 +148,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
     override fun isReceivingAudio() = audioBitrateCalculator.active
     override fun isReceivingVideo() = videoBitrateCalculator.active
     override fun addLossListener(lossListener: LossListener) {
-        /* TODO */
+        tccGenerator.addLossListener(lossListener)
     }
 
     companion object {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSender.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSender.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj
 
+import org.jitsi.nlj.rtp.LossListener
 import org.jitsi.nlj.rtp.TransportCcEngine
 import org.jitsi.nlj.rtp.bandwidthestimation.BandwidthEstimator
 import org.jitsi.nlj.srtp.SrtpTransformers
@@ -42,6 +43,7 @@ abstract class RtpSender :
     abstract fun getPacketStreamStats(): PacketStreamStats.Snapshot
     abstract fun getTransportCcEngineStats(): TransportCcEngine.StatisticsSnapshot
     abstract fun requestKeyframe(mediaSsrc: Long? = null)
+    abstract fun addLossListener(lossListener: LossListener)
     abstract fun setFeature(feature: Features, enabled: Boolean)
     abstract fun isFeatureEnabled(feature: Features): Boolean
     abstract fun tearDown()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -22,6 +22,7 @@ import org.jitsi.nlj.rtcp.KeyframeRequester
 import org.jitsi.nlj.rtcp.NackHandler
 import org.jitsi.nlj.rtcp.RtcpEventNotifier
 import org.jitsi.nlj.rtcp.RtcpSrUpdater
+import org.jitsi.nlj.rtp.LossListener
 import org.jitsi.nlj.rtp.TransportCcEngine
 import org.jitsi.nlj.rtp.bandwidthestimation.BandwidthEstimator
 import org.jitsi.nlj.rtp.bandwidthestimation.GoogleCcEstimator
@@ -232,6 +233,10 @@ class RtpSenderImpl(
 
     override fun requestKeyframe(mediaSsrc: Long?) {
         keyframeRequester.requestKeyframe(mediaSsrc)
+    }
+
+    override fun addLossListener(lossListener: LossListener) {
+        transportCcEngine.addLossListener(lossListener)
     }
 
     override fun setFeature(feature: Features, enabled: Boolean) {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -146,6 +146,9 @@ class Transceiver(
             }
         )
 
+        rtpReceiver.addLossListener(endpointConnectionStats.incomingLossTracker)
+        rtpSender.addLossListener(endpointConnectionStats.outgoingLossTracker)
+
         rtcpEventNotifier.addRtcpEventListener(endpointConnectionStats)
 
         endpointConnectionStats.addListener(rtpSender)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/LossListener.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/LossListener.kt
@@ -33,8 +33,8 @@ class LossTracker : LossListener {
     }
 
     @Synchronized
-    override fun packetLost() {
-        lostPackets.update(1)
+    override fun packetLost(numLost: Int) {
+        lostPackets.update(numLost.toLong())
     }
 
     @Synchronized
@@ -63,5 +63,5 @@ class LossTracker : LossListener {
 *   don't have all the information the BandwidthEstimator API needs. */
 interface LossListener {
     fun packetReceived(previouslyReportedLost: Boolean)
-    fun packetLost()
+    fun packetLost(numLost: Int)
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/LossListener.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/LossListener.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright @ 2019 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.nlj.rtp
+
+import org.jitsi.utils.OrderedJsonObject
+import org.jitsi.utils.secs
+import org.jitsi.utils.stats.RateTracker
+
+class LossTracker : LossListener {
+    private val lostPackets = RateTracker(60.secs, 1.secs)
+    private val receivedPackets = RateTracker(60.secs, 1.secs)
+
+    @Synchronized
+    override fun packetReceived(previouslyReportedLost: Boolean) {
+        receivedPackets.update(1)
+        if (previouslyReportedLost) {
+            lostPackets.update(-1)
+        }
+    }
+
+    @Synchronized
+    override fun packetLost() {
+        lostPackets.update(1)
+    }
+
+    @Synchronized
+    fun getSnapshot(): Snapshot {
+        return Snapshot(
+            lostPackets.getAccumulatedCount(),
+            receivedPackets.getAccumulatedCount()
+        )
+    }
+
+    data class Snapshot(
+        val packetsLost: Long,
+        val packetsReceived: Long
+    ) {
+        fun toJson() = OrderedJsonObject().apply {
+            put("packets_lost", packetsLost)
+            put("packets_received", packetsReceived)
+        }
+    }
+}
+
+/**
+ * An interface to report when a packet is received, or is observed to be lost.
+ */
+/* TODO?  This kind of overlaps with BandwidthEstimator?  But it can be used in cases where we
+*   don't have all the information the BandwidthEstimator API needs. */
+interface LossListener {
+    fun packetReceived(previouslyReportedLost: Boolean)
+    fun packetLost()
+}

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
@@ -155,7 +155,7 @@ class TransportCcEngine(
                         numPacketsReportedLost.increment()
                         synchronized(this) {
                             lossListeners.forEach {
-                                it.packetLost()
+                                it.packetLost(1)
                             }
                         }
                     }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
@@ -16,6 +16,7 @@
 package org.jitsi.nlj.transform.node.incoming
 
 import org.jitsi.nlj.PacketInfo
+import org.jitsi.nlj.rtp.LossListener
 import org.jitsi.nlj.rtp.RtpExtensionType.TRANSPORT_CC
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.node.ObserverNode
@@ -39,7 +40,7 @@ import org.jitsi.utils.secs
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
-import java.util.TreeMap
+import java.util.*
 
 /**
  * Extract the TCC sequence numbers from each passing packet and generate
@@ -69,6 +70,8 @@ class TccGeneratorNode(
     }
     private val rfc3711IndexTracker = Rfc3711IndexTracker()
 
+    private val lossListeners = LinkedList<LossListener>()
+
     init {
         streamInformation.onRtpExtensionMapping(TRANSPORT_CC) {
             tccExtensionId = it
@@ -91,6 +94,27 @@ class TccGeneratorNode(
     }
 
     /**
+     * Adds a loss listener to be notified about packet arrival and loss reports.
+     * @param listener
+     */
+    fun addLossListener(listener: LossListener) {
+        synchronized(lock) {
+            lossListeners.add(listener)
+        }
+    }
+
+    /**
+     * Removes a loss listener.
+     * @param listener
+     */
+    @Synchronized
+    fun removeLossListener(listener: LossListener) {
+        synchronized(lock) {
+            lossListeners.remove(listener)
+        }
+    }
+
+    /**
      * @param tccSeqNum the extended sequence number.
      */
     private fun addPacket(tccSeqNum: Int, timestamp: Instant?, isMarked: Boolean, ssrc: Long) {
@@ -101,11 +125,39 @@ class TccGeneratorNode(
                 // TODO: Chrome does something more advanced, keeping older sequences to replay on packet reordering.
                 packetArrivalTimes.clear()
             }
-            if (windowStartSeq == -1 || tccSeqNum < windowStartSeq) {
-                windowStartSeq = tccSeqNum
-            }
 
-            timestamp?.run { packetArrivalTimes.putIfAbsent(tccSeqNum, timestamp) }
+            timestamp?.run {
+                if (packetArrivalTimes.isEmpty()) {
+                    lossListeners.forEach {
+                        it.packetReceived(false)
+                    }
+                } else {
+                    val oldMax = packetArrivalTimes.lastKey()
+                    if (tccSeqNum > oldMax) {
+                        val numLost = tccSeqNum - oldMax + 1
+                        /* TODO: should we squelch for large tcc jumps? */
+                        lossListeners.forEach {
+                            if (numLost > 0) {
+                                it.packetLost(numLost)
+                            }
+                            it.packetReceived(false)
+                        }
+                    } else if (tccSeqNum < windowStartSeq || !packetArrivalTimes.containsKey(tccSeqNum)) {
+                        /* If we've already cleared the arrival info about this packet, assume it was previously
+                        * reported as lost - there are some corner cases where this isn't true, but they should be rare.
+                        */
+                        lossListeners.forEach {
+                            it.packetReceived(true)
+                        }
+                    }
+                }
+
+                if (windowStartSeq == -1 || tccSeqNum < windowStartSeq) {
+                    windowStartSeq = tccSeqNum
+                }
+
+                packetArrivalTimes.putIfAbsent(tccSeqNum, timestamp)
+            }
             if (isTccReadyToSend(isMarked)) {
                 buildFeedback(ssrc).forEach { sendTcc(it) }
             }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
@@ -127,14 +127,18 @@ class TccGeneratorNode(
             }
 
             timestamp?.run {
-                if (packetArrivalTimes.isEmpty()) {
+                if (packetArrivalTimes.isEmpty() && windowStartSeq == -1) {
                     lossListeners.forEach {
                         it.packetReceived(false)
                     }
                 } else {
-                    val oldMax = packetArrivalTimes.lastKey()
+                    val oldMax = if (packetArrivalTimes.isNotEmpty()) {
+                        packetArrivalTimes.lastKey()
+                    } else {
+                        windowStartSeq - 1
+                    }
                     if (tccSeqNum > oldMax) {
-                        val numLost = tccSeqNum - oldMax + 1
+                        val numLost = tccSeqNum - oldMax - 1
                         /* TODO: should we squelch for large tcc jumps? */
                         lossListeners.forEach {
                             if (numLost > 0) {

--- a/jvb/src/main/java/org/jitsi/videobridge/stats/callstats/ConferencePeriodicRunnable.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/stats/callstats/ConferencePeriodicRunnable.java
@@ -16,6 +16,7 @@
 package org.jitsi.videobridge.stats.callstats;
 
 import org.jetbrains.annotations.*;
+import org.jitsi.nlj.rtp.*;
 import org.jitsi.nlj.stats.*;
 import org.jitsi.nlj.transform.node.incoming.*;
 import org.jitsi.nlj.transform.node.outgoing.*;
@@ -121,7 +122,7 @@ class ConferencePeriodicRunnable
         return allEndpointStats;
     }
 
-    private static double getFractionLost(EndpointConnectionStats.LossStatsSnapshot lossStatsSnapshot)
+    private static double getFractionLost(LossTracker.Snapshot lossStatsSnapshot)
     {
         if (lossStatsSnapshot.getPacketsLost() + lossStatsSnapshot.getPacketsReceived() > 0)
         {


### PR DESCRIPTION
Previously we would report weird packet loss statistics when we received "weird" TCC packets.

This re-uses the existing processing of loss reports from TransportCcEngine (for outgoing loss) and TccGeneratorNode (for incoming loss) to let us calculate better statistics.