### PR TITLE
fix: Schedule RelayMessageTransport timeout regardless of sctp config.

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
@@ -425,13 +425,13 @@ class Relay @JvmOverloads constructor(
             ) {
                 logger.info("DTLS handshake complete")
                 setSrtpInformation(chosenSrtpProtectionProfile, tlsRole, keyingMaterial)
+                scheduleRelayMessageTransportTimeout()
                 if (sctpConfig.enabled && sctpConfig.useUsrSctp) {
                     when (val socket = sctpSocket) {
                         is SctpClientSocket -> connectUsrSctpConnection(socket)
                         is SctpServerSocket -> acceptUsrSctpConnection(socket)
                         else -> Unit
                     }
-                    scheduleRelayMessageTransportTimeout()
                 } else if (sctpConfig.enabled) {
                     if (sctpRole == Sctp.Role.CLIENT) {
                         sctpTransport!!.connect()


### PR DESCRIPTION
This should run with web sockets as well.
