### PR TITLE
Remove use-component-socket, cleanup

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -15,7 +15,6 @@
  */
 package org.jitsi.videobridge;
 
-import kotlin.*;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.*;
 import org.jitsi.health.Result;
@@ -28,7 +27,6 @@ import org.jitsi.videobridge.load_management.*;
 import org.jitsi.videobridge.metrics.*;
 import org.jitsi.videobridge.shutdown.*;
 import org.jitsi.videobridge.stats.*;
-import org.jitsi.videobridge.util.*;
 import org.jitsi.videobridge.xmpp.*;
 import org.jitsi.xmpp.extensions.colibri2.*;
 import org.jitsi.xmpp.extensions.health.*;
@@ -102,20 +100,6 @@ public class Videobridge
     @NotNull private final Version version;
 
     @NotNull private final ShutdownManager shutdownManager;
-
-    static
-    {
-        org.jitsi.rtp.util.BufferPool.Companion.setGetArray(ByteBufferPool::getBuffer);
-        org.jitsi.rtp.util.BufferPool.Companion.setReturnArray(buffer -> {
-            ByteBufferPool.returnBuffer(buffer);
-            return Unit.INSTANCE;
-        });
-        org.jitsi.nlj.util.BufferPool.Companion.setGetBuffer(ByteBufferPool::getBuffer);
-        org.jitsi.nlj.util.BufferPool.Companion.setReturnBuffer(buffer -> {
-            ByteBufferPool.returnBuffer(buffer);
-            return Unit.INSTANCE;
-        });
-    }
 
     /**
      * Initializes a new <tt>Videobridge</tt> instance.

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
@@ -37,6 +37,7 @@ import org.jitsi.videobridge.metrics.Metrics
 import org.jitsi.videobridge.metrics.VideobridgePeriodicMetrics
 import org.jitsi.videobridge.rest.root.Application
 import org.jitsi.videobridge.stats.MucPublisher
+import org.jitsi.videobridge.util.ByteBufferPool
 import org.jitsi.videobridge.util.TaskPools
 import org.jitsi.videobridge.util.UlimitCheck
 import org.jitsi.videobridge.version.JvbVersionService
@@ -77,6 +78,8 @@ fun main() {
 
     UlimitCheck.printUlimits()
     startIce4j()
+
+    setupBufferPools()
 
     // Initialize, binding on the main ICE port.
     Harvesters.init()
@@ -228,4 +231,12 @@ private fun startIce4j() {
 private fun stopIce4j() {
     // Shut down harvesters.
     Harvesters.close()
+}
+
+/** Configure our libraries to use JVB's global [ByteBufferPool] */
+private fun setupBufferPools() {
+    org.jitsi.rtp.util.BufferPool.getArray = { ByteBufferPool.getBuffer(it) }
+    org.jitsi.rtp.util.BufferPool.returnArray = { ByteBufferPool.returnBuffer(it) }
+    org.jitsi.nlj.util.BufferPool.getBuffer = { ByteBufferPool.getBuffer(it) }
+    org.jitsi.nlj.util.BufferPool.returnBuffer = { ByteBufferPool.returnBuffer(it) }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/ice/IceConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/ice/IceConfig.kt
@@ -83,14 +83,6 @@ class IceConfig private constructor() {
             .convertFrom<String> { KeepAliveStrategy.fromString(it) }
     }
 
-    /**
-     * Whether the ice4j "component socket" mode is used.
-     */
-    val useComponentSocket: Boolean by config {
-        "org.jitsi.videobridge.USE_COMPONENT_SOCKET".from(JitsiConfig.legacyConfig)
-        "videobridge.ice.use-component-socket".from(JitsiConfig.newConfig)
-    }
-
     val resolveRemoteCandidates: Boolean by config(
         "videobridge.ice.resolve-remote-candidates".from(JitsiConfig.newConfig)
     )

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
@@ -131,8 +131,7 @@ class IceTransport @JvmOverloads constructor(
         logger.addContext("local_ufrag", it.localUfrag)
     }
 
-    // TODO: Do we still need the id here now that we have logContext?
-    private val iceStream = iceAgent.createMediaStream("stream-$id").apply {
+    private val iceStream = iceAgent.createMediaStream("stream").apply {
         addPairChangeListener(iceStreamPairChangedListener)
     }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
@@ -136,14 +136,8 @@ class IceTransport @JvmOverloads constructor(
         addPairChangeListener(iceStreamPairChangedListener)
     }
 
-    private val iceComponent = iceAgent.createComponent(
-        iceStream,
-        IceConfig.config.keepAliveStrategy,
-        IceConfig.config.useComponentSocket
-    )
-
+    private val iceComponent = iceAgent.createComponent(iceStream, IceConfig.config.keepAliveStrategy, true)
     private val packetStats = PacketStats()
-
     val icePassword: String
         get() = iceAgent.localPassword
 
@@ -263,7 +257,6 @@ class IceTransport @JvmOverloads constructor(
     }
 
     fun getDebugState(): OrderedJsonObject = OrderedJsonObject().apply {
-        put("useComponentSocket", IceConfig.config.useComponentSocket)
         put("keepAliveStrategy", IceConfig.config.keepAliveStrategy.toString())
         put("nominationStrategy", IceConfig.config.nominationStrategy.toString())
         put("advertisePrivateCandidates", IceConfig.config.advertisePrivateCandidates)

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -289,9 +289,6 @@ videobridge {
     # "selected_and_tcp", "selected_only", or "all_succeeded".
     keep-alive-strategy = "selected_and_tcp"
 
-    # Whether to use the "component socket" feature of ice4j.
-    use-component-socket = true
-
     # Whether to attempt DNS resolution for remote candidates that contain a non-literal address. When set to 'false'
     # such candidates will be ignored.
     resolve-remote-candidates = false


### PR DESCRIPTION
Setting use-component-socket=false has been broken for a long time. We always read/write using the Component's socket:
https://github.com/jitsi/jitsi-videobridge/blob/877b6a2f0fdb98f440e094678116b3b090f59533/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt#L214
https://github.com/jitsi/jitsi-videobridge/blob/877b6a2f0fdb98f440e094678116b3b090f59533/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt#L245

- **ref: Move BufferPool setup to Main.**
- **ref: Remove the use-component-socket option.**
- **log: Remove endpoint ID from IceMediaStream name.**
