### PR TITLE
Fix routing of audio and stats when routeLoudestOnly is disabled

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -1138,7 +1138,9 @@ public class Conference
     {
         if (!LoudestConfig.Companion.getRouteLoudestOnly())
         {
-            return false;
+            // When "route loudest only" is disabled all speakers should be considered "ranked" (we forward all audio
+            // and stats).
+            return true;
         }
         return speechActivity.isAmongLoudest(ep.getId());
     }

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -163,6 +163,11 @@ public class Conference
     @NotNull private final EncodingsManager encodingsManager = new EncodingsManager();
 
     /**
+     * Cache here because it's accessed on every packet.
+     */
+    private final boolean routeLoudestOnly = LoudestConfig.getRouteLoudestOnly();
+
+    /**
      * The task of updating the ordered list of endpoints in the conference. It runs periodically in order to adapt to
      * endpoints stopping or starting to their video streams (which affects the order).
      */
@@ -1283,7 +1288,7 @@ public class Conference
     public boolean levelChanged(@NotNull AbstractEndpoint endpoint, long level)
     {
         SpeakerRanking ranking = speechActivity.levelChanged(endpoint, level);
-        if (ranking == null)
+        if (ranking == null || !routeLoudestOnly)
             return false;
         if (ranking.isDominant && LoudestConfig.Companion.getAlwaysRouteDominant())
             return false;


### PR DESCRIPTION
- fix: Don't drop audio when routeLoudestOnly is disabled in config.
- fix: Do not drop stats when routeLoudestOnly is disabled.
