### PR TITLE
Enable XMPP stream resumption

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/metrics/VideobridgeMetrics.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/metrics/VideobridgeMetrics.kt
@@ -247,6 +247,11 @@ object VideobridgeMetrics {
         "Total duration of video received, in milliseconds (each SSRC counts separately)."
     )
 
+    val xmppDisconnects = metricsContainer.registerCounter(
+        "xmpp_disconnects",
+        "The number of times one of the XMPP connections has disconnected."
+    )
+
     private val tossedPacketsEnergyBuckets =
         listOf(0, 7, 15, 23, 31, 39, 47, 55, 63, 71, 79, 87, 95, 103, 111, 119, 127).map { it.toDouble() }
             .toDoubleArray()

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <kotest.version>5.9.1</kotest.version>
         <junit.version>5.10.2</junit.version>
         <jitsi.utils.version>1.0-133-g6af1020</jitsi.utils.version>
-        <jicoco.version>1.1-143-g175c44b</jicoco.version>
+        <jicoco.version>1.1-148-g3afa2ac</jicoco.version>
         <mockk.version>1.13.11</mockk.version>
         <ktlint-maven-plugin.version>3.2.0</ktlint-maven-plugin.version>
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>


### PR DESCRIPTION
- **feat: Add a metric for XMPP disconnects.**
- **chore: Update jicoco to 1.1-148 (enable XMPP SM)   feat: Add an endpointId field to StartEvent.   feat: Move jwt utils from jibri into jicoco-jwt.   chore: Update jitsi-metaconfig.   Add Java 21 to GitHub testing matrix   feat: Enables stream resumption.**
