### PR TITLE
Support "no signature" signers on local X.509 certificates.

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/AlgUnsignedSigner.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/AlgUnsignedSigner.kt
@@ -1,18 +1,17 @@
 package org.jitsi.nlj.dtls
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
-import org.bouncycastle.asn1.DERNull
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
 import org.bouncycastle.operator.ContentSigner
 import java.io.OutputStream
 
 /**
- * A "signing" algorithm which produces an empty signature.  Based on
- * draft-davidben-x509-alg-none.
+ * A "signing" algorithm which produces an empty signature.  Defined by
+ * draft-ietf-lamps-x509-alg-none, current implementation based on version -05.
  * Should be treated as an unknown algorithm by all recipients, so any attempt to
  * validate it will return false.
  */
-class NoSignatureSigner : ContentSigner {
+class AlgUnsignedSigner : ContentSigner {
     override fun getAlgorithmIdentifier(): AlgorithmIdentifier {
         return identifier
     }
@@ -31,17 +30,9 @@ class NoSignatureSigner : ContentSigner {
     companion object {
         private val identifier = AlgorithmIdentifier(
             /*
-             id-pkix OBJECT IDENTIFIER  ::= { iso(1) identified-organization(3)
-                  dod(6) internet(1) security(5) mechanisms(5) pkix(7) }
-
-              id-alg-noSignature OBJECT IDENTIFIER ::= {id-pkix id-alg(6) 2}
+                id-alg-unsigned OBJECT IDENTIFIER ::= {1 3 6 1 5 5 7 6 36}
              */
-            ASN1ObjectIdentifier("1.3.6.1.5.5.7.6.2"),
-            /*
-            The parameters for id-alg-noSignature MUST be present
-               and MUST be encoded as NULL.
-             */
-            DERNull.INSTANCE
+            ASN1ObjectIdentifier("1.3.6.1.5.5.7.6.36")
         )
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/AlgUnsignedSigner.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/AlgUnsignedSigner.kt
@@ -6,8 +6,7 @@ import org.bouncycastle.operator.ContentSigner
 import java.io.OutputStream
 
 /**
- * A "signing" algorithm which produces an empty signature.  Defined by
- * draft-ietf-lamps-x509-alg-none, current implementation based on version -05.
+ * A "signing" algorithm which produces an empty signature.  Defined by RFC 9925.
  * Should be treated as an unknown algorithm by all recipients, so any attempt to
  * validate it will return false.
  */

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsConfig.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsConfig.kt
@@ -54,8 +54,8 @@ class DtlsConfig private constructor() {
         }
     }
 
-    val useNoSignatureSigner: Boolean by config {
-        "jmt.dtls.use-no-signature-signer".from(JitsiConfig.newConfig)
+    val useAlgUnsigned: Boolean by config {
+        "jmt.dtls.use-alg-unsigned".from(JitsiConfig.newConfig)
     }
 
     companion object {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsConfig.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsConfig.kt
@@ -54,6 +54,10 @@ class DtlsConfig private constructor() {
         }
     }
 
+    val useNoSignatureSigner: Boolean by config {
+        "jmt.dtls.use-no-signature-signer".from(JitsiConfig.newConfig)
+    }
+
     companion object {
         val config = DtlsConfig()
     }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsUtils.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsUtils.kt
@@ -112,8 +112,8 @@ class DtlsUtils {
                 subject,
                 keyPair.public
             )
-            val signer = if (config.useNoSignatureSigner) {
-                NoSignatureSigner()
+            val signer = if (config.useAlgUnsigned) {
+                AlgUnsignedSigner()
             } else {
                 JcaContentSignerBuilder("SHA256withECDSA").build(keyPair.private)
             }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsUtils.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsUtils.kt
@@ -112,7 +112,11 @@ class DtlsUtils {
                 subject,
                 keyPair.public
             )
-            val signer = JcaContentSignerBuilder("SHA256withECDSA").build(keyPair.private)
+            val signer = if (config.useNoSignatureSigner) {
+                NoSignatureSigner()
+            } else {
+                JcaContentSignerBuilder("SHA256withECDSA").build(keyPair.private)
+            }
 
             return certBuilder.build(signer).toASN1Structure()
         }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsUtils.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsUtils.kt
@@ -112,7 +112,7 @@ class DtlsUtils {
                 subject,
                 keyPair.public
             )
-            val signer = if (config.useAlgUnsigned) {
+            val signer = if (DtlsConfig.config.useAlgUnsigned) {
                 AlgUnsignedSigner()
             } else {
                 JcaContentSignerBuilder("SHA256withECDSA").build(keyPair.private)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/NoSignatureSigner.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/NoSignatureSigner.kt
@@ -1,6 +1,7 @@
 package org.jitsi.nlj.dtls
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
+import org.bouncycastle.asn1.DERNull
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
 import org.bouncycastle.operator.ContentSigner
 import java.io.OutputStream
@@ -21,13 +22,26 @@ class NoSignatureSigner : ContentSigner {
     }
 
     override fun getSignature(): ByteArray {
+        /*
+        The Certificate's signatureValue field MUST be a BIT STRING of length zero.
+         */
         return ByteArray(0)
     }
 
     companion object {
-        // A random OID we're squatting on, in the Columbia University number space.
-        // (Registered in 1997, apparently unused since then.)
-        // To be replaced with an IETF-assigned one if and when one is assigned.
-        private val identifier = AlgorithmIdentifier(ASN1ObjectIdentifier("1.2.840.113560.420.69"))
+        private val identifier = AlgorithmIdentifier(
+            /*
+             id-pkix OBJECT IDENTIFIER  ::= { iso(1) identified-organization(3)
+                  dod(6) internet(1) security(5) mechanisms(5) pkix(7) }
+
+              id-alg-noSignature OBJECT IDENTIFIER ::= {id-pkix id-alg(6) 2}
+             */
+            ASN1ObjectIdentifier("1.3.6.1.5.5.7.6.2"),
+            /*
+            The parameters for id-alg-noSignature MUST be present
+               and MUST be encoded as NULL.
+             */
+            DERNull.INSTANCE
+        )
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/NoSignatureSigner.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/NoSignatureSigner.kt
@@ -1,0 +1,33 @@
+package org.jitsi.nlj.dtls
+
+import org.bouncycastle.asn1.ASN1ObjectIdentifier
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier
+import org.bouncycastle.operator.ContentSigner
+import java.io.OutputStream
+
+/**
+ * A "signing" algorithm which produces an empty signature.  Based on
+ * draft-davidben-x509-alg-none.
+ * Should be treated as an unknown algorithm by all recipients, so any attempt to
+ * validate it will return false.
+ */
+class NoSignatureSigner : ContentSigner {
+    override fun getAlgorithmIdentifier(): AlgorithmIdentifier {
+        return identifier
+    }
+
+    override fun getOutputStream(): OutputStream {
+        return OutputStream.nullOutputStream()
+    }
+
+    override fun getSignature(): ByteArray {
+        return ByteArray(0)
+    }
+
+    companion object {
+        // A random OID we're squatting on, in the Columbia University number space.
+        // (Registered in 1997, apparently unused since then.)
+        // To be replaced with an IETF-assigned one if and when one is assigned.
+        private val identifier = AlgorithmIdentifier(ASN1ObjectIdentifier("1.2.840.113560.420.69"))
+    }
+}

--- a/jitsi-media-transform/src/main/resources/reference.conf
+++ b/jitsi-media-transform/src/main/resources/reference.conf
@@ -64,8 +64,8 @@ jmt {
     local-fingerprint-hash-function = sha-256
     // The hash functions that are accepted for remote certificate fingerprints, in decreasing strength order
     accepted-fingerprint-hash-functions = [ sha-512, sha-384, sha-256, sha-1 ]
-    // Whether to use the "no-signature" signer rather than self-signing the local certificate
-    use-no-signature-signer = true
+    // Whether to use "alg-unsigned" rather than self-signing the local certificate
+    use-alg-unsigned = true
   }
   keyframe {
     // The minimum interval between consecutive keyframe requests from a particular receiver for a media source.

--- a/jitsi-media-transform/src/main/resources/reference.conf
+++ b/jitsi-media-transform/src/main/resources/reference.conf
@@ -64,7 +64,8 @@ jmt {
     local-fingerprint-hash-function = sha-256
     // The hash functions that are accepted for remote certificate fingerprints, in decreasing strength order
     accepted-fingerprint-hash-functions = [ sha-512, sha-384, sha-256, sha-1 ]
-
+    // Whether to use the "no-signature" signer rather than self-signing the local certificate
+    use-no-signature-signer = true
   }
   keyframe {
     // The minimum interval between consecutive keyframe requests from a particular receiver for a media source.


### PR DESCRIPTION
As defined in ~~draft-davidben-x509-alg-none~~ RFC 9925.