### PR TITLE
Fix Exporter reconnect backoff loop

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
@@ -57,6 +57,7 @@ internal class Exporter(
     private val isShuttingDown = AtomicBoolean(false)
     private val reconnectAttempts = AtomicInteger(0)
     private var reconnectFuture: ScheduledFuture<*>? = null
+
     @Volatile private var connectionOpenedAtMs: Long = 0
 
     // Ping/pong state

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
@@ -58,7 +58,7 @@ internal class Exporter(
     private val reconnectAttempts = AtomicInteger(0)
     private var reconnectFuture: ScheduledFuture<*>? = null
 
-    @Volatile private var connectionOpenedAtMs: Long = 0
+    private var connectionOpenedAtMs: Long = 0
 
     // Ping/pong state
     private var pingScheduledFuture: ScheduledFuture<*>? = null
@@ -95,7 +95,10 @@ internal class Exporter(
             val openedAt = connectionOpenedAtMs
             val stableConnection = openedAt > 0 &&
                 System.currentTimeMillis() - openedAt > stableConnectionThreshold.toMillis()
-            if (stableConnection) reconnectAttempts.set(0)
+            if (stableConnection) {
+                reconnectAttempts.set(0)
+                connectionOpenedAtMs = 0
+            }
 
             session = null
             logger.info("Websocket closed with status $statusCode, reason: $reason")

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
@@ -57,6 +57,7 @@ internal class Exporter(
     private val isShuttingDown = AtomicBoolean(false)
     private val reconnectAttempts = AtomicInteger(0)
     private var reconnectFuture: ScheduledFuture<*>? = null
+    @Volatile private var connectionOpenedAtMs: Long = 0
 
     // Ping/pong state
     private var pingScheduledFuture: ScheduledFuture<*>? = null
@@ -90,6 +91,11 @@ internal class Exporter(
             get() = session != null
 
         override fun onWebSocketClose(statusCode: Int, reason: String?) {
+            val openedAt = connectionOpenedAtMs
+            val stableConnection = openedAt > 0 &&
+                System.currentTimeMillis() - openedAt > stableConnectionThreshold.toMillis()
+            if (stableConnection) reconnectAttempts.set(0)
+
             session = null
             logger.info("Websocket closed with status $statusCode, reason: $reason")
             stopPing()
@@ -99,16 +105,15 @@ internal class Exporter(
                 instanceWebSocketInternalErrors.incrementAndGet()
             }
             if (!isShuttingDown.get()) {
-                // Avoid reconnect loops with no delay in case of an "internal error" (1011)
-                scheduleReconnect(internalError)
+                scheduleReconnect()
             }
         }
 
         override fun onWebSocketOpen(session: Session) {
             this.session = session
+            connectionOpenedAtMs = System.currentTimeMillis()
             logger.info("Websocket connected: $isConnected")
             serializer = initSerializer()
-            reconnectAttempts.set(0)
             cancelReconnect()
             startPing()
         }
@@ -251,10 +256,7 @@ internal class Exporter(
         }
     }
 
-    private fun scheduleReconnect(
-        // Ignore the number of attempts and schedule using the maximum configured delay instead.
-        maxDelay: Boolean = false
-    ) {
+    private fun scheduleReconnect() {
         if (isShuttingDown.get()) {
             return
         }
@@ -267,7 +269,7 @@ internal class Exporter(
             }
         }
 
-        val delayMs = if (maxDelay) Companion.maxDelay.toMillis() else getDelayMs(attempt)
+        val delayMs = getDelayMs(attempt)
         logger.info("Scheduling reconnection attempt $attempt in $delayMs ms")
 
         cancelReconnect()
@@ -390,6 +392,10 @@ internal class Exporter(
 
         private val maxDelay: Duration by config {
             "videobridge.exporter.max-delay".from(JitsiConfig.newConfig)
+        }
+
+        val stableConnectionThreshold: Duration by config {
+            "videobridge.exporter.stable-connection-threshold".from(JitsiConfig.newConfig)
         }
 
         // 0, base, base * 2, max at 30 seconds

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -431,6 +431,6 @@ videobridge {
     // How long a connection must stay open before it is considered stable. Only stable connections reset the
     // reconnect attempt counter (and thus the backoff). Prevents tight reconnect loops when the remote closes
     // the connection immediately after it opens.
-    stable-connection-threshold = 1 minute
+    stable-connection-threshold = 30 seconds
   }
 }

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -428,5 +428,9 @@ videobridge {
     // and doubles at each step maxing at max-delay.
     base-delay = 1 second
     max-delay = 30 seconds
+    // How long a connection must stay open before it is considered stable. Only stable connections reset the
+    // reconnect attempt counter (and thus the backoff). Prevents tight reconnect loops when the remote closes
+    // the connection immediately after it opens.
+    stable-connection-threshold = 1 minute
   }
 }


### PR DESCRIPTION
Reset `reconnectAttempts` only after a stable connection (open longer than
`stable-connection-threshold`, default 1 minute), not on every WebSocket open.

Previously the counter was reset in `onWebSocketOpen`, so any connection that
opened and immediately closed would always be treated as attempt 1 (0 ms delay),
causing an infinite tight reconnect loop with no backoff.

Also removes the `maxDelay` parameter from `scheduleReconnect` — it was a
workaround for the same bug (forcing max delay for 1011 errors to avoid the
0 ms loop). With the counter reset fixed, normal backoff handles all error codes.