### PR TITLE
Bump jitsi-sctp.

### DIFF
--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -107,8 +107,8 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>sctp</artifactId>
-      <version>1.0-14-ge26331d</version>
+      <artifactId>jitsi-sctp</artifactId>
+      <version>1.0-20-gcf25585</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
     <!-- we inherit an old version of slf4j-api from tinder, which pcap4j doesn't work with. Adding slf4j-api 1.7.30 (the current stable) as a dep of jvb fixes the problem. -->


### PR DESCRIPTION
This version's native libraries are auto-built by GitHub actions, and now include ppc64el libraries.