### PR TITLE
Add debug flag to start PCAP captures automatically for every endpoint.

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/ToggleablePcapWriter.kt
@@ -65,7 +65,14 @@ class ToggleablePcapWriter(
         override fun trace(f: () -> Unit) = f.invoke()
     }
 
+    init {
+        if (startEnabled) {
+            enable()
+        }
+    }
+
     companion object {
         private val allowed: Boolean by config("jmt.debug.pcap.enabled".from(JitsiConfig.newConfig))
+        private val startEnabled: Boolean by config("jmt.debug.pcap.start-enabled".from(JitsiConfig.newConfig))
     }
 }

--- a/jitsi-media-transform/src/main/resources/reference.conf
+++ b/jitsi-media-transform/src/main/resources/reference.conf
@@ -175,7 +175,11 @@ jmt {
     pcap {
       // Whether to permit the API to dynamically enable the capture of
       // unencrypted PCAP files of media traffic.
+      // Should only be enabled in test or debug environments.
       enabled = false
+      // Whether to start pcaps for every endpoint automatically.  Requires "enable" to be true.
+      // Definitely should only be enabled in debug environments.
+      start-enabled = false
       // The directory in which to place captured PCAP files.
       directory = "/tmp"
     }


### PR DESCRIPTION
Useful for debugging problems that occur at initial join time.

Also add language warning against enabling PCAPs in production.