### PR TITLE
Fix: Always copy the mediaSources array for signaledMediaSources.

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -219,7 +219,7 @@ class Transceiver(
         logger.cdebug { "$id setting media sources: ${mediaSources.joinToString()}" }
         val ret = this.mediaSources.setMediaSources(mediaSources)
         val mergedMediaSources = this.mediaSources.getMediaSources()
-        val signaledMediaSources = if (mediaSources === mergedMediaSources) mediaSources.copy() else mediaSources
+        val signaledMediaSources = mediaSources.copy()
         rtpReceiver.handleEvent(SetMediaSourcesEvent(mergedMediaSources, signaledMediaSources))
         return ret
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayedEndpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayedEndpoint.kt
@@ -174,7 +174,7 @@ class RelayedEndpoint(
             applyVideoTypeCache(value)
             val changed = _mediaSources.setMediaSources(value)
             val mergedMediaSources = _mediaSources.getMediaSources()
-            val signaledMediaSources = if (value === mergedMediaSources) value.copy() else value
+            val signaledMediaSources = value.copy()
             if (changed) {
                 val setMediaSourcesEvent = SetMediaSourcesEvent(mediaSources, signaledMediaSources)
 


### PR DESCRIPTION
This fixes a case where the mediaSources and signaledMediaSources objects could end up sharing a MediaSourceDesc object, leading to encodings not getting properly reset after a VP9 -> VP8 switch.