### PR TITLE
Disable colibri WebSockets and public HTTP server by default in debian package

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -78,16 +78,6 @@ case "$1" in
         if [ ! -f $HOCON_CONFIG ]; then
             echo "Generating a default hocon config"
             echo "videobridge {
-    http-servers {
-        public {
-            port = 9090
-        }
-    }
-    websockets {
-        enabled = true
-        domain = \"$JVB_HOSTNAME:443\"
-        tls = true
-    }
     apis.xmpp-client.configs {
         shard {
             HOSTNAME=localhost


### PR DESCRIPTION
Previously the generated `jvb.conf` enabled websockets and started the public HTTP server on port 9090. Both now default to disabled, matching the `reference.conf` defaults.

To enable, add the following to `/etc/jitsi/videobridge/jvb.conf`:

```
videobridge {
    http-servers {
        public {
            port = 9090
        }
    }
    websockets {
        enabled = true
        domain = "<hostname>:443"
        tls = true
    }
}
```

See also: jitsi/jitsi-meet#17431 for the corresponding nginx/apache config change.