### PR TITLE
Sanity check arguments in projection contexts' doFind method.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/vp8/VP8FrameMap.java
@@ -380,6 +380,11 @@ public class VP8FrameMap
         @Nullable
         private VP8Frame doFind(Predicate<VP8Frame> pred, long startIndex, long endIndex, int increment)
         {
+            if (!((increment > 0 && startIndex <= endIndex) || (increment < 0 && startIndex >= endIndex))) {
+                throw new IllegalArgumentException("Values of startIndex=" + startIndex + ", endIndex=" + endIndex +
+                        " , and increment=" + increment + " could lead to infinite loop");
+            }
+
             for (long index = startIndex; index != endIndex; index += increment)
             {
                 VP8Frame frame = getIndex(index);

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDFrameMap.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDFrameMap.kt
@@ -231,6 +231,10 @@ internal class FrameHistory(size: Int) :
     }
 
     private fun doFind(pred: (Av1DDFrame) -> Boolean, startIndex: Long, endIndex: Long, increment: Int): Av1DDFrame? {
+        require((increment > 0 && startIndex <= endIndex) || (increment < 0 && startIndex >= endIndex)) {
+            "Values of startIndex=$startIndex, endIndex=$endIndex, and increment=$increment " +
+                "could lead to infinite loop"
+        }
         var index = startIndex
         while (index != endIndex) {
             val frame = getIndex(index)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9PictureMap.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9PictureMap.kt
@@ -261,6 +261,10 @@ constructor(size: Int) : ArrayCache<Vp9Picture>(
         startLayer: Int,
         increment: Int
     ): Vp9Frame? {
+        require((increment > 0 && startIndex <= endIndex) || (increment < 0 && startIndex >= endIndex)) {
+            "Values of startIndex=$startIndex, endIndex=$endIndex, and increment=$increment " +
+                "could lead to infinite loop"
+        }
         var index = startIndex
         var layer = startLayer
         var firstPicture = true


### PR DESCRIPTION
Attempting to prevent the infinite loop reported in Issue #2346.