### PR TITLE
feat: Relax the health checks for STUN

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/health/config/HealthConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/health/config/HealthConfig.kt
@@ -41,6 +41,14 @@ class HealthConfig private constructor() {
         "videobridge.health.sticky-failures".from(JitsiConfig.newConfig)
     }
 
+    val requireStun: Boolean by config {
+        "videobridge.health.require-stun".from(JitsiConfig.newConfig)
+    }
+
+    val requireValidAddress: Boolean by config {
+        "videobridge.health.require-valid-address".from(JitsiConfig.newConfig)
+    }
+
     companion object {
         @JvmField
         val config = HealthConfig()

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -21,6 +21,14 @@ videobridge {
     # (i.e. once the bridge becomes unhealthy, it will never
     # go back to a healthy state)
     sticky-failures = false
+
+    # If enabled, health checks fail when there are no valid addresses available for ICE. Here "valid" means not
+    # site local, link local or loopback.
+    require-valid-address = true
+
+    # If enabled, health checks will fail when a STUN mapping harvester is configured, but fails to get a mapping (even
+    # if there is a valid address available through other mappings or locally).
+    require-stun = false
   }
   ep-connection-status {
     # How long we'll wait for an endpoint to *start* sending

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>ice4j</artifactId>
-                <version>3.0-66-g1c60acc</version>
+                <version>3.0-68-gd289f12</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
By default only fail when there is no valid address for ICE. Put the
option to require STUN behind a flag.
