### PR TITLE
Save persistent AV1 state

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/format/PayloadType.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/format/PayloadType.kt
@@ -74,6 +74,7 @@ enum class PayloadTypeEncoding {
     OTHER,
     VP8,
     VP9,
+    AV1,
     H264,
     RED,
     RTX,
@@ -128,6 +129,12 @@ class Vp9PayloadType(
     parameters: PayloadTypeParams = ConcurrentHashMap(),
     rtcpFeedbackSet: RtcpFeedbackSet = emptySet()
 ) : VideoPayloadType(pt, PayloadTypeEncoding.VP9, parameters = parameters, rtcpFeedbackSet = rtcpFeedbackSet)
+
+class Av1PayloadType(
+    pt: Byte,
+    parameters: PayloadTypeParams = ConcurrentHashMap(),
+    rtcpFeedbackSet: RtcpFeedbackSet = emptySet()
+) : VideoPayloadType(pt, PayloadTypeEncoding.AV1, parameters = parameters, rtcpFeedbackSet = rtcpFeedbackSet)
 
 class H264PayloadType(
     pt: Byte,

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/AdaptiveSourceProjectionContext.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/AdaptiveSourceProjectionContext.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.cc;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.jitsi.nlj.*;
 import org.jitsi.rtp.rtcp.*;
 import org.json.simple.*;
@@ -78,6 +79,17 @@ public interface AdaptiveSourceProjectionContext
      * timestamp and other RTP-level details.
      */
     RtpState getRtpState();
+
+    /**
+     * @return Persistent state, if any, that should be associated with this
+     * particular projection context type, so that when it comes back it can
+     * resume data, if necessary.
+     */
+    @Nullable
+    default Object getPersistentState()
+    {
+        return null;
+    }
 
     /**
      * Gets a JSON representation of the parts of this object's state that

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
@@ -651,7 +651,7 @@ private class Vp9CodecState(val lastTl0Index: Int) : CodecState {
             return null
         }
         val tl0IndexDelta = if (packet.hasTL0PICIDX) {
-            val tl0IndexDelta = VpxUtils.getTl0PicIdxDelta(
+            VpxUtils.getTl0PicIdxDelta(
                 lastTl0Index,
                 VpxUtils.applyTl0PicIdxDelta(packet.TL0PICIDX, -1)
             )

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
@@ -635,7 +635,11 @@ private class Vp9CodecState(val lastTl0Index: Int) : CodecState {
         if (packet !is Vp9Packet) {
             return null
         }
-        val tl0IndexDelta = VpxUtils.getTl0PicIdxDelta(lastTl0Index, (packet.TL0PICIDX - 1))
+        val tl0IndexDelta = if (packet.hasTL0PICIDX) {
+            VpxUtils.getTl0PicIdxDelta(lastTl0Index, (packet.TL0PICIDX - 1))
+        } else {
+            0
+        }
         return Vp9CodecDeltas(tl0IndexDelta)
     }
 
@@ -645,7 +649,9 @@ private class Vp9CodecState(val lastTl0Index: Int) : CodecState {
 private class Vp9CodecDeltas(val tl0IndexDelta: Int) : CodecDeltas {
     override fun rewritePacket(packet: RtpPacket) {
         require(packet is Vp9Packet)
-        packet.TL0PICIDX = VpxUtils.applyTl0PicIdxDelta(packet.TL0PICIDX, tl0IndexDelta)
+        if (packet.hasTL0PICIDX) {
+            packet.TL0PICIDX = VpxUtils.applyTl0PicIdxDelta(packet.TL0PICIDX, tl0IndexDelta)
+        }
     }
 
     override fun toString() = "[VP9 TL0Idx]$tl0IndexDelta"

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDFrameProjection.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDFrameProjection.kt
@@ -96,15 +96,17 @@ class Av1DDFrameProjection internal constructor(
         diagnosticContext: DiagnosticContext,
         ssrc: Long,
         sequenceNumberDelta: Int,
-        timestamp: Long
+        timestamp: Long,
+        frameNumber: Int?,
+        templateId: Int?
     ) : this(
         diagnosticContext = diagnosticContext,
         av1Frame = null,
         ssrc = ssrc,
         timestamp = timestamp,
         sequenceNumberDelta = sequenceNumberDelta,
-        frameNumber = 0,
-        templateIdDelta = 0,
+        frameNumber = frameNumber ?: 0,
+        templateIdDelta = templateId ?: -1,
         dti = null,
         mark = false,
         created = null
@@ -229,6 +231,9 @@ class Av1DDFrameProjection internal constructor(
      * Get the next template ID that would come after the template IDs in this projection's structure
      */
     fun getNextTemplateId(): Int? {
+        if (av1Frame == null && templateIdDelta != -1) {
+            return templateIdDelta
+        }
         return av1Frame?.structure?.let { rewriteTemplateId(it.templateIdOffset + it.templateCount) }
     }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/util/PayloadTypeUtil.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/util/PayloadTypeUtil.kt
@@ -16,11 +16,13 @@
 package org.jitsi.videobridge.util
 
 import org.jitsi.nlj.format.AudioRedPayloadType
+import org.jitsi.nlj.format.Av1PayloadType
 import org.jitsi.nlj.format.H264PayloadType
 import org.jitsi.nlj.format.OpusPayloadType
 import org.jitsi.nlj.format.OtherAudioPayloadType
 import org.jitsi.nlj.format.OtherVideoPayloadType
 import org.jitsi.nlj.format.PayloadType
+import org.jitsi.nlj.format.PayloadTypeEncoding.AV1
 import org.jitsi.nlj.format.PayloadTypeEncoding.Companion.createFrom
 import org.jitsi.nlj.format.PayloadTypeEncoding.H264
 import org.jitsi.nlj.format.PayloadTypeEncoding.OPUS
@@ -94,6 +96,7 @@ class PayloadTypeUtil {
             return when (encoding) {
                 VP8 -> Vp8PayloadType(id, parameters, rtcpFeedbackSet)
                 VP9 -> Vp9PayloadType(id, parameters, rtcpFeedbackSet)
+                AV1 -> Av1PayloadType(id, parameters, rtcpFeedbackSet)
                 H264 -> H264PayloadType(id, parameters, rtcpFeedbackSet)
                 RTX -> RtxPayloadType(id, parameters)
                 OPUS -> OpusPayloadType(id, parameters)

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionTest.kt
@@ -53,6 +53,7 @@ class Av1DDAdaptiveSourceProjectionTest {
         val context = Av1DDAdaptiveSourceProjectionContext(
             diagnosticContext,
             initialState,
+            null,
             logger
         )
         val generator = ScalableAv1PacketGenerator(1)
@@ -75,6 +76,7 @@ class Av1DDAdaptiveSourceProjectionTest {
         val context = Av1DDAdaptiveSourceProjectionContext(
             diagnosticContext,
             initialState,
+            null,
             logger
         )
         var expectedSeq = 10001
@@ -378,6 +380,7 @@ class Av1DDAdaptiveSourceProjectionTest {
         val context = Av1DDAdaptiveSourceProjectionContext(
             diagnosticContext,
             initialState,
+            null,
             logger
         )
         var latestSeq = buffer[0].packetAs<Av1DDPacket>().sequenceNumber
@@ -769,6 +772,7 @@ class Av1DDAdaptiveSourceProjectionTest {
         val context = Av1DDAdaptiveSourceProjectionContext(
             diagnosticContext,
             initialState,
+            null,
             logger
         )
         val firstPacketInfo = generator.nextPacket()
@@ -796,6 +800,7 @@ class Av1DDAdaptiveSourceProjectionTest {
         val context = Av1DDAdaptiveSourceProjectionContext(
             diagnosticContext,
             initialState,
+            null,
             logger
         )
         val firstPacketInfo = generator.nextPacket()
@@ -825,7 +830,7 @@ class Av1DDAdaptiveSourceProjectionTest {
         val diagnosticContext = DiagnosticContext()
         diagnosticContext["test"] = "twoStreamsNoSwitchingTest"
         val initialState = RtpState(1, 10000, 1000000)
-        val context = Av1DDAdaptiveSourceProjectionContext(diagnosticContext, initialState, logger)
+        val context = Av1DDAdaptiveSourceProjectionContext(diagnosticContext, initialState, null, logger)
         val targetIndex = getIndex(eid = 1, dt = 2)
         var expectedSeq = 10001
         var expectedTs: Long = 1003000
@@ -854,7 +859,7 @@ class Av1DDAdaptiveSourceProjectionTest {
         val diagnosticContext = DiagnosticContext()
         diagnosticContext["test"] = "twoStreamsSwitchingTest"
         val initialState = RtpState(1, 10000, 1000000)
-        val context = Av1DDAdaptiveSourceProjectionContext(diagnosticContext, initialState, logger)
+        val context = Av1DDAdaptiveSourceProjectionContext(diagnosticContext, initialState, null, logger)
         var expectedSeq = 10001
         var expectedTs: Long = 1003000
         var expectedFrameNumber = 0
@@ -982,6 +987,7 @@ class Av1DDAdaptiveSourceProjectionTest {
         val context = Av1DDAdaptiveSourceProjectionContext(
             diagnosticContext,
             initialState,
+            null,
             logger
         )
         var targetTid = 0
@@ -1035,6 +1041,7 @@ class Av1DDAdaptiveSourceProjectionTest {
         val context = Av1DDAdaptiveSourceProjectionContext(
             diagnosticContext,
             initialState,
+            null,
             logger
         )
         var expectedSeq = 10001
@@ -1159,6 +1166,7 @@ class Av1DDAdaptiveSourceProjectionTest {
         val context = Av1DDAdaptiveSourceProjectionContext(
             diagnosticContext,
             initialState,
+            null,
             logger
         )
         var expectedSeq = 10001
@@ -1320,6 +1328,31 @@ class Av1DDAdaptiveSourceProjectionTest {
         runSourceSuspensionTest(generator, getIndex(eid = 0, dt = 0)) {
             it.temporalId == 0
         }
+    }
+
+    @Test
+    fun persistentStateProjectionTest() {
+        val diagnosticContext = DiagnosticContext()
+        diagnosticContext["test"] = "singlePacketProjectionTest"
+        val initialState = RtpState(1, 10000, 1000000)
+        val context = Av1DDAdaptiveSourceProjectionContext(
+            diagnosticContext,
+            initialState,
+            Av1PersistentState(5555, 7),
+            logger
+        )
+        val generator = ScalableAv1PacketGenerator(1)
+        val packetInfo = generator.nextPacket()
+        val packet = packetInfo.packetAs<Av1DDPacket>()
+        val targetIndex = getIndex(eid = 0, dt = 0)
+        Assert.assertTrue(context.accept(packetInfo, targetIndex))
+        context.rewriteRtp(packetInfo)
+        Assert.assertEquals(10001, packet.sequenceNumber)
+        Assert.assertEquals(1003000, packet.timestamp)
+        Assert.assertEquals(5556, packet.frameNumber)
+        Assert.assertEquals(0, packet.frameInfo?.spatialId)
+        Assert.assertEquals(0, packet.frameInfo?.temporalId)
+        Assert.assertEquals(7, packet.descriptor?.structure?.templateIdOffset)
     }
 }
 


### PR DESCRIPTION
Should work around Chrome issue when AV1 DDs are not sent for a source for some time, then resume.