### PR TITLE
Don't feed SCTP packets to the SCTP stack after it's been closed.

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -1115,7 +1115,7 @@ class Endpoint @JvmOverloads constructor(
             sctpHandler?.stop()
             usrSctpHandler?.stop()
             sctpManager?.closeConnection()
-            sctpTransport?.socket?.close()
+            sctpTransport?.stop()
         } catch (t: Throwable) {
             logger.error("Exception while expiring: ", t)
         }
@@ -1249,7 +1249,7 @@ class Endpoint @JvmOverloads constructor(
                 val dataChannelStack = DataChannelStack(
                     { data, sid, ppid ->
                         val message = DcSctpMessage(sid.toShort(), ppid, data.array())
-                        val status = sctpTransport?.socket?.send(message, DcSctpTransport.DEFAULT_SEND_OPTIONS)
+                        val status = sctpTransport?.send(message, DcSctpTransport.DEFAULT_SEND_OPTIONS)
                         return@DataChannelStack if (status == SendStatus.kSuccess) {
                             0
                         } else {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -1240,7 +1240,7 @@ class Endpoint @JvmOverloads constructor(
         }
 
         override fun OnAborted(error: ErrorKind, message: String) {
-            logger.warn("SCTP aborted with error $error: $message")
+            logger.info("SCTP aborted with error $error: $message")
         }
 
         override fun OnConnected() {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
@@ -439,7 +439,7 @@ class Relay @JvmOverloads constructor(
                     scheduleRelayMessageTransportTimeout()
                 } else if (sctpConfig.enabled) {
                     if (sctpRole == Sctp.Role.CLIENT) {
-                        sctpTransport!!.socket.connect()
+                        sctpTransport!!.connect()
                     }
                 }
             }
@@ -498,7 +498,7 @@ class Relay @JvmOverloads constructor(
             it.start(SctpCallbacks(it))
             sctpHandler!!.setSctpTransport(it)
             if (dtlsTransport.isConnected && sctpDesc.role == Sctp.Role.CLIENT) {
-                it.socket.connect()
+                it.connect()
             }
         }
     }
@@ -1172,7 +1172,7 @@ class Relay @JvmOverloads constructor(
             sctpHandler?.stop()
             usrSctpHandler?.stop()
             sctpManager?.closeConnection()
-            sctpTransport?.socket?.close()
+            sctpTransport?.stop()
         } catch (t: Throwable) {
             logger.error("Exception while expiring: ", t)
         }
@@ -1275,7 +1275,7 @@ class Relay @JvmOverloads constructor(
                 val dataChannelStack = DataChannelStack(
                     { data, sid, ppid ->
                         val message = DcSctpMessage(sid.toShort(), ppid, data.array())
-                        val status = sctpTransport?.socket?.send(message, DcSctpTransport.DEFAULT_SEND_OPTIONS)
+                        val status = sctpTransport?.send(message, DcSctpTransport.DEFAULT_SEND_OPTIONS)
                         return@DataChannelStack if (status == SendStatus.kSuccess) {
                             0
                         } else {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
@@ -1266,7 +1266,7 @@ class Relay @JvmOverloads constructor(
         }
 
         override fun OnAborted(error: ErrorKind, message: String) {
-            logger.warn("SCTP aborted with error $error: $message")
+            logger.info("SCTP aborted with error $error: $message")
         }
 
         override fun OnConnected() {


### PR DESCRIPTION
(It results in harmless-but-scary warnings in the logs about verification tags being wrong.)