### PR TITLE
Change VideobridgeExpireThread.expire()#L140 log level from info to debug

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/VideobridgeExpireThread.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/VideobridgeExpireThread.java
@@ -137,7 +137,7 @@ public class VideobridgeExpireThread
      */
     private void expire(Videobridge videobridge)
     {
-        logger.info("Running expire()");
+        logger.debug("Running expire()");
         for (Conference conference : videobridge.getConferences())
         {
             // The Conferences will live an iteration more than the Contents.


### PR DESCRIPTION
As discussed in #1917 decreasing the log level to debug to avoid logs flooding.