### PR TITLE
Compute and store extended sequence numbers as Long rather than Int.

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/codec/vpx/PictureIdIndexTracker.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/codec/vpx/PictureIdIndexTracker.kt
@@ -19,14 +19,14 @@ package org.jitsi.nlj.codec.vpx
  * of 0x8000).
  */
 class PictureIdIndexTracker {
-    private var roc = 0
+    private var roc = 0L
     private var highestSeqNumReceived = -1
-    private fun getIndex(seqNum: Int, updateRoc: Boolean): Int {
+    private fun getIndex(seqNum: Int, updateRoc: Boolean): Long {
         if (highestSeqNumReceived == -1) {
             if (updateRoc) {
                 highestSeqNumReceived = seqNum
             }
-            return seqNum
+            return seqNum.toLong()
         }
         val delta = VpxUtils.getExtendedPictureIdDelta(seqNum, highestSeqNumReceived)
         val v =

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/ResumableStreamRewriter.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/ResumableStreamRewriter.kt
@@ -108,7 +108,7 @@ class ResumableStreamRewriter(val keepHistory: Boolean = false) {
 
     private class RewriteHistoryItem(
         var accept: Boolean?,
-        val newIndex: Int
+        val newIndex: Long
     )
 
     private class StreamRewriteHistory(highestSeqSent: Int) : ArrayCache<RewriteHistoryItem>(
@@ -118,14 +118,14 @@ class ResumableStreamRewriter(val keepHistory: Boolean = false) {
         /* Caller should have this object synchronized if needed. */
         synchronize = false
     ) {
-        var firstIndex: Int = -1
+        var firstIndex: Long = -1L
 
         var gapsLeft = 0
             private set
 
         private val rfc3711IndexTracker = Rfc3711IndexTracker()
 
-        private fun fillBetween(start: Int, end: Int, firstNewIndex: Int) {
+        private fun fillBetween(start: Long, end: Long, firstNewIndex: Long) {
             if (end <= lastIndex - size + 1) {
                 return
             }
@@ -146,10 +146,10 @@ class ResumableStreamRewriter(val keepHistory: Boolean = false) {
         fun rewriteSequenceNumber(accept: Boolean, sequenceNumber: Int): Int {
             val index = rfc3711IndexTracker.update(sequenceNumber)
 
-            val newIndex: Int
+            val newIndex: Long
 
             when {
-                (firstIndex == -1) -> {
+                (firstIndex == -1L) -> {
                     /* First index seen. */
                     insertItem(RewriteHistoryItem(accept, index), index)
 
@@ -253,7 +253,7 @@ class ResumableStreamRewriter(val keepHistory: Boolean = false) {
             private const val MAX_REWRITE_HISTORY = 1000
 
             /** Map an index back to a sequence number. */
-            private fun toSequenceNumber(index: Int): Int = index and 0xffff
+            private fun toSequenceNumber(index: Long): Int = (index and 0xffff).toInt()
         }
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
@@ -329,7 +329,7 @@ class TransportCcEngine(
         }
 
         val lastSequence: Int
-            get() = if (lastIndex == -1) -1 else lastIndex and 0xFFFF
+            get() = if (lastIndex == -1L) -1 else (lastIndex and 0xFFFF).toInt()
     }
 
     companion object {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDParser.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDParser.kt
@@ -147,9 +147,9 @@ class TemplateHistory(minHistory: Int) {
     private val indexTracker = Rfc3711IndexTracker()
     private val history = TreeCache<Av1DdInfo>(minHistory)
     private var latestDecodeTargets = -1
-    private var latestDecodeTargetIndex = -1
+    private var latestDecodeTargetIndex = -1L
 
-    fun get(seqNo: Int): Map.Entry<Int, Av1DdInfo>? {
+    fun get(seqNo: Int): Map.Entry<Long, Av1DdInfo>? {
         val index = indexTracker.update(seqNo)
         return history.getEntryBefore(index)
     }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
@@ -49,9 +49,10 @@ class TccSeqNumTagger(
                     val ext = rtpPacket.getHeaderExtension(tccExtId)
                         ?: rtpPacket.addHeaderExtension(tccExtId, TccHeaderExtension.DATA_SIZE_BYTES)
 
-                    TccHeaderExtension.setSequenceNumber(ext, currTccSeqNum)
-
                     val curSeq = currTccSeqNum
+
+                    TccHeaderExtension.setSequenceNumber(ext, curSeq)
+
                     val len = rtpPacket.length.bytes
                     packetInfo.onSent { weakTcc.get()?.mediaPacketSent(curSeq, len) }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/ArrayCache.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/ArrayCache.kt
@@ -200,7 +200,7 @@ open class ArrayCache<T>(
         if (head == -1 || index > cache[head].index) {
             return
         }
-        val diff = cache[head].index - index
+        val diff = index - cache[head].index
         val position = position(diff)
         if (cache[position].index == index) {
             cache[position].timeAdded = timeAdded

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/ArrayCache.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/ArrayCache.kt
@@ -20,6 +20,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.NodeStatsProducer
 import java.lang.Integer.max
+import java.lang.Long.max
 import java.time.Clock
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -60,7 +61,7 @@ open class ArrayCache<T>(
     val hitRate
         get() = _numHits.get() * 1.0 / max(1, _numHits.get() + _numMisses.get())
 
-    protected val lastIndex: Int
+    protected val lastIndex: Long
         get() = if (head == -1) -1 else cache[head].index
 
     val empty: Boolean
@@ -69,7 +70,7 @@ open class ArrayCache<T>(
     /**
      * Inserts an item with a specific index in the cache. Stores a copy.
      */
-    fun insertItem(item: T, index: Int, timeAdded: Long): Boolean = if (synchronize) {
+    fun insertItem(item: T, index: Long, timeAdded: Long): Boolean = if (synchronize) {
         synchronized(syncRoot) {
             doInsert(item, index, timeAdded)
         }
@@ -81,9 +82,11 @@ open class ArrayCache<T>(
      * Inserts an item with a specific index in the cache, computing time
      * from [clock]. Stores a copy.
      */
-    fun insertItem(item: T, index: Int): Boolean = insertItem(item, index, clock.millis())
+    fun insertItem(item: T, index: Long): Boolean = insertItem(item, index, clock.millis())
 
-    private fun doInsert(item: T, index: Int, timeAdded: Long): Boolean {
+    private fun position(diff: Long): Int = ((head + diff) floorMod size.toLong()).toInt()
+
+    private fun doInsert(item: T, index: Long, timeAdded: Long): Boolean {
         val diff = if (head == -1) -1 else index - cache[head].index
         val position = when {
             head == -1 -> {
@@ -95,9 +98,9 @@ open class ArrayCache<T>(
                 numOldInserts++
                 return false
             }
-            diff < 0 -> (head + diff) floorMod size
+            diff < 0 -> position(diff)
             else -> {
-                head = (head + diff) floorMod size
+                head = position(diff)
                 head
             }
         }
@@ -121,7 +124,7 @@ open class ArrayCache<T>(
      * copy.
      */
     @JvmOverloads
-    fun getContainer(index: Int, shouldCloneItem: Boolean = true): Container? {
+    fun getContainer(index: Long, shouldCloneItem: Boolean = true): Container? {
         val result = when {
             synchronize -> synchronized(syncRoot) {
                 doGet(index, shouldCloneItem)
@@ -133,7 +136,7 @@ open class ArrayCache<T>(
         return result
     }
 
-    private fun doGet(index: Int, shouldCloneItem: Boolean): Container? {
+    private fun doGet(index: Long, shouldCloneItem: Boolean): Container? {
         if (index < 0) {
             return null
         }
@@ -148,7 +151,7 @@ open class ArrayCache<T>(
             return null
         }
 
-        val position = (head + diff) floorMod size
+        val position = position(diff)
         if (cache[position].index == index) {
             return cache[position].clone(shouldCloneItem)
         }
@@ -158,7 +161,7 @@ open class ArrayCache<T>(
     /**
      * Checks whether the cache contains an item with a given index.
      */
-    fun containsIndex(index: Int): Boolean {
+    fun containsIndex(index: Long): Boolean {
         return if (synchronize) {
             synchronized(syncRoot) {
                 doContains(index)
@@ -168,7 +171,7 @@ open class ArrayCache<T>(
         }
     }
 
-    private fun doContains(index: Int): Boolean {
+    private fun doContains(index: Long): Boolean {
         if (head == -1) {
             return false
         }
@@ -178,14 +181,14 @@ open class ArrayCache<T>(
             return false
         }
 
-        val position = (head + diff) floorMod size
+        val position = position(diff)
         return (cache[position].index == index)
     }
 
     /**
      * Updates the [timeAdded] value of an item with a particular index, if it is in the cache.
      */
-    protected fun updateTimeAdded(index: Int, timeAdded: Long) = if (synchronize) {
+    protected fun updateTimeAdded(index: Long, timeAdded: Long) = if (synchronize) {
         synchronized(syncRoot) {
             doUpdateTimeAdded(index, timeAdded)
         }
@@ -193,12 +196,12 @@ open class ArrayCache<T>(
         doUpdateTimeAdded(index, timeAdded)
     }
 
-    private fun doUpdateTimeAdded(index: Int, timeAdded: Long) {
+    private fun doUpdateTimeAdded(index: Long, timeAdded: Long) {
         if (head == -1 || index > cache[head].index) {
             return
         }
         val diff = cache[head].index - index
-        val position = (head - diff) floorMod size
+        val position = position(diff)
         if (cache[position].index == index) {
             cache[position].timeAdded = timeAdded
         }
@@ -221,7 +224,7 @@ open class ArrayCache<T>(
     private fun doForEachDescending(predicate: (T) -> Boolean) {
         if (head == -1) return
 
-        val indexRange = cache[head].index downTo max(cache[head].index - size, 1)
+        val indexRange = cache[head].index downTo max(cache[head].index - size, 1L)
         for (i in 0 until size) {
             val position = (head - i) floorMod size
             if (cache[position].index in indexRange) {
@@ -268,7 +271,7 @@ open class ArrayCache<T>(
 
     inner class Container(
         var item: T? = null,
-        var index: Int = -1,
+        var index: Long = -1,
         var timeAdded: Long = -1
     ) {
         fun clone(shouldCloneItem: Boolean): Container {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/Rfc3711IndexTracker.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/Rfc3711IndexTracker.kt
@@ -21,7 +21,7 @@ import org.jitsi.rtp.util.isNewerThan
 import org.jitsi.rtp.util.rolledOverTo
 
 class Rfc3711IndexTracker {
-    var roc: Int = 0
+    var roc: Long = 0
         private set
     private var highestSeqNumReceived = -1
 
@@ -31,7 +31,7 @@ class Rfc3711IndexTracker {
      * NOTE that this method must be called for all 'received' sequence numbers so that it may keep
      * its rollover counter accurate
      */
-    fun update(seqNum: Int): Int {
+    fun update(seqNum: Int): Long {
         return getIndex(seqNum, true)
     }
 
@@ -39,12 +39,12 @@ class Rfc3711IndexTracker {
      * return the index (as defined by RFC3711 at https://tools.ietf.org/html/rfc3711#section-3.3.1)
      * for the given [seqNum]. If [updateRoc] is [true] and we've rolled over, updates our ROC.
      */
-    private fun getIndex(seqNum: Int, updateRoc: Boolean): Int {
+    private fun getIndex(seqNum: Int, updateRoc: Boolean): Long {
         if (highestSeqNumReceived == -1) {
             if (updateRoc) {
                 highestSeqNumReceived = seqNum
             }
-            return seqNum
+            return seqNum.toLong()
         }
 
         val v = when {
@@ -76,7 +76,7 @@ class Rfc3711IndexTracker {
      * Interprets an RTP sequence number in the context of the highest sequence number received. Returns the index
      * which corresponds to the packet, but does not update the ROC.
      */
-    fun interpret(seqNum: Int): Int {
+    fun interpret(seqNum: Int): Long {
         return getIndex(seqNum, false)
     }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/TreeCache.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/TreeCache.kt
@@ -27,24 +27,24 @@ import java.util.*
 open class TreeCache<T>(
     private val minSize: Int
 ) {
-    private val map = TreeMap<Int, T>()
+    private val map = TreeMap<Long, T>()
 
-    private var highestIndex = -1
+    private var highestIndex = -1L
 
-    fun insert(index: Int, value: T) {
+    fun insert(index: Long, value: T) {
         map[index] = value
 
         updateState(index)
     }
 
-    fun getEntryBefore(index: Int): Map.Entry<Int, T>? {
+    fun getEntryBefore(index: Long): Map.Entry<Long, T>? {
         updateState(index)
         return map.floorEntry(index)
     }
 
-    fun get(index: Int): T? = map[index]
+    fun get(index: Long): T? = map[index]
 
-    private fun updateState(index: Int) {
+    private fun updateState(index: Long) {
         if (highestIndex < index) {
             highestIndex = index
         }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/Util.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/Util.kt
@@ -49,6 +49,10 @@ infix fun Int.floorMod(other: Int): Int {
     return Math.floorMod(this, other)
 }
 
+infix fun Long.floorMod(other: Long): Long {
+    return Math.floorMod(this, other)
+}
+
 /** Set the value at position [index] in a [MutableList] to [element].  If the list has fewer
  * than [index] entries, extend the intermediate entries between its current size and
  * [index] with [fillerElement].

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/util/ArrayCacheTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/util/ArrayCacheTest.kt
@@ -19,15 +19,24 @@ package org.jitsi.nlj.util
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.shouldBe
+import org.jitsi.utils.ms
+import org.jitsi.utils.time.FakeClock
 
 internal class ArrayCacheTest : ShouldSpec() {
 
     data class Dummy(val index: Long)
 
-    private val arrayCache = object : ArrayCache<Dummy>(10, { Dummy(it.index) }) {
+    private val fakeClock = FakeClock()
+
+    private val arrayCache = object : ArrayCache<Dummy>(10, { Dummy(it.index) }, clock = fakeClock) {
         var discarded = 0
         override fun discardItem(item: Dummy) {
             discarded++
+        }
+
+        /** Expose protected [updateTimeAdded] to tests */
+        fun publicUpdateTimeAdded(index: Long, timeAdded: Long) {
+            updateTimeAdded(index, timeAdded)
         }
     }
 
@@ -124,6 +133,27 @@ internal class ArrayCacheTest : ShouldSpec() {
             arrayCache.flush()
             arrayCache.discarded shouldBe arrayCache.size
             arrayCache.getContainer(200) shouldBe null
+        }
+        context("time added should be correct") {
+            val time1 = fakeClock.millis()
+            arrayCache.insertItem(data1, data1.index) shouldBe true
+
+            fakeClock.elapse(100.ms)
+            val time2 = fakeClock.millis()
+            arrayCache.getContainer(data1.index)!!.timeAdded shouldBe time1
+            arrayCache.insertItem(dataOlder, dataOlder.index)
+
+            fakeClock.elapse(100.ms)
+            arrayCache.getContainer(dataOlder.index)!!.timeAdded shouldBe time2
+            arrayCache.getContainer(data1.index)!!.timeAdded shouldBe time1
+
+            fakeClock.elapse(100.ms)
+            val time3 = fakeClock.millis()
+            arrayCache.publicUpdateTimeAdded(dataOlder.index, time3)
+
+            fakeClock.elapse(100.ms)
+            arrayCache.getContainer(dataOlder.index)!!.timeAdded shouldBe time3
+            arrayCache.getContainer(data1.index)!!.timeAdded shouldBe time1
         }
     }
 }

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/util/ArrayCacheTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/util/ArrayCacheTest.kt
@@ -22,7 +22,7 @@ import io.kotest.matchers.shouldBe
 
 internal class ArrayCacheTest : ShouldSpec() {
 
-    data class Dummy(val index: Int)
+    data class Dummy(val index: Long)
 
     private val arrayCache = object : ArrayCache<Dummy>(10, { Dummy(it.index) }) {
         var discarded = 0
@@ -86,7 +86,7 @@ internal class ArrayCacheTest : ShouldSpec() {
             numInserts++
             numHits++
 
-            for (i in 150..200) {
+            for (i in 150L..200L) {
                 arrayCache.insertItem(Dummy(i), i) shouldBe true
                 numInserts++
             }

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
@@ -27,6 +27,8 @@ import java.util.function.*;
 
 import static java.lang.Integer.max;
 import static java.lang.Integer.min;
+import static java.lang.Long.max;
+import static java.lang.Long.min;
 
 /**
  * A history of recent frames on a VP8 stream.
@@ -276,7 +278,7 @@ public class VP8FrameMap
         }
 
         int numCached = 0;
-        int firstIndex = -1;
+        long firstIndex = -1;
 
         PictureIdIndexTracker indexTracker = new PictureIdIndexTracker();
 
@@ -285,14 +287,14 @@ public class VP8FrameMap
          */
         public VP8Frame get(int pictureId)
         {
-            int index = indexTracker.interpret(pictureId);
+            long index = indexTracker.interpret(pictureId);
             return getIndex(index);
         }
 
         /**
          * Gets a frame with a given VP8 picture ID index from the cache.
          */
-        private VP8Frame getIndex(int index)
+        private VP8Frame getIndex(long index)
         {
             if (index <= getLastIndex() - getSize())
             {
@@ -317,7 +319,7 @@ public class VP8FrameMap
 
         public boolean insert(int pictureId, VP8Frame frame)
         {
-            int index = indexTracker.update(pictureId);
+            long index = indexTracker.update(pictureId);
             boolean ret = super.insertItem(frame, index);
             if (ret)
             {
@@ -342,16 +344,16 @@ public class VP8FrameMap
         @Nullable
         public VP8Frame findBefore(VP8Frame frame, Predicate<VP8Frame> pred)
         {
-            int lastIndex = getLastIndex();
+            long lastIndex = getLastIndex();
             if (lastIndex == -1)
             {
                 return null;
             }
 
-            int index = indexTracker.interpret(frame.getPictureId());
+            long index = indexTracker.interpret(frame.getPictureId());
 
-            int searchStartIndex = min(index - 1, lastIndex);
-            int searchEndIndex = max(lastIndex - getSize(), firstIndex - 1);
+            long searchStartIndex = min(index - 1, lastIndex);
+            long searchEndIndex = max(lastIndex - getSize(), firstIndex - 1);
 
             return doFind(pred, searchStartIndex, searchEndIndex, -1);
         }
@@ -359,28 +361,28 @@ public class VP8FrameMap
         @Nullable
         public VP8Frame findAfter(VP8Frame frame, Predicate<VP8Frame> pred)
         {
-            int lastIndex = getLastIndex();
+            long lastIndex = getLastIndex();
             if (lastIndex == -1)
             {
                 return null;
             }
 
-            int index = indexTracker.interpret(frame.getPictureId());
+            long index = indexTracker.interpret(frame.getPictureId());
 
             if (index >= lastIndex)
             {
                 return null;
             }
 
-            int searchStartIndex = max(index + 1, max(lastIndex - getSize() + 1, firstIndex));
+            long searchStartIndex = max(index + 1, max(lastIndex - getSize() + 1, firstIndex));
 
             return doFind(pred, searchStartIndex, lastIndex + 1, 1);
         }
 
         @Nullable
-        private VP8Frame doFind(Predicate<VP8Frame> pred, int startIndex, int endIndex, int increment)
+        private VP8Frame doFind(Predicate<VP8Frame> pred, long startIndex, long endIndex, int increment)
         {
-            for (int index = startIndex; index != endIndex; index += increment)
+            for (long index = startIndex; index != endIndex; index += increment)
             {
                 VP8Frame frame = getIndex(index);
                 if (frame != null && pred.test(frame))

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionContext.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionContext.kt
@@ -75,7 +75,7 @@ class Av1DDAdaptiveSourceProjectionContext(
      * We can't send frames with frame number less than this, because we don't have
      * space in the projected sequence number/frame number counts.
      */
-    private var lastFrameNumberIndexResumption = -1
+    private var lastFrameNumberIndexResumption = -1L
 
     override fun accept(packetInfo: PacketInfo, targetIndex: Int): Boolean {
         val packet = packetInfo.packet

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDFrame.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDFrame.kt
@@ -81,7 +81,7 @@ class Av1DDFrame internal constructor(
     /**
      * The FrameID index (FrameID plus cycles) of this frame.
      */
-    val index: Int,
+    val index: Long,
 
     /**
      * The template ID of this frame
@@ -169,10 +169,10 @@ class Av1DDFrame internal constructor(
 
     // Validate that the index matches the pictureId
     init {
-        assert((index and 0xffff) == frameNumber)
+        assert((index and 0xffff).toInt() == frameNumber)
     }
 
-    constructor(packet: Av1DDPacket, index: Int) : this(
+    constructor(packet: Av1DDPacket, index: Long) : this(
         ssrc = packet.ssrc,
         timestamp = packet.timestamp,
         earliestKnownSequenceNumber = packet.sequenceNumber,

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionContext.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionContext.kt
@@ -75,7 +75,7 @@ class Vp9AdaptiveSourceProjectionContext(
      * We can't send frames with picIdIdx less than this, because we don't have
      * space in the projected sequence number/picId/tl0PicIdx counts.
      */
-    private var lastPicIdIndexResumption = -1
+    private var lastPicIdIndexResumption = -1L
 
     @Synchronized
     override fun accept(packetInfo: PacketInfo, targetIndex: Int): Boolean {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9Frame.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9Frame.kt
@@ -113,7 +113,7 @@ class Vp9Frame internal constructor(
     /**
      * The PictureID index (PictureID plus cycles) of this frame.
      */
-    val index: Int,
+    val index: Long,
 
     /**
      * The VP9 TL0PICIDX of the incoming VP9 frame that this instance refers to
@@ -186,10 +186,10 @@ class Vp9Frame internal constructor(
 
     // Validate that the index matches the pictureId
     init {
-        assert((index and 0x7fff) == pictureId)
+        assert((index and 0x7fff).toInt() == pictureId)
     }
 
-    constructor(packet: Vp9Packet, index: Int) : this(
+    constructor(packet: Vp9Packet, index: Long) : this(
         ssrc = packet.ssrc,
         timestamp = packet.timestamp,
         earliestKnownSequenceNumber = packet.sequenceNumber,

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9Picture.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9Picture.kt
@@ -29,7 +29,7 @@ import kotlin.collections.ArrayList
  *
  * @author Jonathan Lennox
  */
-class Vp9Picture(packet: Vp9Packet, index: Int) {
+class Vp9Picture(packet: Vp9Packet, index: Long) {
     val frames = ArrayList<Vp9Frame?>()
 
     init {
@@ -82,7 +82,7 @@ class Vp9Picture(packet: Vp9Packet, index: Int) {
     val pictureId: Int
         get() = firstFrame().pictureId
 
-    val index: Int
+    val index: Long
         get() = firstFrame().index
 
     val tl0PICIDX: Int

--- a/jvb/src/test/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveSourceProjectionTest.java
+++ b/jvb/src/test/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveSourceProjectionTest.java
@@ -131,10 +131,10 @@ public class VP8AdaptiveSourceProjectionTest
     {
         final Vp8Packet packet;
         final int origSeq;
-        final int extOrigSeq;
+        final long extOrigSeq;
         final boolean nearOldest;
 
-        ProjectedPacket(Vp8Packet p, int s, int e, boolean o)
+        ProjectedPacket(Vp8Packet p, int s, long e, boolean o)
         {
             packet = p;
             origSeq = s;
@@ -175,7 +175,7 @@ public class VP8AdaptiveSourceProjectionTest
 
         int latestSeq = buffer.get(0).<Vp8Packet>packetAs().getSequenceNumber();
 
-        TreeMap<Integer, ProjectedPacket> projectedPackets = new TreeMap<>();
+        TreeMap<Long, ProjectedPacket> projectedPackets = new TreeMap<>();
         Rfc3711IndexTracker origSeqIdxTracker = new Rfc3711IndexTracker();
         Rfc3711IndexTracker newSeqIdxTracker = new Rfc3711IndexTracker();
 
@@ -225,8 +225,8 @@ public class VP8AdaptiveSourceProjectionTest
                 assertEquals(RtpUtils.applyTimestampDelta(origTs, expectedTsOffset), packet.getTimestamp());
                 assertEquals(origTl0PicIdx, packet.getTL0PICIDX());
                 int newSeq = packet.getSequenceNumber();
-                int extNewSeq = newSeqIdxTracker.update(newSeq);
-                int extOrigSeq = origSeqIdxTracker.update(origSeq);
+                long extNewSeq = newSeqIdxTracker.update(newSeq);
+                long extOrigSeq = origSeqIdxTracker.update(origSeq);
                 assertFalse(projectedPackets.containsKey(extNewSeq));
                 projectedPackets.put(extNewSeq, new ProjectedPacket(packet, origSeq, extOrigSeq, nearOldest));
             }
@@ -239,7 +239,7 @@ public class VP8AdaptiveSourceProjectionTest
             Collections.shuffle(buffer, random);
         }
 
-        Iterator<Integer> iter = projectedPackets.keySet().iterator();
+        Iterator<Long> iter = projectedPackets.keySet().iterator();
 
         ProjectedPacket prevPacket = projectedPackets.get(iter.next());
 
@@ -265,8 +265,8 @@ public class VP8AdaptiveSourceProjectionTest
         ProjectedPacket firstPacket = projectedPackets.firstEntry().getValue();
         ProjectedPacket lastPacket = projectedPackets.lastEntry().getValue();
 
-        int origDelta = lastPacket.extOrigSeq - firstPacket.extOrigSeq;
-        int projDelta = projectedPackets.lastKey() - projectedPackets.firstKey();
+        long origDelta = lastPacket.extOrigSeq - firstPacket.extOrigSeq;
+        long projDelta = projectedPackets.lastKey() - projectedPackets.firstKey();
         assertTrue(projDelta <= origDelta);
     }
 

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionTest.kt
@@ -352,8 +352,8 @@ class Av1DDAdaptiveSourceProjectionTest {
     private class ProjectedPacket constructor(
         val packet: Av1DDPacket,
         val origSeq: Int,
-        val extOrigSeq: Int,
-        val extFrameNum: Int,
+        val extOrigSeq: Long,
+        val extFrameNum: Long,
     )
 
     /** Run an out-of-order test on a single stream, randomized order except for the first
@@ -384,10 +384,10 @@ class Av1DDAdaptiveSourceProjectionTest {
             logger
         )
         var latestSeq = buffer[0].packetAs<Av1DDPacket>().sequenceNumber
-        val projectedPackets = TreeMap<Int, ProjectedPacket>()
+        val projectedPackets = TreeMap<Long, ProjectedPacket>()
         val origSeqIdxTracker = Rfc3711IndexTracker()
         val newSeqIdxTracker = Rfc3711IndexTracker()
-        val frameNumsDropped = HashSet<Int>()
+        val frameNumsDropped = HashSet<Long>()
         val frameNumsIndexTracker = Rfc3711IndexTracker()
         for (i in 0..99999) {
             val packetInfo = buffer[0]
@@ -436,7 +436,7 @@ class Av1DDAdaptiveSourceProjectionTest {
                 buffer.shuffle(random)
             }
         }
-        val frameNumsSeen = HashSet<Int>()
+        val frameNumsSeen = HashSet<Long>()
 
         /* Add packets that weren't added yet, or that were dropped for being too old, to frameNumsSeen. */
         frameNumsSeen.addAll(frameNumsDropped)

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/av1/Av1DDQualityFilterTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/av1/Av1DDQualityFilterTest.kt
@@ -756,7 +756,7 @@ private open class DDBasedGenerator(
             frameInfo = structure.templateInfo[templateId],
             // Will be less than 0xffff
             frameNumber = frameCount,
-            index = frameCount,
+            index = frameCount.toLong(),
             templateId = templateId,
             structure = structure,
             activeDecodeTargets = null,
@@ -867,7 +867,7 @@ private class MultiEncodingSimulcastGenerator(val av1FrameMaps: HashMap<Long, Av
             frameInfo = structure.templateInfo[templateId],
             // Will be less than 0xffff
             frameNumber = pictureCount,
-            index = pictureCount,
+            index = pictureCount.toLong(),
             templateId = templateId,
             structure = structure,
             activeDecodeTargets = null,

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionTest.kt
@@ -165,7 +165,7 @@ class Vp9AdaptiveSourceProjectionTest {
     private class ProjectedPacket constructor(
         val packet: Vp9Packet,
         val origSeq: Int,
-        val extOrigSeq: Int,
+        val extOrigSeq: Long,
         val nearOldest: Boolean
     )
 
@@ -196,7 +196,7 @@ class Vp9AdaptiveSourceProjectionTest {
             logger
         )
         var latestSeq = buffer[0]!!.packetAs<Vp9Packet>().sequenceNumber
-        val projectedPackets = TreeMap<Int, ProjectedPacket?>()
+        val projectedPackets = TreeMap<Long, ProjectedPacket?>()
         val origSeqIdxTracker = Rfc3711IndexTracker()
         val newSeqIdxTracker = Rfc3711IndexTracker()
         for (i in 0..99999) {
@@ -259,7 +259,7 @@ class Vp9AdaptiveSourceProjectionTest {
                 buffer.shuffle(random)
             }
         }
-        val iter: Iterator<Int> = projectedPackets.keys.iterator()
+        val iter: Iterator<Long> = projectedPackets.keys.iterator()
         var prevPacket = projectedPackets[iter.next()]
         while (iter.hasNext()) {
             val packet = projectedPackets[iter.next()]

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilterTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilterTest.kt
@@ -464,7 +464,7 @@ private class SingleLayerFrameGenerator : FrameGenerator() {
             usesInterLayerDependency = false,
             isInterPicturePredicted = (pictureCount > 0),
             pictureId = pictureCount,
-            index = pictureCount,
+            index = pictureCount.toLong(),
             tl0PICIDX = pictureCount and 0xff,
             isKeyframe = (pictureCount == 0),
             numSpatialLayers = if (pictureCount == 0) 1 else -1
@@ -507,7 +507,7 @@ private class TemporallyScaledFrameGenerator : FrameGenerator() {
             usesInterLayerDependency = false,
             isInterPicturePredicted = (pictureCount > 0),
             pictureId = pictureCount,
-            index = pictureCount,
+            index = pictureCount.toLong(),
             tl0PICIDX = tl0Count and 0xff,
             isKeyframe = (pictureCount == 0),
             numSpatialLayers = if (pictureCount == 0) 1 else -1
@@ -555,7 +555,7 @@ private class SVCFrameGenerator : FrameGenerator() {
             usesInterLayerDependency = sLayer > 0,
             isInterPicturePredicted = !keyframePicture,
             pictureId = pictureCount,
-            index = pictureCount,
+            index = pictureCount.toLong(),
             tl0PICIDX = tl0Count and 0xff,
             isKeyframe = keyframePicture && sLayer == 0,
             numSpatialLayers = if (keyframePicture && sLayer == 0) 3 else -1
@@ -608,7 +608,7 @@ private class KSVCFrameGenerator : FrameGenerator() {
             usesInterLayerDependency = keyframePicture && sLayer > 0,
             isInterPicturePredicted = !keyframePicture,
             pictureId = pictureCount,
-            index = pictureCount,
+            index = pictureCount.toLong(),
             tl0PICIDX = tl0Count and 0xff,
             isKeyframe = keyframePicture && sLayer == 0,
             numSpatialLayers = if (keyframePicture && sLayer == 0) 3 else -1
@@ -662,7 +662,7 @@ private class SimulcastFrameGenerator : FrameGenerator() {
             usesInterLayerDependency = false,
             isInterPicturePredicted = !keyframePicture,
             pictureId = pictureCount,
-            index = pictureCount,
+            index = pictureCount.toLong(),
             tl0PICIDX = tl0Count and 0xff,
             isKeyframe = keyframePicture,
             numSpatialLayers = if (keyframePicture) 1 else -1


### PR DESCRIPTION
In a long-lived session, I'm pretty sure that extended sequence numbers can exceed an int, especially for transport sequence numbers (the most quickly-incrementing sequence number in our system).

In most cases the rollover will be fine, but there are some cases (e.g. `TccGeneratorNode`) where we compare extended sequence numbers numerically.