### PR TITLE
Change the default value of initial-max-height-px to 0.

### DIFF
--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -48,7 +48,10 @@ videobridge {
     # The default constraint to use if the receiver signals ReceiverConstraints with missing defaultConstraints.
     default-max-height-px = 180
     # The constraint to use for the initial allocation, before the receiver has signaled ReceiverConstraints.
-    initial-max-height-px = 180
+    # This should be set to non-zero only if you have clients that do not always send ReceiverConstraints.
+    # Otherwise this leads to a race condition where video media is sent before clients are ready to receive
+    # it, resulting in excessive PLIs and delays displaying video.
+    initial-max-height-px = 0
     onstage-preferred-height-px = 360
     onstage-preferred-framerate = 30
     // Whether the bridge is allowed to oversend (send the lowest layer regardless of BWE) for on-stage endpoints. If


### PR DESCRIPTION
A non-zero value of setting causes a race condition where video media is sent before clients are ready to receive it, resulting in excessive PLIs and delays displaying video.