### PR TITLE
Fix jetty versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <kotest.version>5.9.1</kotest.version>
         <junit.version>5.10.2</junit.version>
         <jitsi.utils.version>1.0-132-g83984af</jitsi.utils.version>
-        <jicoco.version>1.1-140-g8f45a9f</jicoco.version>
+        <jicoco.version>1.1-141-g87749d2</jicoco.version>
         <mockk.version>1.13.11</mockk.version>
         <ktlint-maven-plugin.version>3.2.0</ktlint-maven-plugin.version>
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
         <ktlint-maven-plugin.version>3.2.0</ktlint-maven-plugin.version>
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
         <spotbugs.version>4.6.0</spotbugs.version>
-        <jersey.version>3.1.7</jersey.version>
         <jackson.version>2.17.1</jackson.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
+        <jersey.version>3.0.10</jersey.version>
         <prometheus.version>0.16.0</prometheus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <kotest.version>5.9.1</kotest.version>
         <junit.version>5.10.2</junit.version>
         <jitsi.utils.version>1.0-132-g83984af</jitsi.utils.version>
-        <jicoco.version>1.1-141-g87749d2</jicoco.version>
+        <jicoco.version>1.1-141-g30ec741</jicoco.version>
         <mockk.version>1.13.11</mockk.version>
         <ktlint-maven-plugin.version>3.2.0</ktlint-maven-plugin.version>
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>


### PR DESCRIPTION
- **chore: Update jicoco.**
- **fix(#2184): Revert "chore(deps): Bump jersey.version from 3.0.10 to 3.1.7 (#2145)"**
