### PR TITLE
Revert "Bump Bouncycastle to version 1.75. (#2036)"

### DIFF
--- a/jitsi-media-transform/pom.xml
+++ b/jitsi-media-transform/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>jitsi-srtp</artifactId>
-            <version>1.1-13-g1d0db60</version>
+            <version>1.1-12-ga64adcc</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -55,17 +55,17 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bctls-jdk18on</artifactId>
+            <artifactId>bctls-jdk15on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
+            <artifactId>bcprov-jdk15on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk18on</artifactId>
+            <artifactId>bcpkix-jdk15on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <spotbugs.version>4.6.0</spotbugs.version>
         <jersey.version>3.0.10</jersey.version>
         <jackson.version>2.12.4</jackson.version>
-        <bouncycastle.version>1.75</bouncycastle.version>
+        <bouncycastle.version>1.70</bouncycastle.version>
         <prometheus.version>0.16.0</prometheus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
The update to 1.75 was found to cause a failure for some endpoints to finish DTLS, leaving them unable to join a conference. We are investigating and planning to update once the problem is fixed. The CVEs that affect 1.70 but not 1.75 do not affect jitsi-videobridge.

This reverts commit 44a053343d051b64894abf760777f6e4ad0135de.
