### PR TITLE
In some cases, process VP8 or VP9 packets as AV1.

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/ParsedVideoPacket.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/ParsedVideoPacket.kt
@@ -31,4 +31,10 @@ abstract class ParsedVideoPacket(
     abstract val isKeyframe: Boolean
     abstract val isStartOfFrame: Boolean
     abstract val isEndOfFrame: Boolean
+
+    /** Whether the packet meets the needs of the routing infrastructure.
+     * If a packet could be parsed more than one way (e.g. it is VP8 or VP9 but also has an AV1 DD)
+     * this will let us choose which parse to prefer.
+     */
+    abstract fun meetsRoutingNeeds(): Boolean
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/VideoCodecParser.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/VideoCodecParser.kt
@@ -19,7 +19,6 @@ package org.jitsi.nlj.rtp.codec
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.RtpEncodingDesc
-import org.jitsi.nlj.findRtpLayerDescs
 import org.jitsi.nlj.rtp.VideoRtpPacket
 
 /**

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDPacket.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDPacket.kt
@@ -98,6 +98,9 @@ class Av1DDPacket : ParsedVideoPacket {
     override val isEndOfFrame: Boolean
         get() = statelessDescriptor.endOfFrame
 
+    override fun meetsRoutingNeeds(): Boolean =
+        true // If it didn't parse as AV1 we would have failed in the constructor
+
     override val layerIds: Collection<Int>
         get() = frameInfo?.dtisPresent
             ?: run { super.layerIds }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
@@ -69,6 +69,10 @@ class Vp8Packet private constructor(
         /** This uses [get] rather than initialization because [isMarked] is a var. */
         get() = isMarked
 
+    override fun meetsRoutingNeeds(): Boolean {
+        return hasPictureId && hasTemporalLayerIndex
+    }
+
     val hasTemporalLayerIndex =
         DePacketizer.VP8PayloadDescriptor.hasTemporalLayerIndex(buffer, payloadOffset, payloadLength)
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp9/Vp9Packet.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp9/Vp9Packet.kt
@@ -68,6 +68,12 @@ class Vp9Packet private constructor(
     override val isEndOfFrame: Boolean =
         isEndOfFrame ?: DePacketizer.VP9PayloadDescriptor.isEndOfFrame(buffer, payloadOffset, payloadLength)
 
+    override fun meetsRoutingNeeds(): Boolean {
+        // Question: should we include hasLayerIndices here?  I.e. if we get a VP9 packet with an AV1 DD and
+        // a VP9 picture ID, but no VP9 layer indices, are we better off parsing it as VP9 or AV1?
+        return hasPictureId
+    }
+
     override val layerIds: Collection<Int>
         get() = if (hasLayerIndices) {
             listOf(RtpLayerDesc.getIndex(0, spatialLayerIndex, temporalLayerIndex))

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
@@ -135,11 +135,11 @@ class VideoParser(
          * so the count is correct. */
         /* Alternately we could keep track of keyframes we've already seen, by timestamp, but that seems unnecessary. */
         if (parsedPacket != null && parsedPacket.isKeyframe && parsedPacket.isStartOfFrame) {
-            logger.cdebug { "Received a keyframe for ssrc ${packet.ssrc} ${packet.sequenceNumber}" }
+            logger.cdebug { "Received a keyframe for ssrc ${packet.ssrc} at seq ${packet.sequenceNumber}" }
             stats.numKeyframes++
         }
         if (packetInfo.layeringChanged) {
-            logger.cdebug { "Layering structure changed for ssrc ${packet.ssrc} ${packet.sequenceNumber}" }
+            logger.cdebug { "Layering structure changed for ssrc ${packet.ssrc} at seq ${packet.sequenceNumber}" }
             stats.numLayeringChanges++
         }
 
@@ -196,8 +196,8 @@ class VideoParser(
             ?: // VideoQualityLayerLookup will drop this packet later, so no need to warn about it now
             return null
         logger.cdebug {
-            "Creating new ${T::class.java} for source ${source.sourceName}, " +
-                "current videoCodecParser is ${parser?.javaClass}"
+            "Creating new ${T::class.java.simpleName} for source ${source.sourceName}, " +
+                "current videoCodecParser is ${parser?.javaClass?.simpleName}"
         }
         resetSource(source)
         packetInfo.layeringChanged = true


### PR DESCRIPTION
If the packets don't have the necessary fields to be routed as their payload type, but they do have an AV1 DD, route them based on the AV1 DD instead.