### PR TITLE
Fix RTT when SSRC rewriting is enabled.

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -143,7 +143,8 @@ class RtpSenderImpl(
         outgoingRtpRoot = pipeline {
             node(object : TransformerNode("Pre-processor") {
                 override fun transform(packetInfo: PacketInfo): PacketInfo? {
-                    return preProcesor?.invoke(packetInfo) ?: packetInfo
+                    preProcesor?.let { return it.invoke(packetInfo) }
+                    return packetInfo
                 }
                 override fun trace(f: () -> Unit) {}
             })

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -403,6 +403,7 @@ class PluggableTransformerNode(
         return packetInfo
     }
     override fun trace(f: () -> Unit) {}
+    override val aggregationKey = this.name
 }
 
 /**

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -393,6 +393,18 @@ abstract class TransformerNode(name: String) : StatsKeepingNode(name) {
     }
 }
 
+/** A [TransformerNode] which gets its transformation function dynamically. */
+class PluggableTransformerNode(
+    name: String,
+    val transform: () -> ((PacketInfo) -> PacketInfo?)?
+) : TransformerNode(name) {
+    override fun transform(packetInfo: PacketInfo): PacketInfo? {
+        transform()?.let { return it.invoke(packetInfo) }
+        return packetInfo
+    }
+    override fun trace(f: () -> Unit) {}
+}
+
 /**
  * Unlike a [TransformerNode], [ModifierNode] modifies a packet in-place and never
  * outright 'fails', meaning the original [PacketInfo] will *always* be forwarded.


### PR DESCRIPTION
- **fix: Drop the packet if a preProcessor exists and rejects it.**
- **fix: Also pre-process RTCP packets.**
- **fix: Move the notifyRtcpSent call to the sender pipeline.**


Reported by Philldomd here https://community.jitsi.org/t/version-9646-changes-websocket-removed-and-with-that-rtt-and-jitter-became-0-on-metrics/134871/8