### PR TITLE
Add checkstyle rules to match guidelines for opening braces.

### DIFF
--- a/jvb/checkstyle.xml
+++ b/jvb/checkstyle.xml
@@ -18,6 +18,14 @@
             <property name="tokens" value="LITERAL_FINALLY"/>
             <property name="tokens" value="LITERAL_IF"/>
             <property name="tokens" value="LITERAL_TRY"/>
+            <property name="tokens" value="LITERAL_SYNCHRONIZED"/>
+            <property name="tokens" value="ANNOTATION_DEF"/>
+            <property name="tokens" value="CLASS_DEF"/>
+            <property name="tokens" value="CTOR_DEF"/>
+            <property name="tokens" value="ENUM_DEF"/>
+            <property name="tokens" value="INTERFACE_DEF"/>
+            <property name="tokens" value="METHOD_DEF"/>
+            <property name="tokens" value="RECORD_DEF"/>
         </module>
 
         <!-- Skips empty blocks {}, to not skip them: value="alone" -->

--- a/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/AbstractEndpoint.java
@@ -598,7 +598,8 @@ public abstract class AbstractEndpoint
         }
     }
 
-   public interface EventHandler {
+   public interface EventHandler
+    {
         void iceSucceeded();
         void iceFailed();
         void sourcesChanged();

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -901,7 +901,10 @@ public class Conference
     /**
      * Gets the list of the relays this conference is using.
      */
-    public List<Relay> getRelays() { return new ArrayList<>(this.relaysById.values()); }
+    public List<Relay> getRelays()
+    {
+        return new ArrayList<>(this.relaysById.values());
+    }
 
     /**
      * Gets the (unique) identifier/ID of this instance.

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -1168,7 +1168,8 @@ public class Videobridge
         public AtomicLong currentLocalEndpoints = new AtomicLong();
     }
 
-    public interface EventHandler {
+    public interface EventHandler
+    {
         void conferenceCreated(@NotNull Conference conference);
         void conferenceExpired(@NotNull Conference conference);
     }

--- a/jvb/src/main/java/org/jitsi/videobridge/datachannel/DataChannelStack.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/datachannel/DataChannelStack.java
@@ -124,7 +124,8 @@ public class DataChannelStack
      */
     public DataChannel createDataChannel(int channelType, int priority, long reliability, int sid, String label)
     {
-        synchronized (dataChannels) {
+        synchronized (dataChannels)
+        {
             DataChannel dataChannel = new DataChannel(
                     dataChannelDataSender, logger, channelType, priority, reliability, sid, label);
             dataChannels.put(sid, dataChannel);

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/FeatureState.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/FeatureState.java
@@ -16,17 +16,20 @@
 
 package org.jitsi.videobridge.rest.root.debug;
 
-public enum FeatureState {
+public enum FeatureState
+{
     ENABLE(true),
     DISABLE(false);
 
     boolean value;
 
-    FeatureState(boolean value) {
+    FeatureState(boolean value)
+    {
         this.value = value;
     }
 
-    public boolean getValue() {
+    public boolean getValue()
+    {
         return value;
     }
 

--- a/jvb/src/main/java/org/jitsi/videobridge/sctp/SctpManager.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/sctp/SctpManager.java
@@ -34,7 +34,8 @@ import static org.jitsi.videobridge.sctp.SctpConfig.config;
  * will route it through the {@link SctpSocket} instance so that, if it is an SCTP app packet the user of the
  * {@link SctpSocket} will receive it via the data callback.
  */
-public class SctpManager {
+public class SctpManager
+{
     private static final Logger classLogger = new LoggerImpl(SctpManager.class.getName());
 
     private final Logger logger;
@@ -89,7 +90,8 @@ public class SctpManager {
      * @param sctpPacket an incoming SCTP packet which may be either an SCTP protocol control packet or an SCTP
      *                   application packet
      */
-    public void handleIncomingSctp(PacketInfo sctpPacket) {
+    public void handleIncomingSctp(PacketInfo sctpPacket)
+    {
         logger.debug(() -> "SCTP Socket " + socket.hashCode() + " receiving incoming SCTP data");
         //NOTE(brian): from what I can tell in usrsctp, we can assume that it will make a copy
         // of the buffer we pass it here (this ends up hitting usrsctp_conninput, and the sample
@@ -119,7 +121,8 @@ public class SctpManager {
      * Create an {@link SctpClientSocket} to be used to open an SCTP connection
      * @return an {@link SctpClientSocket}
      */
-    public SctpClientSocket createClientSocket() {
+    public SctpClientSocket createClientSocket()
+    {
         socket = Sctp4j.createClientSocket(DEFAULT_SCTP_PORT);
         socket.outgoingDataSender = this.dataSender;
         if (logger.isDebugEnabled())
@@ -157,7 +160,8 @@ public class SctpManager {
      * in order to change from a buffer that was allocated by jitsi-sctp
      * to one from our pool, this way it can be returned later in the pipeline.
      */
-    private static class BufferCopyingSctpDataSender implements SctpDataSender {
+    private static class BufferCopyingSctpDataSender implements SctpDataSender
+    {
         private final SctpDataSender innerSctpDataSender;
         BufferCopyingSctpDataSender(@NotNull SctpDataSender sctpDataSender)
         {

--- a/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
@@ -300,7 +300,8 @@ public class ByteBufferPool
         return bookkeepingEnabled;
     }
 
-    private static class BufferEvent {
+    private static class BufferEvent
+    {
         final String context;
         final Long timestamp;
         final Exception trace;

--- a/jvb/src/main/java/org/jitsi/videobridge/util/UlimitCheck.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/UlimitCheck.java
@@ -84,7 +84,8 @@ public class UlimitCheck
      * (threads) by running {@code bash}'s {@code ulimit} builtin, and logs
      * the values.
      */
-    public static void printUlimits() {
+    public static void printUlimits()
+    {
 
         Integer fileLimit = getIntFromCommand("ulimit -n");
         Integer fileLimitHard = getIntFromCommand("ulimit -Hn");

--- a/jvb/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocket.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/websocket/ColibriWebSocket.java
@@ -93,7 +93,8 @@ public class ColibriWebSocket extends WebSocketAdapter
         eventHandler.webSocketError(this, cause);
     }
 
-    public interface EventHandler {
+    public interface EventHandler
+    {
         /**
          * Notifies that a specific {@link ColibriWebSocket}
          * instance associated with it has been closed.

--- a/jvb/src/main/java/org/jitsi/videobridge/xmpp/MediaSourceFactory.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/xmpp/MediaSourceFactory.java
@@ -582,7 +582,8 @@ public class MediaSourceFactory
             Collection<SourcePacketExtension> sources,
             Collection<SourceGroupPacketExtension> sourceGroups,
             String owner,
-            String name) {
+            String name)
+    {
         Objects.requireNonNull(owner, "owner is required");
         Objects.requireNonNull(name, "name is required");
 


### PR DESCRIPTION
According to [Jitsi's Contributing Guidelines](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-contributing/#formatting), for Java:

> Opening braces MUST be on their own line (especially those beginning a method).


I believe this covers all cases.

To avoid reformatting one-line statements in IDEA, there's a few options under:
Settings > Editor > Code Style > Java > Wrapping and Braces > Keep when reformatting