### PR TITLE
Remove agafua-syslog dependency

### DIFF
--- a/jvb/lib/logging.properties
+++ b/jvb/lib/logging.properties
@@ -1,5 +1,4 @@
 handlers= java.util.logging.ConsoleHandler
-#handlers= java.util.logging.ConsoleHandler, com.agafua.syslog.SyslogHandler
 #handlers= java.util.logging.ConsoleHandler, io.sentry.jul.SentryHandler
 
 java.util.logging.ConsoleHandler.level = ALL
@@ -7,14 +6,6 @@ java.util.logging.ConsoleHandler.formatter = org.jitsi.utils.logging2.JitsiLogFo
 
 org.jitsi.utils.logging2.JitsiLogFormatter.programname=JVB
 .level=INFO
-
-# Syslog (uncomment handler to use)
-com.agafua.syslog.SyslogHandler.transport = udp
-com.agafua.syslog.SyslogHandler.facility = local0
-com.agafua.syslog.SyslogHandler.port = 514
-com.agafua.syslog.SyslogHandler.hostname = localhost
-com.agafua.syslog.SyslogHandler.formatter = org.jitsi.utils.logging2.JitsiLogFormatter
-com.agafua.syslog.SyslogHandler.escapeNewlines = false
 
 # Sentry (uncomment handler to use)
 io.sentry.jul.SentryHandler.level=WARNING

--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -206,12 +206,6 @@
     </dependency>
     <!-- runtime -->
     <dependency>
-      <groupId>rusv</groupId>
-      <artifactId>agafua-syslog</artifactId>
-      <version>0.4</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>io.sentry</groupId>
       <artifactId>sentry</artifactId>
       <version>7.20.0</version>


### PR DESCRIPTION
The syslog handler was already commented out in `logging.properties` — remove the unused dependency and the related dead config.