### PR TITLE
docs: fix broken link to COLIBRI documentation

### DIFF
--- a/doc/rest.md
+++ b/doc/rest.md
@@ -5,7 +5,7 @@ The two interfaces use different ports. The _private_ interface exposes
 HTTP endpoints which are not meant to be publicly accessible (but might be used
 by other components of the infrastructure, e.g. a signaling server), such as:
 
-* The [COLIBRI control interface](rest-colibri.md) (```/colibri/```)
+* The [COLIBRI control interface](rest-colibri2.md) (```/colibri/```)
 * The health-check interface (```/about/health```)
 * The version interface (```/about/version```)
 


### PR DESCRIPTION
## Description
This PR fixes a broken documentation link in doc/rest.md.

## Changes
- Updated the link from rest-colibri.md to rest-colibri2.md
- The file was renamed to rest-colibri2.md but the reference in rest.md was not updated