### PR TITLE
Add telephone-event payload type

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/format/PayloadType.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/format/PayloadType.kt
@@ -77,15 +77,21 @@ enum class PayloadTypeEncoding {
     H264,
     RED,
     RTX,
-    OPUS;
+    OPUS,
+    TELEPHONE_EVENT;
 
     companion object {
+        private const val TEL_EVENT_TEXT = "telephone-event"
+
         /**
          * [valueOf] does not allow for case-insensitivity and can't be overridden, so this
          * method should be used when creating an instance of this enum from a string
          */
         fun createFrom(value: String): PayloadTypeEncoding {
             return try {
+                if (value.lowercase() == TEL_EVENT_TEXT) {
+                    return TELEPHONE_EVENT
+                }
                 valueOf(value.uppercase())
             } catch (e: IllegalArgumentException) {
                 return OTHER
@@ -94,7 +100,11 @@ enum class PayloadTypeEncoding {
     }
 
     override fun toString(): String = with(StringBuffer()) {
-        append(super.toString())
+        if (super.equals(TELEPHONE_EVENT)) {
+            append(TEL_EVENT_TEXT)
+        } else {
+            append(super.toString())
+        }
         toString()
     }
 }
@@ -144,6 +154,12 @@ class OpusPayloadType(
     pt: Byte,
     parameters: PayloadTypeParams = ConcurrentHashMap()
 ) : AudioPayloadType(pt, PayloadTypeEncoding.OPUS, parameters = parameters)
+
+class TelephoneEventPayloadType(
+    pt: Byte,
+    clockRate: Int,
+    parameters: PayloadTypeParams = ConcurrentHashMap()
+) : AudioPayloadType(pt, PayloadTypeEncoding.TELEPHONE_EVENT, clockRate, parameters)
 
 class AudioRedPayloadType(
     pt: Byte,

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/util/PayloadTypeUtil.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/util/PayloadTypeUtil.kt
@@ -27,9 +27,11 @@ import org.jitsi.nlj.format.PayloadTypeEncoding.OPUS
 import org.jitsi.nlj.format.PayloadTypeEncoding.OTHER
 import org.jitsi.nlj.format.PayloadTypeEncoding.RED
 import org.jitsi.nlj.format.PayloadTypeEncoding.RTX
+import org.jitsi.nlj.format.PayloadTypeEncoding.TELEPHONE_EVENT
 import org.jitsi.nlj.format.PayloadTypeEncoding.VP8
 import org.jitsi.nlj.format.PayloadTypeEncoding.VP9
 import org.jitsi.nlj.format.RtxPayloadType
+import org.jitsi.nlj.format.TelephoneEventPayloadType
 import org.jitsi.nlj.format.VideoRedPayloadType
 import org.jitsi.nlj.format.Vp8PayloadType
 import org.jitsi.nlj.format.Vp9PayloadType
@@ -95,6 +97,7 @@ class PayloadTypeUtil {
                 H264 -> H264PayloadType(id, parameters, rtcpFeedbackSet)
                 RTX -> RtxPayloadType(id, parameters)
                 OPUS -> OpusPayloadType(id, parameters)
+                TELEPHONE_EVENT -> TelephoneEventPayloadType(id, clockRate, parameters)
                 RED -> when (mediaType) {
                     AUDIO -> AudioRedPayloadType(id, clockRate, parameters)
                     VIDEO -> VideoRedPayloadType(id, clockRate, parameters, rtcpFeedbackSet)


### PR DESCRIPTION
The "telephone-event" payload type is currently mapped to OTHER payload type.
This PR introduces TELEPHONE_EVENT payload type and maps "telephone-event" to TELEPHONE_EVENT.
This allows to have more accurate payload type map for PCAP capture functionality and debugging.