### PR TITLE
Use source names as keys to effective constraints debug state.

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.kt
@@ -124,7 +124,7 @@ internal class BandwidthAllocator<T : MediaSourceContainer>(
             debugState["bweBps"] = bweBps
             debugState["allocation"] = allocation.debugState
             debugState["allocationSettings"] = allocationSettings.toJson()
-            debugState["effectiveConstraints"] = effectiveConstraints
+            debugState["effectiveConstraints"] = effectiveConstraints.mapKeys { it.key.sourceName }
             return debugState
         }
 


### PR DESCRIPTION
Previously it would use MediaSourceDesc.toString() for the JSON keys, which look like 
```"MediaSourceDesc[name=ec4f16b0-v0 owner=ec4f16b0, videoType=NONE, encodings=primary_ssrc=401428989,secondary_ssrcs={2884778422=RTX},layers=\n    subjective_quality=0,temporal_id=0,spatial_id=-1\n    subjective_quality=1,temporal_id=1,spatial_id=-1\n    subjective_quality=2,temporal_id=2,spatial_id=-1,primary_ssrc=3871341347,secondary_ssrcs={1551935578=RTX},layers=\n    subjective_quality=64,temporal_id=0,spatial_id=-1\n    subjective_quality=65,temporal_id=1,spatial_id=-1\n    subjective_quality=66,temporal_id=2,spatial_id=-1,primary_ssrc=2532834492,secondary_ssrcs={2207419540=RTX},layers=\n    subjective_quality=128,temporal_id=0,spatial_id=-1\n    subjective_quality=129,temporal_id=1,spatial_id=-1\n    subjective_quality=130,temporal_id=2,spatial_id=-1]"```

which is very much not what you want for a JSON key.