### PR TITLE
fix: Redact http-header values from RECV colibri2 request log.

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -245,7 +245,10 @@ public class Conference
                     {
                         logger.info( () -> {
                             String reqStr = request.getRequest().toXML().toString();
-                            reqStr = RedactColibri.Companion.redactHttpHeaderValues(reqStr);
+                            if (VideobridgeConfig.getRedactColibriHttpHeaders())
+                            {
+                                reqStr = RedactColibri.Companion.redactHttpHeaderValues(reqStr);
+                            }
                             if (VideobridgeConfig.getRedactRemoteAddresses())
                             {
                                 reqStr = RedactColibri.Companion.redactIp(reqStr);
@@ -264,6 +267,10 @@ public class Conference
                         if (processingDelay > 100)
                         {
                             String reqStr = request.getRequest().toXML().toString();
+                            if (VideobridgeConfig.getRedactColibriHttpHeaders())
+                            {
+                                reqStr = RedactColibri.Companion.redactHttpHeaderValues(reqStr);
+                            }
                             if (VideobridgeConfig.getRedactRemoteAddresses())
                             {
                                 reqStr = RedactColibri.Companion.redactIp(reqStr);

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -245,6 +245,7 @@ public class Conference
                     {
                         logger.info( () -> {
                             String reqStr = request.getRequest().toXML().toString();
+                            reqStr = RedactColibriIp.Companion.redactHttpHeaderValues(reqStr);
                             if (VideobridgeConfig.getRedactRemoteAddresses())
                             {
                                 reqStr = RedactColibriIp.Companion.redact(reqStr);

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -245,10 +245,10 @@ public class Conference
                     {
                         logger.info( () -> {
                             String reqStr = request.getRequest().toXML().toString();
-                            reqStr = RedactColibriIp.Companion.redactHttpHeaderValues(reqStr);
+                            reqStr = RedactColibri.Companion.redactHttpHeaderValues(reqStr);
                             if (VideobridgeConfig.getRedactRemoteAddresses())
                             {
-                                reqStr = RedactColibriIp.Companion.redact(reqStr);
+                                reqStr = RedactColibri.Companion.redactIp(reqStr);
                             }
                             return "RECV colibri2 request: " + reqStr;
                         });
@@ -266,7 +266,7 @@ public class Conference
                             String reqStr = request.getRequest().toXML().toString();
                             if (VideobridgeConfig.getRedactRemoteAddresses())
                             {
-                                reqStr = RedactColibriIp.Companion.redact(reqStr);
+                                reqStr = RedactColibri.Companion.redactIp(reqStr);
                             }
                             logger.warn("Took " + processingDelay + " ms to process an IQ (total delay "
                                     + totalDelay + " ms): " + reqStr);

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/VideobridgeConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/VideobridgeConfig.kt
@@ -29,5 +29,10 @@ class VideobridgeConfig private constructor() {
         val redactRemoteAddresses: Boolean by config {
             "videobridge.redact-remote-addresses".from(JitsiConfig.newConfig)
         }
+
+        @JvmStatic
+        val redactColibriHttpHeaders: Boolean by config {
+            "videobridge.redact-colibri-http-headers".from(JitsiConfig.newConfig)
+        }
     }
 }

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -402,6 +402,9 @@ videobridge {
   # Whether to redact remote endpoint IP addresses from logs
   redact-remote-addresses = true
 
+  # Whether to redact the values of HTTP headers specified in incoming colibri requests.
+  redact-colibri-http-headers = true
+
 
   connection-stats {
     # Whether to periodically send connection stats (currently, estimated downlink bandwidth) to endpoints

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-xmpp-extensions</artifactId>
-                <version>1.0-105-g07af8a9</version>
+                <version>1.0-107-ge5f6370</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary
- HTTP header values in `connect` elements (e.g. API keys, auth tokens) were being logged in plain text in the `RECV colibri2 request` log line
- Now unconditionally calls `RedactColibriIp.redactHttpHeaderValues()` before logging, replacing all `http-header` `value` attributes with `[redacted]`

## Test plan
- [ ] Deploy and trigger a colibri2 request with `http-header` elements — values should appear as `[redacted]` in jvb.log
- [ ] Depends on: jitsi/jitsi-xmpp-extensions#redact-http-headers-log

🤖 Generated with [Claude Code](https://claude.com/claude-code)