### PR TITLE
chore: Updates jicoco.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <kotest.version>5.9.1</kotest.version>
         <junit.version>5.10.2</junit.version>
         <jitsi.utils.version>1.0-133-g6af1020</jitsi.utils.version>
-        <jicoco.version>1.1-150-g57913c0</jicoco.version>
+        <jicoco.version>1.1-151-g63a0655</jicoco.version>
         <mockk.version>1.13.11</mockk.version>
         <ktlint-maven-plugin.version>3.2.0</ktlint-maven-plugin.version>
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>


### PR DESCRIPTION
A reconnect fix on startup a race may lead to keep trying to  reconnect filling up the logs with: WARNING: [25] [hostname=localhost id=shard] MucClient.lambda$getConnectAndLoginCallable$9#693: Error connecting: org.jivesoftware.smack.SmackException$AlreadyConnectedException: Client is already connected