### PR TITLE
Port a few more stats to MetricsContainer.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -659,7 +659,7 @@ public class Conference
         boolean hasFailed = statistics.hasIceFailedEndpoint && !statistics.hasIceSucceededEndpoint;
         boolean hasPartiallyFailed = statistics.hasIceFailedEndpoint && statistics.hasIceSucceededEndpoint;
 
-        videobridgeStatistics.dtlsFailedEndpoints.addAndGet(statistics.dtlsFailedEndpoints.get());
+        videobridgeStatistics.endpointsDtlsFailed.addAndGet(statistics.dtlsFailedEndpoints.get());
 
         if (hasPartiallyFailed)
         {

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -515,7 +515,7 @@ public class Conference
 
             if (dominantSpeakerChanged && !silence)
             {
-                getVideobridge().getStatistics().totalDominantSpeakerChanges.increment();
+                getVideobridge().getStatistics().dominantSpeakerChanges.inc();
                 if (getEndpointCount() > 2)
                 {
                     maybeSendKeyframeRequest(recentSpeakers.get(0));

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -1131,13 +1131,17 @@ public class Videobridge
          * The total number of times the dominant speaker in any conference
          * changed.
          */
-        public LongAdder totalDominantSpeakerChanges = new LongAdder();
+        public CounterMetric dominantSpeakerChanges = VideobridgeMetricsContainer.getInstance().registerCounter(
+                "dominant_speaker_changes",
+                "Number of times the dominant speaker in any conference changed.");
 
         /**
          * Number of endpoints whose ICE connection was established, but DTLS
          * wasn't (at the time of expiration).
          */
-        public AtomicInteger dtlsFailedEndpoints = new AtomicInteger();
+        public CounterMetric dtlsFailedEndpoints = VideobridgeMetricsContainer.getInstance().registerCounter(
+                "dtls_failed_endpoints",
+                "Number of endpoints whose ICE connection was established, but DTLS wasn't (at time of expiration).");
 
         /**
          * The stress level for this bridge
@@ -1169,7 +1173,9 @@ public class Videobridge
         /**
          * The total number of times the layering of an incoming video stream changed (updated on endpoint expiration).
          */
-        public AtomicInteger totalLayeringChangesReceived = new AtomicInteger();
+        public CounterMetric layeringChangesReceived = VideobridgeMetricsContainer.getInstance().registerCounter(
+                "layering_changes_received",
+                "Number of times the layering of an incoming video stream changed (updated on endpoint expiration).");
 
         /**
          * The total duration, in milliseconds, of video streams (SSRCs) that were received. For example, if an

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -1139,8 +1139,8 @@ public class Videobridge
          * Number of endpoints whose ICE connection was established, but DTLS
          * wasn't (at the time of expiration).
          */
-        public CounterMetric dtlsFailedEndpoints = VideobridgeMetricsContainer.getInstance().registerCounter(
-                "dtls_failed_endpoints",
+        public CounterMetric endpointsDtlsFailed = VideobridgeMetricsContainer.getInstance().registerCounter(
+                "endpoints_dtls_failed",
                 "Number of endpoints whose ICE connection was established, but DTLS wasn't (at time of expiration).");
 
         /**

--- a/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -536,7 +536,7 @@ public class VideobridgeStatistics
                 jvbStats.numRelaysNoMessageTransportAfterDelay.get()
             );
             unlockedSetStat("total_keyframes_received", jvbStats.keyframesReceived.get());
-            unlockedSetStat("total_layering_changes_received", jvbStats.totalLayeringChangesReceived.get());
+            unlockedSetStat("total_layering_changes_received", jvbStats.layeringChangesReceived.get());
             unlockedSetStat(
                 "total_video_stream_milliseconds_received",
                 jvbStats.totalVideoStreamMillisecondsReceived.get());
@@ -601,7 +601,7 @@ public class VideobridgeStatistics
             unlockedSetStat(OCTO_RECEIVE_PACKET_RATE, relayPacketRateIncoming);
             unlockedSetStat(OCTO_SEND_BITRATE, relayBitrateOutgoingBps);
             unlockedSetStat(OCTO_SEND_PACKET_RATE, relayPacketRateOutgoing);
-            unlockedSetStat(TOTAL_DOMINANT_SPEAKER_CHANGES, jvbStats.totalDominantSpeakerChanges.sum());
+            unlockedSetStat(TOTAL_DOMINANT_SPEAKER_CHANGES, jvbStats.dominantSpeakerChanges.get());
             unlockedSetStat("endpoints_with_suspended_sources", endpointsWithSuspendedSources);
 
             unlockedSetStat(TIMESTAMP, timestampFormat.format(new Date()));

--- a/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/stats/VideobridgeStatistics.java
@@ -585,7 +585,7 @@ public class VideobridgeStatistics
                             jvbStats.colibriWebSocketMessagesSent.get());
             unlockedSetStat(
                     TOTAL_BYTES_RECEIVED, jvbStats.totalBytesReceived.get());
-            unlockedSetStat("dtls_failed_endpoints", jvbStats.dtlsFailedEndpoints.get());
+            unlockedSetStat("dtls_failed_endpoints", jvbStats.endpointsDtlsFailed.get());
             unlockedSetStat(TOTAL_BYTES_SENT, jvbStats.totalBytesSent.get());
             unlockedSetStat(
                     TOTAL_PACKETS_RECEIVED, jvbStats.packetsReceived.get());

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -1005,8 +1005,8 @@ class Endpoint @JvmOverloads constructor(
                 incomingBitrateExpirations.addAndGet(it)
             }
             keyframesReceived.addAndGet(transceiverStats.rtpReceiverStats.videoParserStats.numKeyframes.toLong())
-            totalLayeringChangesReceived.addAndGet(
-                transceiverStats.rtpReceiverStats.videoParserStats.numLayeringChanges
+            layeringChangesReceived.addAndGet(
+                transceiverStats.rtpReceiverStats.videoParserStats.numLayeringChanges.toLong()
             )
 
             val durationActiveVideo = transceiverStats.rtpReceiverStats.incomingStats.ssrcStats.values.filter {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
@@ -865,8 +865,8 @@ class Relay @JvmOverloads constructor(
         conference.videobridge.statistics.apply {
             /* TODO: should these be separate stats from the endpoint stats? */
             keyframesReceived.addAndGet(transceiverStats.rtpReceiverStats.videoParserStats.numKeyframes.toLong())
-            totalLayeringChangesReceived.addAndGet(
-                transceiverStats.rtpReceiverStats.videoParserStats.numLayeringChanges
+            layeringChangesReceived.addAndGet(
+                transceiverStats.rtpReceiverStats.videoParserStats.numLayeringChanges.toLong()
             )
 
             val durationActiveVideo = transceiverStats.rtpReceiverStats.incomingStats.ssrcStats.values.filter {


### PR DESCRIPTION
- I assume `dtlsFailedEndpoints` is cumulative, can you confirm?
- `totalDominantSpeakerChanges` is/was a `LongAdder`. Is this for better performance?