### PR TITLE
Getting audio subscription and route-loudest-only work together

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -170,6 +170,15 @@ public class Conference
     private final boolean routeLoudestOnly = LoudestConfig.getRouteLoudestOnly();
 
     /**
+     * A list of local audio source names that at least one endpoint subscribes to.
+     */
+    private Set<String> subscribedLocalAudioSources = new HashSet<>();
+
+    public Set<String> getSubscribedLocalAudioSources() {
+        return subscribedLocalAudioSources;
+    }
+
+    /**
      * The task of updating the ordered list of endpoints in the conference. It runs periodically in order to adapt to
      * endpoints stopping or starting to their video streams (which affects the order).
      */
@@ -1262,6 +1271,13 @@ public class Conference
         SpeakerRanking ranking = speechActivity.levelChanged(endpoint, level);
         if (ranking == null || !routeLoudestOnly)
             return false;
+        // return false if the source is explicitly subscribed by any other endpoint.
+        List<AudioSourceDesc> sources = endpoint.getAudioSources();
+        for (AudioSourceDesc source : sources) {
+            if (subscribedLocalAudioSources.contains(source.getSourceName())) {
+                return false;
+            }
+        }
         if (ranking.isDominant && LoudestConfig.Companion.getAlwaysRouteDominant())
             return false;
         if (ranking.energyRanking < LoudestConfig.Companion.getNumLoudest())

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -368,7 +368,7 @@ class Endpoint @JvmOverloads constructor(
     /**
      * Last updated ReceiverAudioSubscription
      */
-    private var audioSubscription: AudioSubscription = AudioSubscription()
+    private var audioSubscription: AudioSubscription = AudioSubscription(conference)
 
     /**
      * Recurring event to send connection stats messages.

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/AudioSubscriptionTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/AudioSubscriptionTest.kt
@@ -18,13 +18,20 @@ package org.jitsi.videobridge
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
 import org.jitsi.videobridge.message.ReceiverAudioSubscriptionMessage
 import org.jitsi.videobridge.relay.AudioSourceDesc
+
 
 class AudioSubscriptionTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
-    private val audioSubscription = AudioSubscription()
+    val conference: Conference = mockk {
+        every { subscribedLocalAudioSources } returns mutableSetOf<String>()
+    }
+
+    private val audioSubscription = AudioSubscription(conference)
 
     init {
         context("Mode=None subscription") {


### PR DESCRIPTION
This PR fixes the conflict between audio subscription management and the route-loudest-only configuration when handling incoming packets.

When `route-loudest-only=true` is set, the bridge drops a packet before checking endpoints `wants()` it if it's not among the top `numLoudest` loudest sources. However, if a participant explicitly subscribes to a source (using "include" mode), the expectation is that they want to receive that source regardless of its loudness in most use cases. This implies the subscription should always takes precedence over `route-loudest-only` in incoming packet handling.

To handle this conflict, this PR adds new set called `subscribedLocalAudioSources` in `Conference`, which holds local source names that are subscribed by either local or remote endpoints. The set is updated in following situations:
- When a local endpoint has new "Include" subscription
  - the endpoint adds sources in the subscription to `subscribedLocalAudioSources`
- When a source is removed from the conference
  - the endpoint simply removes the source from `subscribedLocalAudioSources`
- When the bridge receives remote subscription notification from other bridges
  - the conference adds the notified source to `subscribedLocalAudioSources`

To implement the last one, this PR will also add a messaging format or something to notify new remote subscription from a bridge to other bridge.