### PR TITLE
Fix(dcsctp): Fix memory leak.

### DIFF
--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-dcsctp</artifactId>
-      <version>1.0-2-g2d8eee4</version>
+      <version>1.0-3-gaf9d564</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
     <!-- we inherit an old version of slf4j-api from tinder, which pcap4j doesn't work with. Adding slf4j-api 1.7.30 (the current stable) as a dep of jvb fixes the problem. -->


### PR DESCRIPTION
There were reference cycles through JNI, which the garbage collector can't detect.