### PR TITLE
ref(test): Disable kotest classpath autoscan

### DIFF
--- a/jitsi-media-transform/pom.xml
+++ b/jitsi-media-transform/pom.xml
@@ -240,6 +240,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
                 <configuration>
+                    <systemPropertyVariables>
+                        <kotest.framework.classpath.scanning.autoscan.disable>true</kotest.framework.classpath.scanning.autoscan.disable>
+                    </systemPropertyVariables>
                     <excludes>
                         <!-- init() currently throws an exception -->
                         <exclude>DtlsStackTest.*</exclude>

--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -468,6 +468,7 @@
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.config.file>${project.basedir}/lib/logging.properties</java.util.logging.config.file>
+            <kotest.framework.classpath.scanning.autoscan.disable>true</kotest.framework.classpath.scanning.autoscan.disable>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/rtp/pom.xml
+++ b/rtp/pom.xml
@@ -173,6 +173,11 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <kotest.framework.classpath.scanning.autoscan.disable>true</kotest.framework.classpath.scanning.autoscan.disable>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
               <groupId>com.github.gantsign.maven</groupId>


### PR DESCRIPTION
This change reduces test execution time by about 1 min (30%) on my
machine.

Since the update to kotest 5.9 the following warning gets printed during
tests:
Warning: Kotest autoscan is enabled. This means Kotest will scan the classpath for extensions that are annotated with @AutoScan. To avoid this startup cost, disable autoscan by setting the system property 'kotest.framework.classpath.scanning.autoscan.disable=true'. In 6.0 this value will default to true. For further details see https://kotest.io/docs/next/framework/project-config.html#runtime-detection
