### PR TITLE
Allow other JDK implementations

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: extra
 Maintainer: Jitsi Team <dev@jitsi.org>
 Uploaders: Emil Ivov <emcho@jitsi.org>, Damian Minkov <damencho@jitsi.org>
-Build-Depends: debhelper (>= 9), dh-systemd, openjdk-17-jdk | openjdk-21-jdk, maven
+Build-Depends: debhelper (>= 9), dh-systemd, java17-sdk-headless | openjdk-17-jdk | openjdk-21-jdk, maven
 Standards-Version: 3.9.3
 Homepage: https://jitsi.org/videobridge
 
@@ -11,7 +11,7 @@ Package: jitsi-videobridge2
 Replaces: jitsi-videobridge
 Conflicts: jitsi-videobridge (<= 1400-1)
 Architecture: all
-Pre-Depends: openjdk-17-jre-headless | openjdk-17-jre | openjdk-21-jre-headless | openjdk-21-jre, libssl3 | libssl1.1
+Pre-Depends: java17-runtime-headless | openjdk-17-jre-headless | openjdk-17-jre | java21-runtime-headless | openjdk-21-jre-headless | openjdk-21-jre, libssl3 | libssl1.1
 Depends: ${misc:Depends}, procps, uuid-runtime, ruby-hocon
 Recommends: libpcap0.8
 Description: WebRTC compatible Selective Forwarding Unit (SFU)

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: extra
 Maintainer: Jitsi Team <dev@jitsi.org>
 Uploaders: Emil Ivov <emcho@jitsi.org>, Damian Minkov <damencho@jitsi.org>
-Build-Depends: debhelper (>= 9), dh-systemd, java17-sdk-headless | openjdk-17-jdk | openjdk-21-jdk, maven
+Build-Depends: debhelper (>= 9), dh-systemd, java17-sdk-headless | openjdk-17-jdk | java21-sdk-headless | openjdk-21-jdk, maven
 Standards-Version: 3.9.3
 Homepage: https://jitsi.org/videobridge
 


### PR DESCRIPTION
The requirement on openjdk-* is quite strict and don't allow usage of other Java implementations. I've just added the generic dependencies that would allow other Java. As an example, in Debian bullseye there is not openjdk 17 nor 21, but you may download amazon corretto debian package. This change allow to use any java implementation that provides a well crafted debian package