### PR TITLE
Do not signal mappings for disabled sources.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/xmpp/MediaSourceFactory.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/xmpp/MediaSourceFactory.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.xmpp;
 
+import org.jetbrains.annotations.*;
 import org.jitsi.nlj.*;
 import org.jitsi.nlj.rtp.*;
 import org.jitsi.nlj.rtp.codec.vpx.*;
@@ -536,12 +537,10 @@ public class MediaSourceFactory
     {
         final Collection<SourceGroupPacketExtension> finalSourceGroups
                 = sourceGroups == null ? new ArrayList<>() : sourceGroups;
-        if (sources == null)
-        {
-            sources = new ArrayList<>();
-        }
+        final Collection<SourcePacketExtension> finalSources
+                = sources == null ? new ArrayList<>() : sources;
 
-        List<SourceSsrcs> sourceSsrcsList = getSourceSsrcs(sources, finalSourceGroups);
+        List<SourceSsrcs> sourceSsrcsList = getSourceSsrcs(finalSources, finalSourceGroups);
         List<MediaSourceDesc> mediaSources = new ArrayList<>();
 
         sourceSsrcsList.forEach(sourceSsrcs -> {
@@ -567,7 +566,8 @@ public class MediaSourceFactory
                         numTemporalLayersPerStream,
                         secondarySsrcs,
                         sourceSsrcs.owner,
-                        sourceSsrcs.name
+                        sourceSsrcs.name,
+                        getVideoType(finalSources)
             );
             mediaSources.add(mediaSource);
         });
@@ -624,7 +624,8 @@ public class MediaSourceFactory
                     numTemporalLayersPerStream,
                     secondarySsrcs,
                     owner,
-                    name
+                    name,
+                    getVideoType(sources)
             );
         }
         else
@@ -779,7 +780,8 @@ public class MediaSourceFactory
             int numTemporalLayersPerStream,
             Map<Long, SecondarySsrcs> allSecondarySsrcs,
             String owner,
-            String name
+            String name,
+            VideoType videoType
     )
     {
         RtpEncodingDesc[] encodings =
@@ -817,6 +819,18 @@ public class MediaSourceFactory
             throw new IllegalArgumentException("The 'owner' is missing in the source description");
         }
 
-        return new MediaSourceDesc(encodings, owner, name);
+        return new MediaSourceDesc(encodings, owner, name, videoType);
+    }
+
+    private static VideoType getVideoType(@NotNull Collection<SourcePacketExtension> sources)
+    {
+        for (SourcePacketExtension source : sources)
+        {
+            if (source.getVideoType() != null)
+            {
+                return VideoType.valueOf(source.getVideoType().toUpperCase());
+            }
+        }
+        return VideoType.CAMERA;
     }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpoint.kt
@@ -106,6 +106,12 @@ abstract class AbstractEndpoint protected constructor(
         val mediaSourceDesc = findMediaSourceDesc(sourceName)
         if (mediaSourceDesc != null) {
             if (mediaSourceDesc.videoType !== videoType) {
+                if (mediaSourceDesc.videoType.isEnabled() && videoType.isEnabled()) {
+                    logger.warn(
+                        "Changing video type from ${mediaSourceDesc.videoType} to $videoType for $sourceName. " +
+                                "This will not trigger re-signaling the mapping."
+                    )
+                }
                 mediaSourceDesc.videoType = videoType
                 conference.speechActivity.endpointVideoAvailabilityChanged()
             }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpoint.kt
@@ -109,7 +109,7 @@ abstract class AbstractEndpoint protected constructor(
                 if (mediaSourceDesc.videoType.isEnabled() && videoType.isEnabled()) {
                     logger.warn(
                         "Changing video type from ${mediaSourceDesc.videoType} to $videoType for $sourceName. " +
-                                "This will not trigger re-signaling the mapping."
+                            "This will not trigger re-signaling the mapping."
                     )
                 }
                 mediaSourceDesc.videoType = videoType

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -603,7 +603,9 @@ class Endpoint @JvmOverloads constructor(
 
         if (doSsrcRewriting) {
             val newActiveSources =
-                newEffectiveConstraints.entries.filter { !it.value.isDisabled() }.map { it.key }.toList()
+                newEffectiveConstraints.entries.filter {
+                    !it.value.isDisabled() && it.key.videoType.isEnabled()
+                }.map { it.key }.toList()
             val newActiveSourceNames = newActiveSources.map { it.sourceName }.toSet()
             /* safe unlocked access of activeSources. BitrateController will not overlap calls to this method. */
             if (activeSources != newActiveSourceNames) {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocation.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocation.kt
@@ -45,8 +45,8 @@ class BandwidthAllocation @JvmOverloads constructor(
         allocations.all { allocation ->
             other.allocations.any { otherAllocation ->
                 allocation.endpointId == otherAllocation.endpointId &&
-                    allocation.mediaSource?.primarySSRC ==
-                    otherAllocation.mediaSource?.primarySSRC &&
+                    allocation.mediaSource?.primarySSRC == otherAllocation.mediaSource?.primarySSRC &&
+                    allocation.mediaSource?.videoType == otherAllocation.mediaSource?.videoType &&
                     allocation.targetLayer?.index == otherAllocation.targetLayer?.index
             }
         }


### PR DESCRIPTION
This fixes an issue when a receiver joins a conference and one of the senders has a disabled source. The source was signaled with type NONE, which is not handled correctly by receivers. 

- **fix: Do not signal mappings for disabled sources.**
- **feat: Read initial VideoType from colibri.**
- **feat: Log a warning when video type changes between CAMERA and DESKTOP.**

