### PR TITLE
Update Java Debian dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: extra
 Maintainer: Jitsi Team <dev@jitsi.org>
 Uploaders: Emil Ivov <emcho@jitsi.org>, Damian Minkov <damencho@jitsi.org>
-Build-Depends: debhelper (>= 9), dh-systemd, java8-runtime-headless | java8-runtime | java11-runtime-headless | java11-runtime, maven
+Build-Depends: debhelper (>= 9), dh-systemd, java11-sdk, maven
 Standards-Version: 3.9.3
 Homepage: https://jitsi.org/videobridge
 
@@ -11,7 +11,7 @@ Package: jitsi-videobridge2
 Replaces: jitsi-videobridge
 Conflicts: jitsi-videobridge (<= 1400-1)
 Architecture: all
-Pre-Depends: openjdk-11-jre-headless | openjdk-11-jre | java11-runtime-headless | java11-runtime, libssl3 | libssl1.1
+Pre-Depends: java11-runtime-headless | java11-runtime, libssl3 | libssl1.1
 Depends: ${misc:Depends}, procps, uuid-runtime, ruby-hocon
 Description: WebRTC compatible Selective Forwarding Unit (SFU)
  Jitsi Videobridge is a WebRTC compatible Selective Forwarding Unit


### PR DESCRIPTION
Allows for running with Java 17 without any additional install.