### PR TITLE
Treat the minimum of a video frame's width or height as its height.

### DIFF
--- a/doc/constraints.md
+++ b/doc/constraints.md
@@ -12,3 +12,7 @@ higher than the specified need not be transmitted for a specific video source:
   "maxHeight": 180
 }
 ```
+
+Note that in order to handle portrait-mode video correctly,
+despite the name `maxHeight`, this parameter is actually used to specify the smaller
+of the dimensions of the video (which for portrait mode will be its width).

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
@@ -41,10 +41,13 @@ abstract class RtpLayerDesc(
      */
     val sid: Int,
     /**
-     * The max height of the bitstream that this instance represents. The actual
+     * The max "height" of the bitstream that this instance represents. The actual
      * height may be less due to bad network or system load.  [NO_HEIGHT] for unknown.
      *
-     * XXX we should be able to sniff the actual height from the RTP packets.
+     * In order to handle portrait-mode video correctly, this should actually be the smaller of
+     * the bitstream's height or width.
+     *
+     * Where possible we sniff the actual height from the RTP packets.
      */
     var height: Int,
     /**

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDPacket.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDPacket.kt
@@ -27,6 +27,7 @@ import org.jitsi.rtp.rtp.header_extensions.Av1DependencyException
 import org.jitsi.rtp.rtp.header_extensions.Av1TemplateDependencyStructure
 import org.jitsi.rtp.rtp.header_extensions.FrameInfo
 import org.jitsi.utils.logging2.Logger
+import kotlin.math.min
 
 /** A video packet carrying an AV1 Dependency Descriptor.  Note that this may or may not be an actual AV1 packet;
  * other video codecs can also carry the AV1 DD.
@@ -197,7 +198,8 @@ fun Av1DependencyDescriptorHeaderExtension.getScalabilityStructure(
         if (!activeDecodeTargetsBitmask.containsDecodeTarget(i)) {
             return@forEachIndexed
         }
-        val height = structure.maxRenderResolutions.getOrNull(dt.spatialId)?.height ?: -1
+        // Treat the lesser of width and height as the height in order to handle portrait-mode video correctly
+        val height = structure.maxRenderResolutions.getOrNull(dt.spatialId)?.let { min(it.width, it.height) } ?: -1
 
         // Calculate the fraction of this spatial layer's framerate this DT comprises.
         val frameRate = baseFrameRate * layerCounts[dt.spatialId][dt.temporalId] / maxFrameGroup

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp9/Vp9Packet.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp9/Vp9Packet.kt
@@ -24,6 +24,7 @@ import org.jitsi.rtp.extensions.bytearray.hashCodeOfSegment
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.utils.logging2.cwarn
 import org.jitsi_modified.impl.neomedia.codec.video.vp9.DePacketizer
+import kotlin.math.min
 
 /**
  * If this [Vp9Packet] instance is being created via a clone,
@@ -273,12 +274,17 @@ class Vp9Packet private constructor(
 
             val heights = if (hasResolution) {
                 Array(numSpatial) {
-                    off += 2 // We only record height, not width
+                    val width = ((buffer[off].toInt() and 0xff) shl 8) or
+                        (buffer[off + 1].toInt() and 0xff)
+                    off += 2
 
                     val height = ((buffer[off].toInt() and 0xff) shl 8) or
                         (buffer[off + 1].toInt() and 0xff)
                     off += 2
-                    height
+
+                    // Treat the lesser of width or height as the height in order to handle
+                    // portrait-mode video correctly
+                    min(width, height)
                 }
             } else {
                 Array(numSpatial) { RtpLayerDesc.NO_HEIGHT }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VlaReaderNode.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VlaReaderNode.kt
@@ -30,6 +30,7 @@ import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.LoggerImpl
 import org.jitsi.utils.logging2.cdebug
 import org.jitsi.utils.logging2.createChildLogger
+import kotlin.math.min
 
 /**
  * A node which reads the Video Layers Allocation (VLA) RTP header extension and updates the media sources.
@@ -89,14 +90,17 @@ class VlaReaderNode(
                                 }
                                 layer.targetBitrate = targetBitrateKbps.kbps
                                 spatialLayer.res?.let { res ->
-                                    if (layer.height > 0 && layer.height != res.height) {
+                                    // Treat the lesser of width and height as the height
+                                    // in order to handle portrait-mode video correctly
+                                    val minDimension = min(res.height, res.width)
+                                    if (layer.height > 0 && layer.height != minDimension) {
                                         logger.info {
                                             "Updating layer height for source ${sourceDesc.sourceName} " +
                                                 "encoding ${rtpEncoding.primarySSRC} layer ${layer.indexString()} " +
-                                                "from ${layer.height} to ${res.height}"
+                                                "from ${layer.height} to $minDimension"
                                         }
                                     }
-                                    layer.height = res.height
+                                    layer.height = minDimension
                                     /* Presume 2:1 frame rate ratios for temporal layers */
                                     val framerateFraction = 1.0 / (1 shl (maxTl - tlIdx))
                                     layer.frameRate = res.maxFramerate.toDouble() * framerateFraction

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDPacketTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDPacketTest.kt
@@ -159,6 +159,37 @@ class Av1DDPacketTest : ShouldSpec() {
                     Av1DDRtpLayerDesc(0, 2, 0, 2, 180, 30.0),
                 )
             )
+        ),
+        SampleAv1DDPacket(
+            "temporally-scalable portrait-mode keyframe",
+            // RTP header
+            "906487db2fb5ae06481d4dca" +
+                // Two-byte header extension header
+                "1000000f" +
+                // Other header extensions
+                "030387b1a4" +
+                "0502827e" +
+                // AV1 DD
+                "0b178023c58002044eaaaf2860414d34538a094040b3c13fc0" +
+                // VLA
+                "0c17a1009601f403dc0b00b3013f060167027f0602cf04ff06" +
+                // padding
+                "00" +
+                // Media payload, truncated
+                "109096029d012ad0020005396b00",
+            null,
+            RtpEncodingDesc(
+                0x481d4dcaL,
+                arrayOf(
+                    // Make sure the correct "height" value is picked from portrait mode (720x1280)
+                    // TODO: I think the frame rate calculation gets this DD wrong, but I'm not quite sure
+                    //  what the structure encoder is using
+                    Av1DDRtpLayerDesc(0, 0, 0, 0, 720, 10.0),
+                    Av1DDRtpLayerDesc(0, 1, 1, 0, 720, 20.0),
+                    Av1DDRtpLayerDesc(0, 2, 2, 0, 720, 30.0),
+                )
+            )
+
         )
     )
 

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDPacketTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDPacketTest.kt
@@ -183,7 +183,7 @@ class Av1DDPacketTest : ShouldSpec() {
                 arrayOf(
                     // Make sure the correct "height" value is picked from portrait mode (720x1280)
                     // TODO: I think the frame rate calculation gets this DD wrong, but I'm not quite sure
-                    //  what the structure encoder is using
+                    //  what structure the encoder is using
                     Av1DDRtpLayerDesc(0, 0, 0, 0, 720, 10.0),
                     Av1DDRtpLayerDesc(0, 1, 1, 0, 720, 20.0),
                     Av1DDRtpLayerDesc(0, 2, 2, 0, 720, 30.0),

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/codec/vp9/Vp9PacketTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/codec/vp9/Vp9PacketTest.kt
@@ -717,6 +717,53 @@ class Vp9PacketTest : ShouldSpec() {
             tL0PICIDX = null,
             descriptorSize = 5,
             scalabilityStructure = null
+        ),
+
+        /* Mobile chrome, portrait-mode */
+        SampleVp9Packet(
+            "Temporally-scalable portrait mode",
+            "90e553b379aa95ae6012c1c8" +
+                "1000001d" +
+                "030324e813" +
+                "05021b57" +
+                "0b5cc007e1c0081485214eaaaaa8000600004000100002aa80a8000600004000100002a000a800060000400016d549241b" +
+                "5524906d54923157e001974ca864330e222396eca8655304224390eca8775300b3013f0167027f02cf04ff0380" +
+                "0c0a01800f141c00b3013f0b" +
+                "00" +
+                // I=1,P=0,L=1,F=1,B=1,E=1,V=1,Z=0
+                "be" +
+                // M=1, PID=0x61d6=20950
+                "d1d6" +
+                // TID=0,U=1,SID=0,D=0
+                "10" +
+                // Begin SS: N_S=0,Y=1,G=0
+                "10" +
+                // WIDTH=180
+                "00b4" +
+                // HEIGHT=320
+                "0140" +
+                // VP9 media. Truncated.
+                "83498342000b3013f8167827",
+            isStartOfFrame = true,
+            isEndOfFrame = true,
+            isEndOfPicture = true,
+            isKeyframe = true,
+            isInterPicturePredicted = false,
+            pictureId = 20950,
+            hasExtendedPictureId = true,
+            isUpperLevelReference = true,
+            tid = 0,
+            sid = 0,
+            isSwitchingUpPoint = true,
+            usesInterLayerDependency = false,
+            tL0PICIDX = null,
+            descriptorSize = 9,
+            scalabilityStructure = RtpEncodingDesc(
+                0x6012c1c8,
+                arrayOf(
+                    VpxRtpLayerDesc(0, 0, 0, 180, -1.0)
+                )
+            )
         )
     )
 


### PR DESCRIPTION
To handle portrait-mode video correctly.