### PR TITLE
Recommend libpcap0.8 for the JVB debian package.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Conflicts: jitsi-videobridge (<= 1400-1)
 Architecture: all
 Pre-Depends: openjdk-11-jre-headless | openjdk-11-jre | java11-runtime-headless | java11-runtime, libssl3 | libssl1.1
 Depends: ${misc:Depends}, procps, uuid-runtime, ruby-hocon
+Recommends: libpcap0.8
 Description: WebRTC compatible Selective Forwarding Unit (SFU)
  Jitsi Videobridge is a WebRTC compatible Selective Forwarding Unit
  (SFU) for multiuser video communication. It is an essential part


### PR DESCRIPTION
Needed by pcap4j, but pcap capture is not enabled by default.