### PR TITLE
Add a Java option to work around a major performance regression in JDK 17

### DIFF
--- a/jvb/resources/jvb.sh
+++ b/jvb/resources/jvb.sh
@@ -19,4 +19,4 @@ fi
 if [ -z "$VIDEOBRIDGE_MAX_MEMORY" ]; then VIDEOBRIDGE_MAX_MEMORY=3072m; fi
 if [ -z "$VIDEOBRIDGE_GC_TYPE" ]; then VIDEOBRIDGE_GC_TYPE=G1GC; fi
 
-exec java -Xmx$VIDEOBRIDGE_MAX_MEMORY $VIDEOBRIDGE_DEBUG_OPTIONS -XX:+Use$VIDEOBRIDGE_GC_TYPE -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -Djdk.tls.ephemeralDHKeySize=2048 $LOGGING_CONFIG_PARAM $JAVA_SYS_PROPS -cp $cp $mainClass $@
+exec java -Xmx$VIDEOBRIDGE_MAX_MEMORY $VIDEOBRIDGE_DEBUG_OPTIONS -XX:+Use$VIDEOBRIDGE_GC_TYPE -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -Djdk.tls.ephemeralDHKeySize=2048 -Djdk.net.usePlainDatagramSocketImpl=true $LOGGING_CONFIG_PARAM $JAVA_SYS_PROPS -cp $cp $mainClass $@


### PR DESCRIPTION
There was a rewrite of the Java networking stack in Java 13 which made it impossible to concurrently send UDP from multiple threads on the same DatagramSocket.  See https://bugs.openjdk.org/browse/JDK-8303616. This Java option causes Java to use its old DatagramSocket implementation.

Note that unfortunately this workaround does not work in Java 18 and later.