### PR TITLE
issue: 1722  add IPv6 network configuration guide 

### DIFF
--- a/doc/network-configuration.md
+++ b/doc/network-configuration.md
@@ -3,7 +3,7 @@
 ## IPv6 Configuration
 
 JVB supports IPv6 in dual-stack (IPv4 + IPv6) environments.
-To enable it, add the following to your `application.conf`:
+To enable it, add the following to your `jvb.conf`:
 ```hocon
 ice4j {
   harvest {
@@ -25,7 +25,6 @@ ice4j {
 ```
 
 ### Notes
-- STUN/TURN is not required for the Videobridge itself, only for P2P connections
 - Jitsi Web and the Videobridge can have different IPv6 addresses
 - When IPv6 is enabled, a UDP6 listener will open on port 10000
 

--- a/doc/network-configuration.md
+++ b/doc/network-configuration.md
@@ -1,0 +1,42 @@
+# Network Configuration
+
+## IPv6 Configuration
+
+JVB supports IPv6 in dual-stack (IPv4 + IPv6) environments.
+To enable it, add the following to your `application.conf`:
+```hocon
+ice4j {
+  harvest {
+    use-ipv6 = true
+    use-link-local-addresses = false
+    mapping {
+      stun {
+        addresses = [ "your-stun-server:3478" ]
+      }
+      static-mappings = [
+        {
+          local-address = "YOUR_PRIVATE_IPV4"
+          public-address = "YOUR_PUBLIC_IPV4"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Notes
+- STUN/TURN is not required for the Videobridge itself, only for P2P connections
+- Jitsi Web and the Videobridge can have different IPv6 addresses
+- When IPv6 is enabled, a UDP6 listener will open on port 10000
+
+### Verifying ICE Candidates
+To confirm correct candidates are advertised, enable verbose logging in `/etc/jitsi/videobridge/logging.properties`:
+```
+org.jitsi.videobridge.xmpp.XmppConnection.level=ALL
+```
+
+Then grep the logs for `SENT` to inspect the ICE candidates being sent.
+
+### Related Issues
+- [#1722](https://github.com/jitsi/jitsi-videobridge/issues/1722)
+


### PR DESCRIPTION
While going through the open issues, I noticed there was no documentation 
explaining how to configure IPv6 on JVB. Since issue #1722 had a working 
example in the comments but nothing in the official docs, I put together 
a new doc/network-configuration.md file to cover this.

It explains how to set up IPv6 in a dual-stack environment using the ice4j 
harvest config, includes a static NAT mapping example, clarifies that 
STUN/TURN is not needed for the Videobridge itself, and shows how to verify 
ICE candidates via logging.
issue 1722