### PR TITLE
Don't do per-packet debug logging in SsrcCache.

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
@@ -424,16 +424,6 @@ abstract class SsrcCache(val size: Int, val ep: SsrcRewriter, val parentLogger: 
             val ss = getSendSource(rs.props.ssrc1, rs.props, allowCreateOnPacket, remappings)
             if (ss != null) {
                 send = ss.rewriteRtp(packet, start, rs)
-                logger.debug { this.toString() }
-                logger.debug {
-                    if (send) {
-                        "Sending packet: ${debugInfo(packet)} source=${rs.props.name} start=$start"
-                    } else {
-                        "Dropping packet from ${rs.props.name}/${packet.ssrc}. waiting for key frame."
-                    }
-                }
-            } else {
-                logger.debug { "Dropping packet from ${rs.props.name}/${packet.ssrc}. source not active." }
             }
         }
 


### PR DESCRIPTION
We have debug logs turned on during PR testing and it blows up the log.