### PR TITLE
log: Remove redundant log context.

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
@@ -93,8 +93,6 @@ class RelayMessageTransport(
      */
     private val sentMessagesCounts: MutableMap<String, AtomicLong> = ConcurrentHashMap()
 
-    init { logger.addContext("relay-id", relay.id) }
-
     /**
      * Connect the bridge channel message to the websocket URL specified
      */


### PR DESCRIPTION
The Relay already has its ID in the context resulting in:
relayId=jvb-foo-bar relay-id=jvb-foo-bar
