### PR TITLE
In VP9 and AV1, if a new frame is both a reset and a resumption, handle it as a resumption.

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionContext.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionContext.kt
@@ -291,10 +291,10 @@ class Av1DDAdaptiveSourceProjectionContext(
     ): Av1DDFrameProjection {
         if (frameIsNewSsrc(frame)) {
             return createEncodingSwitchProjection(frame, initialPacket, mark, newDt, receivedTime)
-        } else if (isResumption) {
-            return createResumptionProjection(frame, initialPacket, mark, newDt, receivedTime)
         } else if (isReset) {
             return createResetProjection(frame, initialPacket, mark, newDt, receivedTime)
+        } else if (isResumption) {
+            return createResumptionProjection(frame, initialPacket, mark, newDt, receivedTime)
         }
 
         return createInEncodingProjection(frame, initialPacket, mark, newDt, receivedTime)
@@ -384,7 +384,7 @@ class Av1DDAdaptiveSourceProjectionContext(
         lastFrameNumberIndexResumption = frame.index
 
         /* These must be non-null because we don't execute this function unless
-            frameIsNewSsrc has returned false.
+            frameIsNewSsrc and isReset were both false.
          */
         val lastFrame = prevFrame(frame)!!
         val lastProjectedFrame = lastAv1FrameProjection.av1Frame!!

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionContext.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionContext.kt
@@ -266,10 +266,10 @@ class Vp9AdaptiveSourceProjectionContext(
     ): Vp9FrameProjection {
         if (frameIsNewSsrc(frame)) {
             return createEncodingSwitchProjection(frame, initialPacket, mark, receivedTime)
-        } else if (isResumption) {
-            return createResumptionProjection(frame, initialPacket, mark, receivedTime)
         } else if (isReset) {
             return createResetProjection(frame, initialPacket, mark, receivedTime)
+        } else if (isResumption) {
+            return createResumptionProjection(frame, initialPacket, mark, receivedTime)
         }
 
         return createInEncodingProjection(frame, initialPacket, mark, receivedTime)
@@ -370,7 +370,7 @@ class Vp9AdaptiveSourceProjectionContext(
         lastPicIdIndexResumption = frame.index
 
         /* These must be non-null because we don't execute this function unless
-            frameIsNewSsrc has returned false.
+            frameIsNewSsrc and isReset were both false.
          */
         val lastFrame = prevFrame(frame)!!
         val lastProjectedFrame = lastVp9FrameProjection.vp9Frame!!


### PR DESCRIPTION
Should fix a case where sources could get stuck after being off for a long time.