### PR TITLE
Set VideoParser's signaledSources to the actual signaled sources.

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Event.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Event.kt
@@ -19,7 +19,10 @@ import org.jitsi.utils.MediaType
 
 interface Event
 
-class SetMediaSourcesEvent(val mediaSourceDescs: Array<MediaSourceDesc>) : Event
+class SetMediaSourcesEvent(
+    val mediaSourceDescs: Array<MediaSourceDesc>,
+    val signaledMediaSourceDescs: Array<MediaSourceDesc>
+) : Event
 
 class SetLocalSsrcEvent(val mediaType: MediaType, val ssrc: Long) : Event
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -218,7 +218,9 @@ class Transceiver(
     fun setMediaSources(mediaSources: Array<MediaSourceDesc>): Boolean {
         logger.cdebug { "$id setting media sources: ${mediaSources.joinToString()}" }
         val ret = this.mediaSources.setMediaSources(mediaSources)
-        rtpReceiver.handleEvent(SetMediaSourcesEvent(this.mediaSources.getMediaSources()))
+        val mergedMediaSources = this.mediaSources.getMediaSources()
+        val signaledMediaSources = if (mediaSources === mergedMediaSources) mediaSources.copy() else mediaSources
+        rtpReceiver.handleEvent(SetMediaSourcesEvent(mergedMediaSources, signaledMediaSources))
         return ret
     }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
@@ -19,7 +19,6 @@ import org.jitsi.nlj.Event
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.SetMediaSourcesEvent
-import org.jitsi.nlj.copy
 import org.jitsi.nlj.format.Vp8PayloadType
 import org.jitsi.nlj.format.Vp9PayloadType
 import org.jitsi.nlj.rtp.codec.VideoCodecParser
@@ -134,7 +133,7 @@ class VideoParser(
         when (event) {
             is SetMediaSourcesEvent -> {
                 sources = event.mediaSourceDescs
-                signaledSources = sources.copy()
+                signaledSources = event.signaledMediaSourceDescs
                 videoCodecParser?.sources = sources
             }
         }


### PR DESCRIPTION
Rather than the merged ones.

Fixes some cases of VP9->VP8 transition (when subsequent signaling has come in).