### PR TITLE
Removed unnecessary streams usage

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -34,7 +34,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArraySet
 import java.util.function.Predicate
 import kotlin.properties.Delegates
-import kotlin.streams.toList
 
 /**
  * An abstract base class for all [Node] subclasses.  This class
@@ -515,7 +514,7 @@ abstract class DemuxerNode(name: String) : StatsKeepingNode("$name demuxer") {
         }
     }
 
-    override fun getChildren(): Collection<Node> = transformPaths.stream().map(ConditionalPacketPath::path).toList()
+    override fun getChildren(): Collection<Node> = transformPaths.map { it.path }
 
     override fun getNodeStats(): NodeStatsBlock {
         val superStats = super.getNodeStats()


### PR DESCRIPTION
IntelliJ complains that the `toList()` call is only available from version 16 on. This patch provided by @bgrozev removes the stream usage altogether. 