### PR TITLE
Update dcsctp4j version.  Adds ppc64le support.

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -124,12 +124,6 @@ case "$1" in
             sed -i 's/.*--apis.*//' $CONFIG
         fi
 
-        # dcsctp4j isn't built for ppc64el, so use usrsctp there if no explicit option has been set.
-        DEBARCH=$(dpkg --print-architecture)
-        if [ "$DEBARCH" = "ppc64el" ] && ! hocon -f $HOCON_CONFIG get "videobridge.sctp.use-usrsctp" > /dev/null 2>&1 ;then
-            hocon -f $HOCON_CONFIG set "videobridge.sctp.use-usrsctp" "true"
-        fi
-        
         # we don't want to start the daemon as root
         if ! getent group jitsi > /dev/null ; then
             groupadd jitsi

--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-dcsctp</artifactId>
-      <version>1.0-3-gaf9d564</version>
+      <version>1.0-7-gb548df2</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
     <!-- we inherit an old version of slf4j-api from tinder, which pcap4j doesn't work with. Adding slf4j-api 1.7.30 (the current stable) as a dep of jvb fixes the problem. -->


### PR DESCRIPTION
Remove Debian post-install logic that uses usrsctp on ppc64le.