### PR TITLE
Move a few metrics to MetricsContainer.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -1100,24 +1100,32 @@ public class Videobridge
         /**
          * The total number of endpoints created.
          */
-        public AtomicInteger totalEndpoints = new AtomicInteger();
+        public CounterMetric totalEndpoints = VideobridgeMetricsContainer.getInstance().registerCounter(
+                "endpoints",
+                "The total number of endpoints created.");
 
         /**
          * The number of endpoints which had not established an endpoint
          * message transport even after some delay.
          */
-        public AtomicInteger numEndpointsNoMessageTransportAfterDelay = new AtomicInteger();
+        public CounterMetric numEndpointsNoMessageTransportAfterDelay = VideobridgeMetricsContainer.getInstance()
+                .registerCounter("endpoints_no_message_transport_after_delay",
+                "Number of endpoints which had not established a relay message transport even after some delay.");
 
         /**
          * The total number of relays created.
          */
-        public AtomicInteger totalRelays = new AtomicInteger();
+        public CounterMetric totalRelays = VideobridgeMetricsContainer.getInstance().registerCounter(
+                "relays",
+                "The total number of relays created.");
 
         /**
          * The number of relays which had not established a relay
          * message transport even after some delay.
          */
-        public AtomicInteger numRelaysNoMessageTransportAfterDelay = new AtomicInteger();
+        public CounterMetric numRelaysNoMessageTransportAfterDelay = VideobridgeMetricsContainer.getInstance()
+                .registerCounter("relays_no_message_transport_after_delay",
+                "Number of relays which had not established a relay message transport even after some delay.");
 
         /**
          * The total number of times the dominant speaker in any conference

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -291,7 +291,7 @@ class Endpoint @JvmOverloads constructor(
         setupIceTransport()
         setupDtlsTransport()
 
-        conference.videobridge.statistics.totalEndpoints.incrementAndGet()
+        conference.videobridge.statistics.totalEndpoints.inc()
 
         logger.info("Created new endpoint isUsingSourceNames=$isUsingSourceNames, iceControlling=$iceControlling")
     }
@@ -674,7 +674,7 @@ class Endpoint @JvmOverloads constructor(
                 if (!isExpired) {
                     if (!messageTransport.isConnected) {
                         logger.error("EndpointMessageTransport still not connected.")
-                        conference.videobridge.statistics.numEndpointsNoMessageTransportAfterDelay.incrementAndGet()
+                        conference.videobridge.statistics.numEndpointsNoMessageTransportAfterDelay.inc()
                     }
                 }
             },

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
@@ -225,7 +225,7 @@ class Relay @JvmOverloads constructor(
         setupIceTransport()
         setupDtlsTransport()
 
-        conference.videobridge.statistics.totalRelays.incrementAndGet()
+        conference.videobridge.statistics.totalRelays.inc()
     }
 
     fun getMessageTransport(): RelayMessageTransport = messageTransport
@@ -697,7 +697,7 @@ class Relay @JvmOverloads constructor(
                 if (!expired) {
                     if (!messageTransport.isConnected) {
                         logger.error("RelayMessageTransport still not connected.")
-                        conference.videobridge.statistics.numRelaysNoMessageTransportAfterDelay.incrementAndGet()
+                        conference.videobridge.statistics.numRelaysNoMessageTransportAfterDelay.inc()
                     }
                 }
             },


### PR DESCRIPTION
I have a couple of concerns regarding metric (and variable) naming.

1. (nitpicking) In this case, I think keeping the "total" prefix reduces ambiguity for Counters with similar Gauge counterparts (e.g., `totalEndpoints` vs. `currentLocalEndpoints`). For standalone Counters we can omit "total".

2. More importantly, the Prometheus library adds a "total" suffix to Counters automatically. However, the JSON (at `/metrics`) , doesn't get this suffix. Worse yet, this behavior can break the `MetricsContainer` (though unlikely):

- Register a CounterMetric named `endpoints` which ends up as `endpoints_total` in the Prometheus registry;
- Register a CounterMetric named `endpoints_total`. This works for `MetricsContainer`, but can't be registered in the Prometheus registry since the library [handles "_total" suffixes gracefully](https://github.com/prometheus/client_java/blob/master/simpleclient/src/main/java/io/prometheus/client/Counter.java#L101) (i.e., no duplicate suffixes).

If we want consistency, I believe it is better to ensure every Counter ends with "total". I see 3 options:

1. Leave it as is.
2. Rename every ported CounterMetric, adding a "_total" suffix. New CounterMetrics should have this suffix. Contributors would have to be aware of this naming standard.
3. Change `MetricsContainer` so that registering a CounterMetric adds a suffix when necessary. We could log whenever a metric is renamed (and perhaps suggest renaming the metric itself).