### PR TITLE
ref: Port both failed conferences stats to Metrics.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -660,12 +660,12 @@ public class Conference
 
         if (hasPartiallyFailed)
         {
-            videobridgeStatistics.totalPartiallyFailedConferences.incrementAndGet();
+            videobridgeStatistics.totalPartiallyFailedConferences.incAndGet();
         }
 
         if (hasFailed)
         {
-            videobridgeStatistics.totalFailedConferences.incrementAndGet();
+            videobridgeStatistics.totalFailedConferences.incAndGet();
         }
 
         if (logger.isInfoEnabled())

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -660,12 +660,12 @@ public class Conference
 
         if (hasPartiallyFailed)
         {
-            videobridgeStatistics.totalPartiallyFailedConferences.incAndGet();
+            videobridgeStatistics.partiallyFailedConferences.incAndGet();
         }
 
         if (hasFailed)
         {
-            videobridgeStatistics.totalFailedConferences.incAndGet();
+            videobridgeStatistics.failedConferences.incAndGet();
         }
 
         if (logger.isInfoEnabled())

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -949,14 +949,20 @@ public class Videobridge
          * channels failed because there was no transport activity (which
          * includes those that failed because there was no payload activity).
          */
-        public AtomicInteger totalFailedConferences = new AtomicInteger(0);
+        public CounterMetric totalFailedConferences = VideobridgeMetricsContainer.getInstance().registerCounter(
+                "failed_conferences",
+                "The total number of conferences that had ALL of their channels failed because " +
+                        "there was no transport/payload activity.");
 
         /**
          * The cumulative/total number of conferences that had some of their
          * channels failed because there was no transport activity (which
          * includes those that failed because there was no payload activity).
          */
-        public AtomicInteger totalPartiallyFailedConferences = new AtomicInteger(0);
+        public CounterMetric totalPartiallyFailedConferences = VideobridgeMetricsContainer.getInstance()
+                .registerCounter("partially_failed_conferences",
+                        "The total number of conferences that had SOME of their channels failed because " +
+                                "there was no transport/payload activity.");
 
         /**
          * The cumulative/total number of conferences completed/expired on this

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -945,24 +945,18 @@ public class Videobridge
         public AtomicInteger incomingBitrateExpirations = new AtomicInteger(0);
 
         /**
-         * The cumulative/total number of conferences that had all of their
-         * channels failed because there was no transport activity (which
-         * includes those that failed because there was no payload activity).
+         * The cumulative/total number of conferences in which ALL of the endpoints failed ICE.
          */
-        public CounterMetric totalFailedConferences = VideobridgeMetricsContainer.getInstance().registerCounter(
+        public CounterMetric failedConferences = VideobridgeMetricsContainer.getInstance().registerCounter(
                 "failed_conferences",
-                "The total number of conferences that had ALL of their channels failed because " +
-                        "there was no transport/payload activity.");
+                "Number of conferences in which ALL of the endpoints failed ICE.");
 
         /**
-         * The cumulative/total number of conferences that had some of their
-         * channels failed because there was no transport activity (which
-         * includes those that failed because there was no payload activity).
+         * The cumulative/total number of conferences in which SOME of the endpoints failed ICE.
          */
-        public CounterMetric totalPartiallyFailedConferences = VideobridgeMetricsContainer.getInstance()
-                .registerCounter("partially_failed_conferences",
-                        "The total number of conferences that had SOME of their channels failed because " +
-                                "there was no transport/payload activity.");
+        public CounterMetric partiallyFailedConferences = VideobridgeMetricsContainer.getInstance().registerCounter(
+                "partially_failed_conferences",
+                "Number of conferences in which SOME of the endpoints failed ICE.");
 
         /**
          * The cumulative/total number of conferences completed/expired on this

--- a/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -489,10 +489,10 @@ public class VideobridgeStatistics
             unlockedSetStat(RTT_AGGREGATE, rttAggregate);
             unlockedSetStat(
                     TOTAL_FAILED_CONFERENCES,
-                    jvbStats.totalFailedConferences.get());
+                    jvbStats.failedConferences.get());
             unlockedSetStat(
                     TOTAL_PARTIALLY_FAILED_CONFERENCES,
-                    jvbStats.totalPartiallyFailedConferences.get());
+                    jvbStats.partiallyFailedConferences.get());
             unlockedSetStat(
                     TOTAL_CONFERENCES_CREATED,
                     jvbStats.totalConferencesCreated.get());


### PR DESCRIPTION
Port both "failed conferences" stats - `total_failed_conferences` and `total_partially_failed_conferences` - to `CounterMetric` instances, for use with the reworked metrics system. The "total" prefix in the names is omitted for the new `metrics` endpoint (and preserved for the old one) since the Prometheus library automatically adds a `total` suffix.