### PR TITLE
Copy pendingHeaderExtensions when cloning subclasses of RtpPacket.

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/AudioRtpPacket.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/AudioRtpPacket.kt
@@ -27,5 +27,5 @@ open class AudioRtpPacket(
         cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),
         BYTES_TO_LEAVE_AT_START_OF_PACKET,
         length
-    )
+    ).also { postClone(it) }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/RedAudioRtpPacket.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/RedAudioRtpPacket.kt
@@ -43,7 +43,7 @@ class RedAudioRtpPacket(
         cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),
         BYTES_TO_LEAVE_AT_START_OF_PACKET,
         length
-    )
+    ).also { postClone(it) }
 
     companion object {
         val parser = RedPacketParser(::AudioRtpPacket)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/VideoRtpPacket.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/VideoRtpPacket.kt
@@ -43,6 +43,6 @@ open class VideoRtpPacket @JvmOverloads constructor(
             BYTES_TO_LEAVE_AT_START_OF_PACKET,
             length,
             encodingId = encodingId
-        )
+        ).also { postClone(it) }
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDPacket.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDPacket.kt
@@ -129,7 +129,7 @@ class Av1DDPacket : ParsedVideoPacket {
             descriptor = descriptor,
             statelessDescriptor = statelessDescriptor,
             frameInfo = frameInfo
-        )
+        ).also { postClone(it) }
     }
 
     fun getScalabilityStructure(eid: Int = 0, baseFrameRate: Double = 30.0): RtpEncodingDesc? {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
@@ -166,7 +166,7 @@ class Vp8Packet private constructor(
             height = height,
             pictureId = pictureId,
             TL0PICIDX = TL0PICIDX
-        )
+        ).also { postClone(it) }
     }
 
     companion object {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp9/Vp9Packet.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp9/Vp9Packet.kt
@@ -211,7 +211,7 @@ class Vp9Packet private constructor(
             encodingId = encodingId,
             pictureId = pictureId,
             TL0PICIDX = TL0PICIDX
-        )
+        ).also { postClone(it) }
     }
 
     companion object {

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtp/RedPacketParser.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtp/RedPacketParser.kt
@@ -215,7 +215,7 @@ internal class RtpRedPacket(buffer: ByteArray, offset: Int, length: Int) : RtpPa
         cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),
         BYTES_TO_LEAVE_AT_START_OF_PACKET,
         length
-    )
+    ).also { postClone(it) }
 
     companion object {
         val parser = RedPacketParser { b, o, l -> RtpPacket(b, o, l) }

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -407,7 +407,13 @@ open class RtpPacket(
             cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),
             BYTES_TO_LEAVE_AT_START_OF_PACKET,
             length
-        ).also { if (pendingHeaderExtensions != null) it.pendingHeaderExtensions = ArrayList(pendingHeaderExtensions) }
+        ).also { postClone(it) }
+    }
+
+    /** Extra operations that need to be done after [clone].  All subclasses overriding [clone]
+     * must call this method on the newly-created clone. */
+    protected fun postClone(clone: RtpPacket) {
+        pendingHeaderExtensions?.let { clone.pendingHeaderExtensions = ArrayList(it) }
     }
 
     override fun toString(): String = buildString {


### PR DESCRIPTION
Otherwise stripped header extensions aren't stripped in the packet cache.