### PR TITLE
Handle the case where VLA-provided frame rate is less than the onstage preferred frame rate.

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDRtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDRtpLayerDesc.kt
@@ -79,8 +79,7 @@ class Av1DDRtpLayerDesc(
      * {@inheritDoc}
      */
     override fun toString(): String {
-        return "subjective_quality=" + index +
-            ",DT=" + dt
+        return "subjective_quality=$index,DT=$dt,height=$height,frameRate=$frameRate"
     }
 
     companion object {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vpx/VpxRtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vpx/VpxRtpLayerDesc.kt
@@ -118,7 +118,7 @@ constructor(
      * {@inheritDoc}
      */
     override fun toString(): String {
-        return "subjective_quality=$index,temporal_id=$tid,spatial_id=$sid,height=$height"
+        return "subjective_quality=$index,temporal_id=$tid,spatial_id=$sid,height=$height,frameRate=$frameRate"
     }
 
     /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.kt
@@ -174,7 +174,7 @@ internal class BandwidthAllocator<T : MediaSourceContainer>(
 
         logger.trace {
             "Allocating: sortedSources=${sortedSources.map { it.sourceName }}, " +
-                " effectiveConstraints=${newEffectiveConstraints.map { "${it.key.sourceName}=${it.value}" }}"
+                "effectiveConstraints=${newEffectiveConstraints.map { "${it.key.sourceName}=${it.value}" }}"
         }
 
         // Compute the bandwidth allocation.

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BitrateController.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BitrateController.kt
@@ -26,6 +26,7 @@ import org.jitsi.utils.event.SyncEventEmitter
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
 import org.jitsi.utils.logging2.Logger
+import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.utils.secs
 import org.jitsi.videobridge.cc.config.BitrateControllerConfig.Companion.config
 import org.jitsi.videobridge.message.ReceiverVideoConstraintsMessage
@@ -52,6 +53,8 @@ class BitrateController<T : MediaSourceContainer> @JvmOverloads constructor(
     private val clock: Clock = Clock.systemUTC()
 ) {
     val eventEmitter = SyncEventEmitter<EventHandler>()
+
+    private val logger = createChildLogger(parentLogger)
 
     private val bitrateAllocatorEventHandler = BitrateAllocatorEventHandler()
 
@@ -133,6 +136,9 @@ class BitrateController<T : MediaSourceContainer> @JvmOverloads constructor(
     fun accept(packetInfo: PacketInfo): Boolean {
         if (packetInfo.layeringChanged) {
             // This needs to be done synchronously, so it's complete before the accept, below.
+            logger.debug {
+                "Layering information changed for packet from ${packetInfo.endpointId}, updating bandwidth allocation"
+            }
             bandwidthAllocator.update()
         }
         return packetHandler.accept(packetInfo)


### PR DESCRIPTION
Correctly calculate temporal layers' frame rates from VLA (presuming 2:1 ratios).