### PR TITLE
WIP: add handler for ReceiverAudioSubscriptionMessage

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
@@ -157,6 +157,13 @@ public class EndpointMessageTransport
         return null;
     }
 
+    @Override public BridgeChannelMessage receiverAudioSubscription(ReceiverAudioSubscriptionMessage receiverAudioSubscriptionMessage)
+    {
+        getLogger().info("Received audio subscription: " + receiverAudioSubscriptionMessage);
+        // TODO: store the subscription somewhere
+        return null;
+    }
+
     @Override
     public void unhandledMessage(@NotNull BridgeChannelMessage message)
     {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/message/BridgeChannelMessage.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/message/BridgeChannelMessage.kt
@@ -59,7 +59,8 @@ import java.util.concurrent.atomic.AtomicLong
     JsonSubTypes.Type(value = ReceiverVideoConstraintsMessage::class, name = ReceiverVideoConstraintsMessage.TYPE),
     JsonSubTypes.Type(value = SourceVideoTypeMessage::class, name = SourceVideoTypeMessage.TYPE),
     JsonSubTypes.Type(value = ConnectionStats::class, name = ConnectionStats.TYPE),
-    JsonSubTypes.Type(value = VideoTypeMessage::class, name = VideoTypeMessage.TYPE)
+    JsonSubTypes.Type(value = VideoTypeMessage::class, name = VideoTypeMessage.TYPE),
+    JsonSubTypes.Type(value = ReceiverAudioSubscriptionMessage::class, name = ReceiverAudioSubscriptionMessage.TYPE)
 )
 sealed class BridgeChannelMessage {
     private val jsonCacheDelegate = ResettableLazy { createJson() }
@@ -124,6 +125,7 @@ open class MessageHandler {
             is SourceVideoTypeMessage -> sourceVideoType(message)
             is ConnectionStats -> connectionStats(message)
             is VideoTypeMessage -> videoType(message)
+            is ReceiverAudioSubscriptionMessage -> receiverAudioSubscription(message)
         }
     }
 
@@ -150,6 +152,7 @@ open class MessageHandler {
     open fun sourceVideoType(message: SourceVideoTypeMessage) = unhandledMessageReturnNull(message)
     open fun connectionStats(message: ConnectionStats) = unhandledMessageReturnNull(message)
     open fun videoType(message: VideoTypeMessage) = unhandledMessageReturnNull(message)
+    open fun receiverAudioSubscription(message: ReceiverAudioSubscriptionMessage) = unhandledMessageReturnNull(message)
 
     fun getReceivedCounts() = receivedCounts.mapValues { it.value.get() }
 }
@@ -475,6 +478,14 @@ class SourceVideoTypeMessage(
 
     companion object {
         const val TYPE = "SourceVideoTypeMessage"
+    }
+}
+
+class ReceiverAudioSubscriptionMessage(
+    val sourceNames: List<String>
+) : BridgeChannelMessage() {
+    companion object {
+        const val TYPE = "ReceiverAudioSubscriptionMessage"
     }
 }
 


### PR DESCRIPTION
This is going to be one of PRs for the [Audio Switchboard API](https://summerofcode.withgoogle.com/myprojects/details/aBy319rB).

ReceiverAudioSubscriptionMessage is new bridge message to notify selected audio sources from the receiver. where to store the subscription and how to filter packets are further discussed and implemented later.

Corresponding change to lib-jitsi-meet: https://github.com/jitsi/lib-jitsi-meet/pull/2813