### PR TITLE
Bump mvn version to 2.3.

### DIFF
--- a/jitsi-media-transform/pom.xml
+++ b/jitsi-media-transform/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jitsi</groupId>
         <artifactId>jvb-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jitsi</groupId>

--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
       <groupId>org.jitsi</groupId>
       <artifactId>jvb-parent</artifactId>
-      <version>2.1-SNAPSHOT</version>
+      <version>2.3-SNAPSHOT</version>
   </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.jitsi</groupId>
     <artifactId>jvb-parent</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/rtp/pom.xml
+++ b/rtp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jitsi</groupId>
         <artifactId>jvb-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jitsi</groupId>


### PR DESCRIPTION
A bump to 2.2 was intended with the mono repo changes, but it was only
partially done (a v2.2 tag exists, but pom.xml still lists 2.1).
