### PR TITLE
Fixed default file path

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/PcapWriter.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/PcapWriter.kt
@@ -36,7 +36,7 @@ import java.util.Random
 
 class PcapWriter(
     parentLogger: Logger,
-    filePath: String = "/tmp/${Random().nextLong()}.pcap}"
+    filePath: String = "/tmp/${Random().nextLong()}.pcap"
 ) : ObserverNode("PCAP writer") {
     private val logger = createChildLogger(parentLogger)
     private val lazyHandle = lazy {


### PR DESCRIPTION
Fixed the default value of the parameter filePath for the PcapWriter constructor.
Having a "}" at the end of the file name must have been a typo.