### PR TITLE
Don't expire a conference that's in multiple meshes.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -1076,12 +1076,33 @@ public class Conference
     }
 
     /**
+     * @return {@code true} if this {@link Conference} is in more than one relay mesh.
+     */
+    private boolean inMultipleMeshes()
+    {
+        String meshId = null;
+        for (Relay r : relaysById.values())
+        {
+            if (meshId == null)
+            {
+                meshId = r.getMeshId();
+            }
+            else if (!meshId.equals(r.getMeshId()))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * @return {@code true} if this {@link Conference} is ready to be expired.
      */
     public boolean shouldExpire()
     {
         // Allow a conference to have no endpoints in the first 20 seconds.
         return getEndpointCount() == 0
+                && !inMultipleMeshes()
                 && (System.currentTimeMillis() - creationTime > 20000);
     }
 

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -1080,19 +1080,7 @@ public class Conference
      */
     private boolean inMultipleMeshes()
     {
-        String meshId = null;
-        for (Relay r : relaysById.values())
-        {
-            if (meshId == null)
-            {
-                meshId = r.getMeshId();
-            }
-            else if (!meshId.equals(r.getMeshId()))
-            {
-                return true;
-            }
-        }
-        return false;
+        return relaysById.values().stream().map(Relay::getMeshId).collect(Collectors.toSet()).size() > 1;
     }
 
     /**


### PR DESCRIPTION
Even if it has no participants - it might be bridging to a visitor relay.