### PR TITLE
Add support for the VLA RTP header extension

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
@@ -53,7 +53,7 @@ abstract class RtpLayerDesc(
      * represents. The actual frame rate may be less due to bad network or
      * system load.  [NO_FRAME_RATE] for unknown.
      */
-    val frameRate: Double,
+    var frameRate: Double,
 ) {
     abstract fun copy(height: Int = this.height, tid: Int = this.tid, inherit: Boolean = true): RtpLayerDesc
 
@@ -61,6 +61,8 @@ abstract class RtpLayerDesc(
      * The [BitrateTracker] instance used to calculate the receiving bitrate of this RTP layer.
      */
     protected var bitrateTracker = BitrateCalculator.createBitrateTracker()
+
+    var targetBitrate: Bandwidth? = null
 
     /**
      * @return the "id" of this layer within this encoding. This is a server-side id and should
@@ -86,6 +88,7 @@ abstract class RtpLayerDesc(
      */
     internal open fun inheritFrom(other: RtpLayerDesc) {
         inheritStatistics(other.bitrateTracker)
+        targetBitrate = other.targetBitrate
     }
 
     /**
@@ -124,6 +127,7 @@ abstract class RtpLayerDesc(
         addNumber("height", height)
         addNumber("index", index)
         addNumber("bitrate_bps", getBitrate(System.currentTimeMillis()).bps)
+        addNumber("target_bitrate", targetBitrate?.bps ?: 0)
     }
 
     fun debugState(): OrderedJsonObject = getNodeStats().toJson().apply { put("indexString", indexString()) }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
@@ -28,8 +28,7 @@ import org.jitsi.utils.OrderedJsonObject
  *
  * @author George Politis
  */
-abstract class RtpLayerDesc
-constructor(
+abstract class RtpLayerDesc(
     /**
      * The index of this instance's encoding in the source encoding array.
      */
@@ -109,12 +108,6 @@ constructor(
      * @return the cumulative bitrate (in bps) of this [RtpLayerDesc] and its dependencies.
      */
     abstract fun getBitrate(nowMs: Long): Bandwidth
-
-    /**
-     * Expose [getBitrate] as a [Double] in order to make it accessible from java (since [Bandwidth] is an inline
-     * class).
-     */
-    fun getBitrateBps(nowMs: Long): Double = getBitrate(nowMs).bps
 
     /**
      * Recursively checks this layer and its dependencies to see if the bitrate is zero.

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -56,6 +56,7 @@ import org.jitsi.nlj.transform.node.incoming.VideoBitrateCalculator
 import org.jitsi.nlj.transform.node.incoming.VideoMuteNode
 import org.jitsi.nlj.transform.node.incoming.VideoParser
 import org.jitsi.nlj.transform.node.incoming.VideoQualityLayerLookup
+import org.jitsi.nlj.transform.node.incoming.VlaReaderNode
 import org.jitsi.nlj.transform.packetPath
 import org.jitsi.nlj.transform.pipeline
 import org.jitsi.nlj.util.Bandwidth
@@ -248,6 +249,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
                                     node(videoParser)
                                     node(VideoQualityLayerLookup(logger))
                                     node(videoBitrateCalculator)
+                                    node(VlaReaderNode(streamInformationStore, logger))
                                     node(packetHandlerWrapper)
                                 }
                             }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSender.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSender.kt
@@ -16,6 +16,7 @@
 package org.jitsi.nlj
 
 import org.jitsi.nlj.rtp.LossListener
+import org.jitsi.nlj.rtp.RtpExtensionType
 import org.jitsi.nlj.rtp.TransportCcEngine
 import org.jitsi.nlj.rtp.bandwidthestimation.BandwidthEstimator
 import org.jitsi.nlj.srtp.SrtpTransformers
@@ -47,6 +48,7 @@ abstract class RtpSender :
     abstract fun setFeature(feature: Features, enabled: Boolean)
     abstract fun isFeatureEnabled(feature: Features): Boolean
     abstract fun tearDown()
+    abstract fun addRtpExtensionToRetain(extensionType: RtpExtensionType)
 
     /**
      * An optional function to be executed for each RTP packet, as the first step of the send pipeline.

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -23,6 +23,7 @@ import org.jitsi.nlj.rtcp.NackHandler
 import org.jitsi.nlj.rtcp.RtcpEventNotifier
 import org.jitsi.nlj.rtcp.RtcpSrUpdater
 import org.jitsi.nlj.rtp.LossListener
+import org.jitsi.nlj.rtp.RtpExtensionType
 import org.jitsi.nlj.rtp.TransportCcEngine
 import org.jitsi.nlj.rtp.bandwidthestimation.BandwidthEstimator
 import org.jitsi.nlj.rtp.bandwidthestimation.GoogleCcEstimator
@@ -111,6 +112,7 @@ class RtpSenderImpl(
     private val srtcpEncryptWrapper = SrtcpEncryptNode()
     private val toggleablePcapWriter = ToggleablePcapWriter(logger, "$id-tx")
     private val outgoingPacketCache = PacketCacher()
+    private val headerExtensionStripper = HeaderExtStripper(streamInformationStore)
     private val absSendTime = AbsSendTime(streamInformationStore)
     private val statsTracker = OutgoingStatisticsTracker()
     private val packetStreamStats = PacketStreamStatsNode()
@@ -144,7 +146,7 @@ class RtpSenderImpl(
         outgoingRtpRoot = pipeline {
             node(PluggableTransformerNode("RTP pre-processor") { preProcesor })
             node(AudioRedHandler(streamInformationStore, logger))
-            node(HeaderExtStripper(streamInformationStore))
+            node(headerExtensionStripper)
             node(outgoingPacketCache)
             node(absSendTime)
             node(statsTracker)
@@ -331,6 +333,10 @@ class RtpSenderImpl(
         NodeTeardownVisitor().reverseVisit(outputPipelineTerminationNode)
         incomingPacketQueue.close()
         toggleablePcapWriter.disable()
+    }
+
+    override fun addRtpExtensionToRetain(extensionType: RtpExtensionType) {
+        headerExtensionStripper.addRtpExtensionToRetain(extensionType)
     }
 
     companion object {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -18,6 +18,7 @@ package org.jitsi.nlj
 import org.jitsi.nlj.format.PayloadType
 import org.jitsi.nlj.rtcp.RtcpEventNotifier
 import org.jitsi.nlj.rtp.RtpExtension
+import org.jitsi.nlj.rtp.RtpExtensionType
 import org.jitsi.nlj.rtp.bandwidthestimation.BandwidthEstimator
 import org.jitsi.nlj.srtp.SrtpTransformers
 import org.jitsi.nlj.srtp.SrtpUtil
@@ -209,6 +210,10 @@ class Transceiver(
         val localSsrcSetEvent = SetLocalSsrcEvent(mediaType, ssrc)
         rtpSender.handleEvent(localSsrcSetEvent)
         rtpReceiver.handleEvent(localSsrcSetEvent)
+    }
+
+    fun addRtpExtensionToRetain(extensionType: RtpExtensionType) {
+        rtpSender.addRtpExtensionToRetain(extensionType)
     }
 
     fun receivesSsrc(ssrc: Long): Boolean = streamInformationStore.receiveSsrcs.contains(ssrc)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/RtpExtensions.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/RtpExtensions.kt
@@ -103,7 +103,13 @@ enum class RtpExtensionType(val uri: String) {
      */
     AV1_DEPENDENCY_DESCRIPTOR(
         "https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension"
-    );
+    ),
+
+    /**
+     * Video Layers Allocation
+     * https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/video-layers-allocation00
+     */
+    VLA("http://www.webrtc.org/experiments/rtp-hdrext/video-layers-allocation00");
 
     companion object {
         private val uriMap = RtpExtensionType.values().associateBy(RtpExtensionType::uri)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VlaReaderNode.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VlaReaderNode.kt
@@ -87,6 +87,14 @@ class VlaReaderNode(
                                 )
                                 layer.targetBitrate = targetBitrateKbps.kbps
                                 spatialLayer.res?.let { res ->
+                                    if (layer.height > 0 && layer.height != res.height) {
+                                        logger.warn("Updating layer height from ${layer.height} to ${res.height}")
+                                    }
+                                    if (layer.frameRate > 0.0 && layer.frameRate != res.maxFramerate.toDouble()) {
+                                        logger.warn(
+                                            "Updating layer frame rate from ${layer.frameRate} to ${res.maxFramerate}"
+                                        )
+                                    }
                                     layer.height = res.height
                                     layer.frameRate = res.maxFramerate.toDouble()
                                 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VlaReaderNode.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VlaReaderNode.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright @ 2024-Present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.nlj.transform.node.incoming
+
+import org.jitsi.nlj.Event
+import org.jitsi.nlj.MediaSourceDesc
+import org.jitsi.nlj.PacketInfo
+import org.jitsi.nlj.SetMediaSourcesEvent
+import org.jitsi.nlj.rtp.RtpExtensionType.VLA
+import org.jitsi.nlj.transform.node.ObserverNode
+import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
+import org.jitsi.rtp.rtp.RtpPacket
+import org.jitsi.rtp.rtp.header_extensions.VlaExtension
+import org.jitsi.utils.logging2.Logger
+import org.jitsi.utils.logging2.LoggerImpl
+import org.jitsi.utils.logging2.cdebug
+import org.jitsi.utils.logging2.createChildLogger
+
+/**
+ * A node which reads the Video Layers Allocation (VLA) RTP header extension and updates the media sources (TODO).
+ */
+class VlaReaderNode(
+    streamInformationStore: ReadOnlyStreamInformationStore,
+    parentLogger: Logger = LoggerImpl(VlaReaderNode::class.simpleName)
+) : ObserverNode("Video Layers Allocation reader") {
+    private val logger = createChildLogger(parentLogger)
+    private var vlaExtId: Int? = null
+    private var mediaSourceDescs: Array<MediaSourceDesc> = arrayOf()
+
+    init {
+        streamInformationStore.onRtpExtensionMapping(VLA) {
+            vlaExtId = it
+            logger.debug("VLA extension ID set to $it")
+        }
+    }
+
+    override fun handleEvent(event: Event) {
+        when (event) {
+            is SetMediaSourcesEvent -> {
+                mediaSourceDescs = event.mediaSourceDescs.copyOf()
+                logger.cdebug { "Media sources changed:\n${mediaSourceDescs.joinToString()}" }
+            }
+        }
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    override fun observe(packetInfo: PacketInfo) {
+        val rtpPacket = packetInfo.packetAs<RtpPacket>()
+        vlaExtId?.let {
+            rtpPacket.getHeaderExtension(it)?.let { ext ->
+                try {
+                    val vla = VlaExtension.parse(ext)
+                    // TODO update media sources
+                    logger.info(
+                        "VLA extension found: $vla " +
+                            "raw=${ext.buffer.toHexString(ext.dataOffset, ext.dataOffset + ext.dataLengthBytes)}"
+                    )
+                } catch (e: Exception) {
+                    logger.warn("Failed to parse VLA extension", e)
+                }
+            }
+        }
+    }
+
+    override fun trace(f: () -> Unit) {}
+}

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VlaReaderNode.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VlaReaderNode.kt
@@ -90,11 +90,6 @@ class VlaReaderNode(
                                     if (layer.height > 0 && layer.height != res.height) {
                                         logger.warn("Updating layer height from ${layer.height} to ${res.height}")
                                     }
-                                    if (layer.frameRate > 0.0 && layer.frameRate != res.maxFramerate.toDouble()) {
-                                        logger.warn(
-                                            "Updating layer frame rate from ${layer.frameRate} to ${res.maxFramerate}"
-                                        )
-                                    }
                                     layer.height = res.height
                                     layer.frameRate = res.maxFramerate.toDouble()
                                 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtStripper.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtStripper.kt
@@ -48,7 +48,7 @@ class HeaderExtStripper(
     }
 
     fun addRtpExtensionToRetain(extensionType: RtpExtensionType) {
-            retainedExtTypes += extensionType
+        retainedExtTypes += extensionType
     }
 
     override fun modify(packetInfo: PacketInfo): PacketInfo {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtStripper.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtStripper.kt
@@ -36,13 +36,13 @@ class HeaderExtStripper(
         retainedExtTypes.forEach { rtpExtensionType ->
             streamInformationStore.onRtpExtensionMapping(rtpExtensionType) {
                 it?.let {
-                    retainedExts = retainedExts.plus(it)
-                    retainedExtsWithAv1DD = retainedExtsWithAv1DD.plus(it)
+                    retainedExts += it
+                    retainedExtsWithAv1DD += it
                 }
             }
         }
         streamInformationStore.onRtpExtensionMapping(RtpExtensionType.AV1_DEPENDENCY_DESCRIPTOR) {
-            it?.let { retainedExtsWithAv1DD = retainedExtsWithAv1DD.plus(it) }
+            it?.let { retainedExtsWithAv1DD += it }
         }
     }
 
@@ -51,6 +51,7 @@ class HeaderExtStripper(
 
         val retained = if (rtpPacket is Av1DDPacket) retainedExtsWithAv1DD else retainedExts
 
+        // TODO: we should also retain any extensions that were not signaled.
         rtpPacket.removeHeaderExtensionsExcept(retained)
 
         return packetInfo

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtStripper.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/HeaderExtStripper.kt
@@ -23,14 +23,15 @@ import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
 import org.jitsi.rtp.rtp.RtpPacket
 
 /**
- * Strip all hop-by-hop header extensions.  Currently this leaves ssrc-audio-level and video-orientation,
+ * Strip all hop-by-hop header extensions. By default, this leaves ssrc-audio-level and video-orientation,
  * plus the AV1 dependency descriptor if the packet is an Av1DDPacket.
  */
 class HeaderExtStripper(
-    streamInformationStore: ReadOnlyStreamInformationStore
+    streamInformationStore: ReadOnlyStreamInformationStore,
 ) : ModifierNode("Strip header extensions") {
     private var retainedExts: Set<Int> = emptySet()
     private var retainedExtsWithAv1DD: Set<Int> = emptySet()
+    private var retainedExtTypes = defaultRetainedExtTypes
 
     init {
         retainedExtTypes.forEach { rtpExtensionType ->
@@ -44,6 +45,10 @@ class HeaderExtStripper(
         streamInformationStore.onRtpExtensionMapping(RtpExtensionType.AV1_DEPENDENCY_DESCRIPTOR) {
             it?.let { retainedExtsWithAv1DD += it }
         }
+    }
+
+    fun addRtpExtensionToRetain(extensionType: RtpExtensionType) {
+            retainedExtTypes += extensionType
     }
 
     override fun modify(packetInfo: PacketInfo): PacketInfo {
@@ -60,7 +65,7 @@ class HeaderExtStripper(
     override fun trace(f: () -> Unit) = f.invoke()
 
     companion object {
-        private val retainedExtTypes: Set<RtpExtensionType> = setOf(
+        val defaultRetainedExtTypes: Set<RtpExtensionType> = setOf(
             RtpExtensionType.SSRC_AUDIO_LEVEL,
             RtpExtensionType.VIDEO_ORIENTATION
         )

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
@@ -269,7 +269,16 @@ internal class SingleSourceAllocation(
         if (constraints.maxHeight == 0 || !source.hasRtpLayers()) {
             return Layers.noLayers
         }
-        val layers = source.rtpLayers.map { LayerSnapshot(it, it.getBitrate(nowMs).bps) }
+        val layers = source.rtpLayers.map {
+            LayerSnapshot(
+                it,
+                if (config.useVlaTargetBitrate) {
+                    it.targetBitrate?.bps ?: it.getBitrate(nowMs).bps
+                } else {
+                    it.getBitrate(nowMs).bps
+                }
+            )
+        }
 
         return when (source.videoType) {
             VideoType.CAMERA -> selectLayersForCamera(layers, constraints)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
@@ -269,7 +269,7 @@ internal class SingleSourceAllocation(
         if (constraints.maxHeight == 0 || !source.hasRtpLayers()) {
             return Layers.noLayers
         }
-        val layers = source.rtpLayers.map { LayerSnapshot(it, it.getBitrateBps(nowMs)) }
+        val layers = source.rtpLayers.map { LayerSnapshot(it, it.getBitrate(nowMs).bps) }
 
         return when (source.videoType) {
             VideoType.CAMERA -> selectLayersForCamera(layers, constraints)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/config/BitrateControllerConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/config/BitrateControllerConfig.kt
@@ -110,6 +110,10 @@ class BitrateControllerConfig private constructor() {
             .convertFrom<String> { Bandwidth.fromString(it) }
     }
 
+    val useVlaTargetBitrate: Boolean by config {
+        "videobridge.cc.use-vla-target-bitrate".from(JitsiConfig.newConfig)
+    }
+
     companion object {
         @JvmField
         val config = BitrateControllerConfig()

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
@@ -285,6 +285,7 @@ class Relay @JvmOverloads constructor(
             },
             external = true
         )
+        addRtpExtensionToRetain(RtpExtensionType.VLA)
     }
 
     /**

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -77,6 +77,10 @@ videobridge {
     # If set allows receivers to override bandwidth estimation (BWE) with a specific value signaled over the bridge
     # channel (limited to the configured value). If not set, receivers are not allowed to override BWE.
     // assumed-bandwidth-limit = 10 Mbps
+
+    # Whether to use the target bitrate signaled in the VLA extension for allocation. When disabled we use the measured
+    # bitrate instead (preserving previous behavior).
+    use-vla-target-bitrate = false
   }
   # Whether to indicate support for cryptex header extension encryption (RFC 9335)
   cryptex {

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/VlaExtension.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/VlaExtension.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright @ 2024-Present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.rtp.rtp.header_extensions
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import org.jitsi.rtp.rtp.RtpPacket
+import org.jitsi.rtp.rtp.header_extensions.VlaExtension.Stream
+import org.jitsi.rtp.util.BitReader
+
+/**
+ * A parser for the Video Layers Allocation RTP header extension.
+ * https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/video-layers-allocation00
+ */
+@SuppressFBWarnings("SF_SWITCH_NO_DEFAULT", justification = "False positive")
+class VlaExtension {
+    companion object {
+        fun parse(ext: RtpPacket.HeaderExtension): ParsedVla {
+            val empty = ext.dataLengthBytes == 1 && ext.buffer[ext.dataOffset] == 0.toByte()
+            if (empty) {
+                return emptyList()
+            }
+
+            val reader = BitReader(ext.buffer, ext.dataOffset, ext.dataLengthBytes)
+            reader.skipBits(2) // RID
+            val ns = reader.bits(2) + 1
+            val slBm = reader.bits(4)
+            val slBms = IntArray(4) { i -> if (i < ns) slBm else 0 }
+            if (slBm == 0) {
+                slBms[0] = reader.bits(4)
+                if (ns > 1) {
+                    slBms[1] = reader.bits(4)
+                    if (ns > 2) {
+                        slBms[2] = reader.bits(4)
+                        if (ns > 3) {
+                            slBms[3] = reader.bits(4)
+                        }
+                    }
+                }
+                if (ns == 1 || ns == 3) {
+                    reader.skipBits(4)
+                }
+            }
+
+            val slCount = slBms.sumOf { it.countOneBits() }
+            val tlCountLenBytes = slCount / 4 + if (slCount % 4 != 0) 1 else 0
+
+            val tlCountReader = reader.clone(tlCountLenBytes)
+            reader.skipBits(tlCountLenBytes * 8)
+
+            val streams = ArrayList<Stream>(ns)
+            (0 until ns).forEach { streamIdx ->
+                val spatialLayers = ArrayList<SpatialLayer>()
+                val stream = Stream(streamIdx, spatialLayers)
+                streams.add(stream)
+
+                (0 until 4).forEach { slIdx ->
+                    if ((slBms[streamIdx] and (1 shl slIdx)) != 0) {
+                        val targetBitrates = buildList {
+                            repeat(tlCountReader.bits(2) + 1) {
+                                add(reader.leb128())
+                            }
+                        }
+                        spatialLayers.add(
+                            SpatialLayer(
+                                slIdx,
+                                targetBitrates,
+                                null
+                            )
+                        )
+                    }
+                }
+            }
+
+            (0 until ns).forEach outer@{ streamIdx ->
+                (0 until 4).forEach { slIdx ->
+                    if ((slBms[streamIdx] and (1 shl slIdx)) != 0) {
+                        if (reader.remainingBits() < 40) {
+                            return@outer
+                        }
+                        val sl = streams[streamIdx].spatialLayers[slIdx]
+                        sl.res = ResolutionAndFrameRate(
+                            reader.bits(16) + 1,
+                            reader.bits(16) + 1,
+                            reader.bits(8)
+                        )
+                    }
+                }
+            }
+
+            return streams
+        }
+    }
+
+    data class ResolutionAndFrameRate(
+        val width: Int,
+        val height: Int,
+        val maxFramerate: Int
+    )
+
+    data class SpatialLayer(
+        val id: Int,
+        // The target bitrates for each temporal layer in this spatial layer
+        val targetBitratesKbps: List<Long>,
+        var res: ResolutionAndFrameRate?
+    ) {
+        override fun toString(): String = "SpatialLayer(id=$id, targetBitratesKbps=$targetBitratesKbps, " +
+            "width=${res?.width}, height=${res?.height}, maxFramerate=${res?.maxFramerate})"
+    }
+
+    data class Stream(
+        val id: Int,
+        val spatialLayers: List<SpatialLayer>
+    )
+}
+
+typealias ParsedVla = List<Stream>

--- a/rtp/src/test/kotlin/org/jitsi/rtp/extensions/VlaExtensionTest.kt
+++ b/rtp/src/test/kotlin/org/jitsi/rtp/extensions/VlaExtensionTest.kt
@@ -26,6 +26,7 @@ import org.jitsi.rtp.rtp.header_extensions.VlaExtension.ResolutionAndFrameRate
 import org.jitsi.rtp.rtp.header_extensions.VlaExtension.SpatialLayer
 import org.jitsi.rtp.rtp.header_extensions.VlaExtension.Stream
 
+@Suppress("ktlint:standard:no-multi-spaces")
 class VlaExtensionTest : ShouldSpec() {
     init {
         context("Empty") {
@@ -306,7 +307,7 @@ class VlaExtensionTest : ShouldSpec() {
                     0b0011_1111,          // width
                     0b0000_0000,          // height
                     0b1011_0011.toByte(), // height
-                    // 0b0010_0001           // maxFramerate
+                    // 0b0010_0001        // maxFramerate
                 ) shouldBe listOf(
                     Stream(
                         0,
@@ -329,7 +330,7 @@ class VlaExtensionTest : ShouldSpec() {
                         0b0101_0000,          // targetBitrate 1
                         0b0111_1000,          // targetBitrate 2
                         0b1100_1000.toByte(), // targetBitrate 3
-                        //0b0000_0001,          // targetBitrate 3
+                        // 0b0000_0001,       // targetBitrate 3
                     )
                 }
             }
@@ -342,7 +343,7 @@ class VlaExtensionTest : ShouldSpec() {
                         0b0101_0000,          // targetBitrate 1
                         0b1100_1000.toByte(), // targetBitrate 2
                         0b0000_0001,          // targetBitrate 2
-                        //0b0111_1000,          // targetBitrate 3
+                        // 0b0111_1000,       // targetBitrate 3
                     )
                 }
             }

--- a/rtp/src/test/kotlin/org/jitsi/rtp/extensions/VlaExtensionTest.kt
+++ b/rtp/src/test/kotlin/org/jitsi/rtp/extensions/VlaExtensionTest.kt
@@ -1,0 +1,308 @@
+/*
+ * Copyright @ 2024-Present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.rtp.extensions
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.jitsi.rtp.rtp.RtpPacket.HeaderExtension
+import org.jitsi.rtp.rtp.header_extensions.ParsedVla
+import org.jitsi.rtp.rtp.header_extensions.VlaExtension
+import org.jitsi.rtp.rtp.header_extensions.VlaExtension.ResolutionAndFrameRate
+import org.jitsi.rtp.rtp.header_extensions.VlaExtension.SpatialLayer
+import org.jitsi.rtp.rtp.header_extensions.VlaExtension.Stream
+
+class VlaExtensionTest : ShouldSpec() {
+    init {
+        context("Empty") {
+            parse(0x00) shouldBe emptyList()
+        }
+        context("VP8 single stream (with resolution)") {
+            parse(
+                0b0000_0001,
+                0b1000_0000.toByte(),
+                0b0101_0000,
+                0b0111_1000,
+                0b1100_1000.toByte(),
+                0b0000_0001,
+                0b0000_0001,
+                0b0011_1111,
+                0b0000_0000,
+                0b1011_0011.toByte(),
+                0b0010_0001
+            ) shouldBe listOf(
+                Stream(
+                    0,
+                    listOf(
+                        SpatialLayer(
+                            0,
+                            listOf(80, 120, 200),
+                            ResolutionAndFrameRate(320, 180, 33)
+                        )
+                    )
+                )
+            )
+        }
+        context("VP8 single stream (without resolution)") {
+            parse(
+                0b0000_0001,
+                0b1000_0000.toByte(),
+                0b0101_0000,
+                0b0111_1000,
+                0b1100_1000.toByte(),
+                0b0000_0001
+            ) shouldBe listOf(
+                Stream(
+                    0,
+                    listOf(
+                        SpatialLayer(
+                            0,
+                            listOf(80, 120, 200),
+                            null
+                        )
+                    )
+                )
+            )
+        }
+        context("VP8 simulcast stream (with resolutions)") {
+            parse(
+                0b0010_0001,
+                0b1010_1000.toByte(),
+                0b0011_1100,
+                0b0101_1010,
+                0b1001_0110.toByte(),
+                0b0000_0001,
+                0b1100_1000.toByte(),
+                0b0000_0001,
+                0b1010_1100.toByte(),
+                0b0000_0010,
+                0b1111_0100.toByte(),
+                0b0000_0011,
+                0b1110_1110.toByte(),
+                0b0000_0011,
+                0b1110_0110.toByte(),
+                0b0000_0101,
+                0b1101_0100.toByte(),
+                0b0000_1001,
+                0b0000_0001,
+                0b0011_1111,
+                0b0000_0000,
+                0b1011_0011.toByte(),
+                0b0001_1111,
+                0b0000_0010,
+                0b0111_1111,
+                0b0000_0001,
+                0b0110_0111,
+                0b0001_1111,
+                0b0000_0100,
+                0b1111_1111.toByte(),
+                0b0000_0010,
+                0b1100_1111.toByte(),
+                0b0001_1111
+            ) shouldBe listOf(
+                Stream(
+                    0,
+                    listOf(
+                        SpatialLayer(
+                            0,
+                            listOf(60, 90, 150),
+                            ResolutionAndFrameRate(320, 180, 31)
+                        )
+                    )
+                ),
+                Stream(
+                    1,
+                    listOf(
+                        SpatialLayer(
+                            0,
+                            listOf(200, 300, 500),
+                            ResolutionAndFrameRate(640, 360, 31)
+                        )
+                    )
+                ),
+                Stream(
+                    2,
+                    listOf(
+                        SpatialLayer(
+                            0,
+                            listOf(494, 742, 1236),
+                            ResolutionAndFrameRate(1280, 720, 31)
+                        )
+                    )
+                )
+            )
+        }
+        context("VP8 simulcast stream (without resolutions)") {
+            parse(
+                0b1010_0001.toByte(),
+                0b1010_1000.toByte(),
+                0b1001_0101.toByte(),
+                0b0000_0010,
+                0b1001_1111.toByte(),
+                0b0000_0011,
+                0b1011_0100.toByte(),
+                0b0000_0101,
+                0b1000_1101.toByte(),
+                0b0000_1001,
+                0b1101_0011.toByte(),
+                0b0000_1101,
+                0b1110_0000.toByte(),
+                0b0001_0110,
+                0b1101_0000.toByte(),
+                0b0000_1111,
+                0b1011_1000.toByte(),
+                0b0001_0111,
+                0b1000_1000.toByte(),
+                0b0010_0111
+            ) shouldBe listOf(
+                Stream(
+                    0,
+                    listOf(
+                        SpatialLayer(
+                            0,
+                            listOf(277, 415, 692),
+                            null
+                        )
+                    )
+                ),
+                Stream(
+                    1,
+                    listOf(
+                        SpatialLayer(
+                            0,
+                            listOf(1165, 1747, 2912),
+                            null
+                        )
+                    )
+                ),
+                Stream(
+                    2,
+                    listOf(
+                        SpatialLayer(
+                            0,
+                            listOf(2000, 3000, 5000),
+                            null
+                        )
+                    )
+                )
+            )
+        }
+        context("VP9 SVC (witt resolutions)") {
+            parse(
+                0b0000_0111,
+                0b1010_1000.toByte(),
+                0b0100_1101,
+                0b0110_0100,
+                0b1000_1110.toByte(),
+                0b0000_0001,
+                0b1101_0111.toByte(),
+                0b0000_0001,
+                0b1001_0111.toByte(),
+                0b0000_0010,
+                0b1000_1101.toByte(),
+                0b0000_0011,
+                0b1101_0110.toByte(),
+                0b0000_0010,
+                0b1011_1101.toByte(),
+                0b0000_0011,
+                0b1111_1001.toByte(),
+                0b0000_0100,
+                0b0000_0001,
+                0b0011_1111,
+                0b0000_0000,
+                0b1011_0011.toByte(),
+                0b0010_0000,
+                0b0000_0010,
+                0b0111_1111,
+                0b0000_0001,
+                0b0110_0111,
+                0b0010_0000,
+                0b0000_0100,
+                0b1111_1111.toByte(),
+                0b0000_0010,
+                0b1100_1111.toByte(),
+                0b0010_0000
+            ) shouldBe listOf(
+                Stream(
+                    0,
+                    listOf(
+                        SpatialLayer(
+                            0,
+                            listOf(77, 100, 142),
+                            ResolutionAndFrameRate(320, 180, 32)
+                        ),
+                        SpatialLayer(
+                            1,
+                            listOf(215, 279, 397),
+                            ResolutionAndFrameRate(640, 360, 32)
+                        ),
+                        SpatialLayer(
+                            2,
+                            listOf(342, 445, 633),
+                            ResolutionAndFrameRate(1280, 720, 32)
+                        )
+                    )
+                )
+            )
+        }
+        context("VP9 SVC (without resolutions or TLs)") {
+            parse(
+                0b0000_0111,
+                0b0000_0000,
+                0b1001_0110.toByte(),
+                0b0000_0001,
+                0b1111_0100.toByte(),
+                0b0000_0011,
+                0b1010_1010.toByte(),
+                0b0000_1011
+            ) shouldBe listOf(
+                Stream(
+                    0,
+                    listOf(
+                        SpatialLayer(
+                            0,
+                            listOf(150),
+                            null
+                        ),
+                        SpatialLayer(
+                            1,
+                            listOf(500),
+                            null
+                        ),
+                        SpatialLayer(
+                            2,
+                            listOf(1450),
+                            null
+                        )
+                    )
+                )
+            )
+        }
+        context("Invalid VLAs") {
+            parse(0x00) shouldBe emptyList()
+        }
+    }
+}
+
+private fun parse(vararg bytes: Byte): ParsedVla = VlaExtension.parse(RawHeaderExtension(bytes))
+
+@SuppressFBWarnings("CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE")
+class RawHeaderExtension(override val buffer: ByteArray) : HeaderExtension {
+    override val dataOffset: Int = 0
+    override var id: Int = 0
+    override val dataLengthBytes: Int = buffer.size
+    override val totalLengthBytes: Int = buffer.size
+}

--- a/rtp/src/test/kotlin/org/jitsi/rtp/util/BitReaderTest.kt
+++ b/rtp/src/test/kotlin/org/jitsi/rtp/util/BitReaderTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright @ 2024 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.rtp.util
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+
+class BitReaderTest : ShouldSpec() {
+    override fun isolationMode(): IsolationMode = IsolationMode.InstancePerLeaf
+
+    init {
+        val bitReader = BitReader(
+            byteArrayOf(
+                0b0101_1010.toByte(),
+                0b0000_1111.toByte(),
+                0b1010_1010.toByte(),
+                0b1010_1010.toByte(),
+                0b0111_1111.toByte()
+            )
+        )
+        val bits = 40
+        context("Reading single bits as boolean") {
+            bitReader.bitAsBoolean() shouldBe false
+            bitReader.bitAsBoolean() shouldBe true
+            bitReader.bitAsBoolean() shouldBe false
+            bitReader.bitAsBoolean() shouldBe true
+            bitReader.bitAsBoolean() shouldBe true
+            bitReader.remainingBits() shouldBe bits - 5
+        }
+
+        context("Reading single bits as Integer") {
+            bitReader.bit() shouldBe 0
+            bitReader.bit() shouldBe 1
+            bitReader.bit() shouldBe 0
+            bitReader.bit() shouldBe 1
+            bitReader.bit() shouldBe 1
+            bitReader.remainingBits() shouldBe bits - 5
+        }
+
+        context("Reading multiple bits as Integer") {
+            bitReader.bits(4) shouldBe 0b0101
+            bitReader.bits(4) shouldBe 0b1010
+            bitReader.bits(6) shouldBe 0b000011
+            bitReader.bits(2) shouldBe 0b11
+            bitReader.remainingBits() shouldBe bits - 16
+        }
+
+        context("Reading multiple bits as Long") {
+            bitReader.bitsLong(4) shouldBe 0b0101L
+            bitReader.bitsLong(4) shouldBe 0b1010L
+            bitReader.bits(6) shouldBe 0b000011L
+            bitReader.bits(2) shouldBe 0b11L
+            bitReader.remainingBits() shouldBe bits - 16
+        }
+
+        context("skip bits correctly") {
+            bitReader.skipBits(4)
+            bitReader.remainingBits() shouldBe bits - 4
+            bitReader.bit() shouldBe 1
+            bitReader.remainingBits() shouldBe bits - 5
+        }
+
+        context("Reading LEB128-encoded unsigned integers") {
+            bitReader.leb128() shouldBe 0b0101_1010
+            bitReader.remainingBits() shouldBe bits - 8
+            bitReader.leb128() shouldBe 0b00001111
+            bitReader.remainingBits() shouldBe bits - 16
+            bitReader.leb128() shouldBe 0b111_1111__010_1010__010_1010
+            bitReader.remainingBits() shouldBe 0
+        }
+
+        context("Cloning") {
+            bitReader.skipBits(8)
+            val clone = bitReader.clone(2)
+            bitReader.remainingBits() shouldBe bits - 8
+            clone.remainingBits() shouldBe 16
+
+            bitReader.bits(8) shouldBe 0b0000_1111
+            bitReader.remainingBits() shouldBe bits - 16
+            clone.remainingBits() shouldBe 16
+
+            clone.bits(8) shouldBe 0b0000_1111
+            bitReader.remainingBits() shouldBe bits - 16
+            clone.remainingBits() shouldBe 8
+
+            clone.skipBits(8)
+            bitReader.remainingBits() shouldBe bits - 16
+            clone.remainingBits() shouldBe 0
+
+            bitReader.bits(8) shouldBe 0b1010_1010
+            shouldThrow<IllegalStateException> {
+                clone.bits(8)
+            }
+        }
+
+        context("Throwing exception when reading past the bounds") {
+            bitReader.skipBits(bits)
+            bitReader.remainingBits() shouldBe 0
+            shouldThrow<IllegalStateException> {
+                bitReader.bitAsBoolean()
+            }
+            shouldThrow<IllegalStateException> {
+                bitReader.bit()
+            }
+            shouldThrow<IllegalStateException> {
+                bitReader.bits(4)
+            }
+            shouldThrow<IllegalStateException> {
+                bitReader.leb128()
+            }
+            shouldThrow<IllegalStateException> {
+                BitReader(byteArrayOf(0b1111_0000.toByte())).leb128()
+            }
+        }
+    }
+}


### PR DESCRIPTION
- **feat: Add BitReader utilities and tests.**
- **feat: Add a parser for the VLA RTP header extension.**
- **ref: Remove unused function.**
- **feat: Update layers with info found in VLA.**
- **feat: Add an option to use targetBitrate instead of measured bitrate for allocation**
