### PR TITLE
fix: Fix broken audio when SSRC rewriting with relays

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -67,6 +67,7 @@ import org.jitsi.videobridge.message.ReceiverVideoConstraintsMessage
 import org.jitsi.videobridge.message.SenderSourceConstraintsMessage
 import org.jitsi.videobridge.message.SenderVideoConstraintsMessage
 import org.jitsi.videobridge.relay.AudioSourceDesc
+import org.jitsi.videobridge.relay.RelayedEndpoint
 import org.jitsi.videobridge.rest.root.debug.EndpointDebugFeatures
 import org.jitsi.videobridge.sctp.DataChannelHandler
 import org.jitsi.videobridge.sctp.SctpHandler
@@ -878,9 +879,11 @@ class Endpoint @JvmOverloads constructor(
      */
     override fun findAudioSourceProps(ssrc: Long): AudioSourceDesc? {
         conference.getEndpointBySsrc(ssrc)?.let { ep ->
-            if (ep !is Endpoint)
-                return null
-            return ep.audioSources.find { s -> s.ssrc == ssrc }
+            return when (ep) {
+                is Endpoint -> ep.audioSources
+                is RelayedEndpoint -> ep.audioSources
+                else -> emptyList()
+            }.find { it.ssrc == ssrc }
         }
         logger.error { "No properties found for SSRC $ssrc." }
         return null

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
@@ -762,7 +762,7 @@ class Relay @JvmOverloads constructor(
                 }
             )
             ep.statsId = statsId
-            ep.audioSources = audioSources.toTypedArray()
+            ep.audioSources = audioSources.toList()
             ep.mediaSources = videoSources.toTypedArray()
 
             relayedEndpoints[id] = ep
@@ -794,7 +794,7 @@ class Relay @JvmOverloads constructor(
             }
             val oldSsrcs = ep.ssrcs
 
-            ep.audioSources = audioSources.toTypedArray()
+            ep.audioSources = audioSources.toList()
             ep.mediaSources = videoSources.toTypedArray()
 
             val newSsrcs = ep.ssrcs
@@ -883,7 +883,7 @@ class Relay @JvmOverloads constructor(
         audioSources: Collection<AudioSourceDesc>,
         videoSources: Collection<MediaSourceDesc>
     ) {
-        ep.audioSources = audioSources.toTypedArray()
+        ep.audioSources = audioSources.toList()
         ep.mediaSources = videoSources.toTypedArray()
     }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayedEndpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayedEndpoint.kt
@@ -57,7 +57,7 @@ class RelayedEndpoint(
     parentLogger: Logger,
     diagnosticContext: DiagnosticContext
 ) : AbstractEndpoint(conference, id, parentLogger), Relay.IncomingRelayPacketHandler {
-    var audioSources: Array<AudioSourceDesc> = arrayOf()
+    var audioSources: List<AudioSourceDesc> = listOf()
         set(value) {
             field = value
             value.forEach {


### PR DESCRIPTION
Fixes finding the AudioSourceDesc when it belongs to a RelayedEndpoint.
