### PR TITLE
fix: Remove mappings when an endpoint expires.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -922,7 +922,7 @@ public class Conference
         {
             // The removed endpoint was a local Endpoint as opposed to a RelayedEndpoint.
             updateEndpointsCache();
-            endpointsById.forEach((i, senderEndpoint) -> senderEndpoint.removeReceiver(id));
+            endpointsById.values().forEach(e -> e.otherEndpointExpired(removedEndpoint));
             videobridge.localEndpointExpired(removedEndpoint.getVisitor());
         }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpoint.kt
@@ -296,6 +296,11 @@ abstract class AbstractEndpoint protected constructor(
         }
     }
 
+    /** Notify this endpoint that another endpoint expired */
+    open fun otherEndpointExpired(expired: AbstractEndpoint) {
+        removeReceiver(expired.id)
+    }
+
     /**
      * Notifies this instance that the specified receiver no longer wants or
      * needs to receive anything from the endpoint attached to this

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -940,6 +940,15 @@ class Endpoint @JvmOverloads constructor(
         return false
     }
 
+    override fun otherEndpointExpired(expired: AbstractEndpoint) = super.otherEndpointExpired(expired).also {
+        if (doSsrcRewriting) {
+            // Remove the expired endpoint's sources. We don't want duplicate entries in case the endpoint is
+            // re-created (e.g. after an ICE restart).
+            audioSsrcs.removeByOwner(expired.id)
+            videoSsrcs.removeByOwner(expired.id)
+        }
+    }
+
     fun setLastN(lastN: Int) {
         bitrateController.lastN = lastN
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
@@ -295,17 +295,6 @@ abstract class SsrcCache(val size: Int, val ep: SsrcRewriter, val parentLogger: 
      */
     private var remapCount = 0
 
-    companion object {
-        /**
-         * Print packet fields relevant to rewriting mode.
-         */
-        private fun debugInfo(packet: RtpPacket): String {
-            val codecState = packet.getCodecState()
-            val codecInfo = codecState?.toString() ?: ""
-            return "ssrc=${packet.ssrc} seq=${packet.sequenceNumber} ts=${packet.timestamp}" + codecInfo
-        }
-    }
-
     /**
      * Find the properties of the source indicated by the given SSRC. Returns null if not found.
      */
@@ -319,7 +308,6 @@ abstract class SsrcCache(val size: Int, val ep: SsrcRewriter, val parentLogger: 
     /**
      * Assign a group of send SSRCs to use for the specified source.
      * If remapping the send SSRCs from another source, transfer RTP state from the old source.
-     * Collect any remapped sources into the provided list.
      * Returns null if no current mapping exists and allowCreate is false.
      * Otherwise, returns the send source information to use.
      */
@@ -327,10 +315,11 @@ abstract class SsrcCache(val size: Int, val ep: SsrcRewriter, val parentLogger: 
         ssrc: Long,
         props: SourceDesc,
         allowCreate: Boolean,
-        remappings: MutableList<SendSource>
+        /* Collect remapped sources into this list, if provided. */
+        remappings: MutableList<SendSource>? = null
     ): SendSource? {
         /* Moves to end of LRU when found. */
-        var sendSource = sendSources.get(ssrc)
+        var sendSource = sendSources[ssrc]
 
         if (sendSource == null) {
             if (!allowCreate) {
@@ -341,9 +330,9 @@ abstract class SsrcCache(val size: Int, val ep: SsrcRewriter, val parentLogger: 
                 sendSource = SendSource(props, eldest.value.send1, eldest.value.send2)
                 logger.debug { "Remapping SSRC: ${props.ssrc1}->$sendSource. ${eldest.key}->inactive" }
                 /* Request new deltas on next sent packet */
-                receivedSsrcs.get(props.ssrc1)?.hasDeltas = false
+                receivedSsrcs[props.ssrc1]?.hasDeltas = false
                 if (props.ssrc2 != -1L) {
-                    receivedSsrcs.get(props.ssrc2)?.hasDeltas = false
+                    receivedSsrcs[props.ssrc2]?.hasDeltas = false
                 }
                 ++remapCount
             } else {
@@ -352,8 +341,8 @@ abstract class SsrcCache(val size: Int, val ep: SsrcRewriter, val parentLogger: 
                 sendSource = SendSource(props, ssrc1, ssrc2)
                 logger.debug { "Added send SSRC: ${props.ssrc1}->$sendSource" }
             }
-            sendSources.put(ssrc, sendSource)
-            remappings.add(sendSource)
+            sendSources[ssrc] = sendSource
+            remappings?.add(sendSource)
         }
 
         return sendSource
@@ -370,7 +359,7 @@ abstract class SsrcCache(val size: Int, val ep: SsrcRewriter, val parentLogger: 
             touches the already active sources, to prevent them from being
             bumped out of the LRU by earlier elements of the list. */
             sources.filter { source ->
-                sendSources.get(source.primarySSRC) == null
+                sendSources[source.primarySSRC] == null
             }.forEach { source ->
                 getSendSource(source.primarySSRC, SourceDesc(source), allowCreate = true, remappings)
             }
@@ -411,11 +400,11 @@ abstract class SsrcCache(val size: Int, val ep: SsrcRewriter, val parentLogger: 
         var send = false
 
         synchronized(sendSources) {
-            var rs = receivedSsrcs.get(packet.ssrc)
+            var rs = receivedSsrcs[packet.ssrc]
             if (rs == null) {
                 val props = findSourceProps(packet.ssrc) ?: return false
                 rs = ReceiveSsrc(props)
-                receivedSsrcs.put(packet.ssrc, rs)
+                receivedSsrcs[packet.ssrc] = rs
                 logger.debug { "Added receive SSRC: ${packet.ssrc}" }
             }
 
@@ -437,13 +426,10 @@ abstract class SsrcCache(val size: Int, val ep: SsrcRewriter, val parentLogger: 
      * For packets in the same direction as media flow; feedback messages handled separately.
      */
     fun rewriteRtcp(packet: RtcpPacket): Boolean {
-        val remappings = mutableListOf<SendSource>() // unused
-        val senderSsrc = packet.senderSsrc
-
         synchronized(sendSources) {
             /* Don't activate a source on RTCP. */
-            val rs = receivedSsrcs.get(packet.senderSsrc) ?: return false
-            val ss = getSendSource(rs.props.ssrc1, rs.props, allowCreate = false, remappings) ?: return false
+            val rs = receivedSsrcs[packet.senderSsrc] ?: return false
+            val ss = getSendSource(rs.props.ssrc1, rs.props, allowCreate = false) ?: return false
             ss.rewriteRtcp(packet)
             return true
         }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
@@ -349,6 +349,18 @@ abstract class SsrcCache(val size: Int, val ep: SsrcRewriter, val parentLogger: 
     }
 
     /**
+     * Remove all send sources owned by [owner]. Does not signal anything to the client, as only additions need to be
+     * signaled.
+     */
+    fun removeByOwner(owner: String) {
+        synchronized(sendSources) {
+            sendSources.values.removeIf { sendSource ->
+                sendSource.props.owner == owner
+            }
+        }
+    }
+
+    /**
      * Assign send SSRCs to the given sources. Any remapped SSRCs will be notified to the client.
      */
     fun activate(sources: List<MediaSourceDesc>) {


### PR DESCRIPTION
- **ref: Use [] syntax to access map, cleanup.**
- **fix: Remove mappings when an endpoint expires.**
