### PR TITLE
Revert "Bump jitsi-sctp version: assert if soref() is called on a freed socket. (#2116)"

### DIFF
--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-sctp</artifactId>
-      <version>1.0-22-gda328b9</version>
+      <version>1.0-21-gfe0d028</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
     <!-- we inherit an old version of slf4j-api from tinder, which pcap4j doesn't work with. Adding slf4j-api 1.7.30 (the current stable) as a dep of jvb fixes the problem. -->


### PR DESCRIPTION
This reverts commit 21b42fb2f2b5f3e92d0fdbbe9dce507d0fc2731d.