### PR TITLE
VideobridgeExpireThread is created but not started

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Main.kt
@@ -110,7 +110,7 @@ fun main() {
         JvbVersionService.instance.currentVersion,
         Clock.systemUTC()
     )
-    val videobridgeExpireThread = VideobridgeExpireThread(videobridge)
+    val videobridgeExpireThread = VideobridgeExpireThread(videobridge).apply { start() }
     Metrics.metricsUpdater.addUpdateTask {
         VideobridgePeriodicMetrics.update(videobridge)
     }


### PR DESCRIPTION
Hello @bgrozev! I'm not really sure whether it is a typo or done on purpose but I noticed that during `VideobridgeExpireThread` move from `Videobridge` to `Main` in commit https://github.com/jitsi/jitsi-videobridge/commit/b623d6af714a17922750aa9d1c8060406ecb6e0a call to `VideobridgeExpireThread.start()` was lost.
Again, maybe it is done on purpose but in my deployment it leads to a weird situation that peers who lost connection are getting stuck in "reconnecting" state without being expired.