### PR TITLE
Replace json-simple with Jackson

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/MediaSources.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/MediaSources.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.nlj
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.utils.OrderedJsonObject
 
 /**
@@ -59,15 +60,16 @@ class MediaSources {
 
     fun getMediaSources(): Array<MediaSourceDesc> = sources
 
-    fun debugState() = OrderedJsonObject().apply {
+    fun debugState(): ObjectNode = OrderedJsonObject().apply {
         sources.forEach { source ->
-            this[source.sourceName] = OrderedJsonObject().apply {
-                this["owner"] = source.owner
-                this["video_type"] = source.videoType.toString()
+            val sourceNode = OrderedJsonObject().apply {
+                put("owner", source.owner)
+                put("video_type", source.videoType.toString())
                 source.rtpEncodings.forEach {
-                    this["rtp_encoding_${it.primarySSRC}"] = it.debugState()
+                    set<ObjectNode>("rtp_encoding_${it.primarySSRC}", it.debugState())
                 }
             }
+            set<ObjectNode>(source.sourceName, sourceNode)
         }
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/MediaSources.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/MediaSources.kt
@@ -16,8 +16,8 @@
 
 package org.jitsi.nlj
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import org.jitsi.utils.OrderedJsonObject
 
 /**
  * Maintains an array of [MediaSourceDesc]. The set method preserves the existing sources that match one of the new
@@ -60,9 +60,9 @@ class MediaSources {
 
     fun getMediaSources(): Array<MediaSourceDesc> = sources
 
-    fun debugState(): ObjectNode = OrderedJsonObject().apply {
+    fun debugState(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         sources.forEach { source ->
-            val sourceNode = OrderedJsonObject().apply {
+            val sourceNode = JsonNodeFactory.instance.objectNode().apply {
                 put("owner", source.owner)
                 put("video_type", source.videoType.toString())
                 source.rtpEncodings.forEach {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpEncodingDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpEncodingDesc.kt
@@ -15,11 +15,11 @@
  */
 package org.jitsi.nlj
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.rtp.SsrcAssociationType
 import org.jitsi.nlj.rtp.VideoRtpPacket
 import org.jitsi.nlj.stats.NodeStatsBlock
-import org.jitsi.utils.OrderedJsonObject
 
 /**
  * Keeps track of information specific to an RTP encoded stream
@@ -172,7 +172,7 @@ constructor(
     /**
      * Extracts a [NodeStatsBlock] from an [RtpEncodingDesc].
      */
-    fun debugState(): ObjectNode = OrderedJsonObject().apply {
+    fun debugState(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("rtx_ssrc", getSecondarySsrc(SsrcAssociationType.RTX))
         put("fec_ssrc", getSecondarySsrc(SsrcAssociationType.FEC))
         put("eid", eid)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpEncodingDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpEncodingDesc.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.rtp.SsrcAssociationType
 import org.jitsi.nlj.rtp.VideoRtpPacket
 import org.jitsi.nlj.stats.NodeStatsBlock
@@ -171,13 +172,13 @@ constructor(
     /**
      * Extracts a [NodeStatsBlock] from an [RtpEncodingDesc].
      */
-    fun debugState() = OrderedJsonObject().apply {
-        this["rtx_ssrc"] = getSecondarySsrc(SsrcAssociationType.RTX)
-        this["fec_ssrc"] = getSecondarySsrc(SsrcAssociationType.FEC)
-        this["eid"] = eid
-        this["nominal_height"] = nominalHeight
+    fun debugState(): ObjectNode = OrderedJsonObject().apply {
+        put("rtx_ssrc", getSecondarySsrc(SsrcAssociationType.RTX))
+        put("fec_ssrc", getSecondarySsrc(SsrcAssociationType.FEC))
+        put("eid", eid)
+        put("nominal_height", nominalHeight)
         for (layer in layers) {
-            this[layer.indexString()] = layer.debugState()
+            set<ObjectNode>(layer.indexString(), layer.debugState())
         }
     }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
@@ -15,12 +15,12 @@
  */
 package org.jitsi.nlj
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.transform.node.incoming.BitrateCalculator
 import org.jitsi.nlj.util.Bandwidth
 import org.jitsi.nlj.util.BitrateTracker
 import org.jitsi.nlj.util.DataSize
-import org.jitsi.utils.OrderedJsonObject
 
 /**
  * Keeps track of its subjective quality index,
@@ -122,7 +122,7 @@ abstract class RtpLayerDesc(
      */
     abstract fun hasZeroBitrate(nowMs: Long): Boolean
 
-    open fun debugState(): ObjectNode = OrderedJsonObject().apply {
+    open fun debugState(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("frameRate", frameRate)
         put("height", height)
         put("index", index)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.transform.node.incoming.BitrateCalculator
 import org.jitsi.nlj.util.Bandwidth
 import org.jitsi.nlj.util.BitrateTracker
@@ -121,13 +122,13 @@ abstract class RtpLayerDesc(
      */
     abstract fun hasZeroBitrate(nowMs: Long): Boolean
 
-    open fun debugState(): OrderedJsonObject = OrderedJsonObject().apply {
-        this["frameRate"] = frameRate
-        this["height"] = height
-        this["index"] = index
-        this["bitrate_bps"] = getBitrate(System.currentTimeMillis()).bps
-        this["target_bitrate"] = targetBitrate?.bps ?: 0
-        this["indexString"] = indexString()
+    open fun debugState(): ObjectNode = OrderedJsonObject().apply {
+        put("frameRate", frameRate)
+        put("height", height)
+        put("index", index)
+        put("bitrate_bps", getBitrate(System.currentTimeMillis()).bps)
+        put("target_bitrate", targetBitrate?.bps ?: 0)
+        put("indexString", indexString())
     }
 
     abstract fun indexString(): String

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiver.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiver.kt
@@ -15,12 +15,12 @@
  */
 package org.jitsi.nlj
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.rtp.LossListener
 import org.jitsi.nlj.srtp.SrtpTransformers
 import org.jitsi.nlj.stats.EndpointConnectionStats
 import org.jitsi.nlj.stats.RtpReceiverStats
 import org.jitsi.nlj.util.Bandwidth
-import org.jitsi.utils.OrderedJsonObject
 
 abstract class RtpReceiver :
     StatsKeepingPacketHandler(),
@@ -39,7 +39,7 @@ abstract class RtpReceiver :
      */
     abstract fun enqueuePacket(p: PacketInfo)
 
-    abstract fun debugState(mode: DebugStateMode): OrderedJsonObject
+    abstract fun debugState(mode: DebugStateMode): ObjectNode
 
     /**
      * Set the SRTP transformers to be used for RTP/RTCP encryption and decryption

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
@@ -68,7 +69,6 @@ import org.jitsi.rtp.Packet
 import org.jitsi.rtp.extensions.looksLikeRtcp
 import org.jitsi.rtp.extensions.looksLikeRtp
 import org.jitsi.rtp.rtcp.RtcpPacket
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.cdebug
@@ -285,7 +285,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
 
     override fun doProcessPacket(packetInfo: PacketInfo) = inputTreeRoot.processPacket(packetInfo)
 
-    override fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+    override fun debugState(mode: DebugStateMode): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         NodeDebugStateVisitor(this, mode).visit(inputTreeRoot)
     }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
@@ -284,7 +285,7 @@ class RtpReceiverImpl @JvmOverloads constructor(
 
     override fun doProcessPacket(packetInfo: PacketInfo) = inputTreeRoot.processPacket(packetInfo)
 
-    override fun debugState(mode: DebugStateMode) = OrderedJsonObject().apply {
+    override fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
         NodeDebugStateVisitor(this, mode).visit(inputTreeRoot)
     }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSender.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSender.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.rtp.LossListener
 import org.jitsi.nlj.rtp.RtpExtensionType
 import org.jitsi.nlj.rtp.TransportCcEngine
@@ -22,7 +23,6 @@ import org.jitsi.nlj.srtp.SrtpTransformers
 import org.jitsi.nlj.stats.EndpointConnectionStats
 import org.jitsi.nlj.stats.PacketStreamStats
 import org.jitsi.nlj.transform.node.outgoing.OutgoingStatisticsSnapshot
-import org.jitsi.utils.OrderedJsonObject
 
 /**
  * Not an 'RtpSender' in the sense that it sends only RTP (and not
@@ -55,5 +55,5 @@ abstract class RtpSender :
      */
     var preProcesor: ((PacketInfo) -> PacketInfo?)? = null
 
-    abstract fun debugState(mode: DebugStateMode): OrderedJsonObject
+    abstract fun debugState(mode: DebugStateMode): ObjectNode
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
@@ -333,17 +334,17 @@ class RtpSenderImpl(
         probingDataSender.handleEvent(event)
     }
 
-    override fun debugState(mode: DebugStateMode) = OrderedJsonObject().apply {
+    override fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
         if (mode == DebugStateMode.FULL) {
             appendAll(super.getNodeStats().toJson())
-            this["packet_queue"] = incomingPacketQueue.debugState
-            this["running"] = running
+            put("packet_queue", incomingPacketQueue.debugState.toString())
+            put("running", running)
         }
         appendAll(nackHandler.getNodeStats().toJson())
-        this["probing_data_sender"] = probingDataSender.debugState(mode)
-        this["local_video_ssrc"] = localVideoSsrc?.toString() ?: "null"
-        this["local_audio_ssrc"] = localAudioSsrc?.toString() ?: "null"
-        this["transport_cc_engine"] = transportCcEngine.getStatistics().toJson()
+        set<ObjectNode>("probing_data_sender", probingDataSender.debugState(mode))
+        put("local_video_ssrc", localVideoSsrc?.toString() ?: "null")
+        put("local_audio_ssrc", localAudioSsrc?.toString() ?: "null")
+        set<ObjectNode>("transport_cc_engine", transportCcEngine.getStatistics().toJson())
         NodeDebugStateVisitor(this, mode).reverseVisit(outputPipelineTerminationNode)
     }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
@@ -62,7 +63,6 @@ import org.jitsi.nlj.util.StreamInformationStore
 import org.jitsi.nlj.util.appendAll
 import org.jitsi.rtp.rtcp.RtcpPacket
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.cdebug
@@ -334,7 +334,7 @@ class RtpSenderImpl(
         probingDataSender.handleEvent(event)
     }
 
-    override fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+    override fun debugState(mode: DebugStateMode): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         if (mode == DebugStateMode.FULL) {
             appendAll(super.getNodeStats().toJson())
             set<ObjectNode>("packet_queue", incomingPacketQueue.debugState)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -337,7 +337,7 @@ class RtpSenderImpl(
     override fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
         if (mode == DebugStateMode.FULL) {
             appendAll(super.getNodeStats().toJson())
-            put("packet_queue", incomingPacketQueue.debugState.toString())
+            set<ObjectNode>("packet_queue", incomingPacketQueue.debugState)
             put("running", running)
         }
         appendAll(nackHandler.getNodeStats().toJson())

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.format.PayloadType
 import org.jitsi.nlj.rtcp.RtcpEventNotifier
 import org.jitsi.nlj.rtp.RtpExtension
@@ -325,12 +326,12 @@ class Transceiver(
         rtpReceiver.forceMuteVideo(shouldMute)
     }
 
-    fun debugState(mode: DebugStateMode): OrderedJsonObject = OrderedJsonObject().apply {
-        put("stream_information_store", streamInformationStore.debugState(mode))
-        put("media_sources", mediaSources.debugState())
-        put("endpoint_connection_stats", endpointConnectionStats.getSnapshot().toJson())
-        put("receiver", rtpReceiver.debugState(mode))
-        put("sender", rtpSender.debugState(mode))
+    fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+        set<ObjectNode>("stream_information_store", streamInformationStore.debugState(mode))
+        set<ObjectNode>("media_sources", mediaSources.debugState())
+        set<ObjectNode>("endpoint_connection_stats", endpointConnectionStats.getSnapshot().toJson())
+        set<ObjectNode>("receiver", rtpReceiver.debugState(mode))
+        set<ObjectNode>("sender", rtpSender.debugState(mode))
     }
 
     /**

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.format.PayloadType
 import org.jitsi.nlj.rtcp.RtcpEventNotifier
@@ -33,7 +34,6 @@ import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
 import org.jitsi.nlj.util.SsrcAssociation
 import org.jitsi.nlj.util.StreamInformationStoreImpl
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.cdebug
@@ -326,7 +326,7 @@ class Transceiver(
         rtpReceiver.forceMuteVideo(shouldMute)
     }
 
-    fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+    fun debugState(mode: DebugStateMode): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         set<ObjectNode>("stream_information_store", streamInformationStore.debugState(mode))
         set<ObjectNode>("media_sources", mediaSources.debugState())
         set<ObjectNode>("endpoint_connection_stats", endpointConnectionStats.getSnapshot().toJson())

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
@@ -16,13 +16,13 @@
 
 package org.jitsi.nlj.dtls
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.bouncycastle.tls.Certificate
 import org.bouncycastle.tls.DTLSTransport
 import org.bouncycastle.tls.DatagramTransport
 import org.jitsi.nlj.srtp.TlsRole
 import org.jitsi.nlj.util.BufferPool
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.concurrent.ArrayBlockingQueueWithShutdown
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.cdebug
@@ -236,7 +236,7 @@ class DtlsStack(
         processIncomingProtocolData()
     }
 
-    fun getDebugState(): ObjectNode = OrderedJsonObject().apply {
+    fun getDebugState(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("localFingerprintHashFunction", certificateInfo.localFingerprint)
         put("remoteFingerprints", remoteFingerprints.map { (hash, fp) -> "$hash: $fp" }.joinToString())
         put("role", (role?.javaClass ?: "null").toString())

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.nlj.dtls
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.bouncycastle.tls.Certificate
 import org.bouncycastle.tls.DTLSTransport
 import org.bouncycastle.tls.DatagramTransport
@@ -235,7 +236,7 @@ class DtlsStack(
         processIncomingProtocolData()
     }
 
-    fun getDebugState(): OrderedJsonObject = OrderedJsonObject().apply {
+    fun getDebugState(): ObjectNode = OrderedJsonObject().apply {
         put("localFingerprintHashFunction", certificateInfo.localFingerprint)
         put("remoteFingerprints", remoteFingerprints.map { (hash, fp) -> "$hash: $fp" }.joinToString())
         put("role", (role?.javaClass ?: "null").toString())

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/KeyframeRequester.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/KeyframeRequester.kt
@@ -234,14 +234,14 @@ class KeyframeRequester @JvmOverloads constructor(
     }
 
     override fun statsJson() = super.statsJson().apply {
-        this["num_api_requests"] = numApiRequests
-        this["num_api_requests_dropped"] = numApiRequestsDropped
-        this["num_firs_dropped"] = numFirsDropped
-        this["num_firs_generated"] = numFirsGenerated
-        this["num_firs_forwarded"] = numFirsForwarded
-        this["num_plis_dropped"] = numPlisDropped
-        this["num_plis_generated"] = numPlisGenerated
-        this["num_plis_forwarded"] = numPlisForwarded
+        put("num_api_requests", numApiRequests)
+        put("num_api_requests_dropped", numApiRequestsDropped)
+        put("num_firs_dropped", numFirsDropped)
+        put("num_firs_generated", numFirsGenerated)
+        put("num_firs_forwarded", numFirsForwarded)
+        put("num_plis_dropped", numPlisDropped)
+        put("num_plis_generated", numPlisGenerated)
+        put("num_plis_forwarded", numPlisForwarded)
     }
 
     fun onRttUpdate(newRtt: Double) {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/ClassicTransportCcEngine.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/ClassicTransportCcEngine.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj.rtp
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.rtp.bandwidthestimation.BandwidthEstimator
 import org.jitsi.nlj.util.ArrayCache
@@ -283,7 +284,7 @@ class ClassicTransportCcEngine(
         val numMissingPacketReports: Long,
         val bandwidthEstimatorStats: BandwidthEstimator.StatisticsSnapshot
     ) : TransportCcEngine.StatisticsSnapshot() {
-        override fun toJson(): Map<*, *> {
+        override fun toJson(): ObjectNode {
             return OrderedJsonObject().also {
                 it.put("name", ClassicTransportCcEngine::class.java.simpleName)
                 it.put("numPacketsReported", numPacketsReported)
@@ -292,7 +293,7 @@ class ClassicTransportCcEngine(
                 it.put("numPacketsReportedAfterLost", numPacketsReportedAfterLost)
                 it.put("numPacketsUnreported", numPacketsUnreported)
                 it.put("numMissingPacketReports", numMissingPacketReports)
-                it.put("bandwidth_estimator_stats", bandwidthEstimatorStats.toJson())
+                it.set<ObjectNode>("bandwidth_estimator_stats", bandwidthEstimatorStats.toJson())
             }
         }
     }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/ClassicTransportCcEngine.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/ClassicTransportCcEngine.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj.rtp
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.rtp.bandwidthestimation.BandwidthEstimator
@@ -28,7 +29,6 @@ import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.ReceivedPacketReport
 import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.RtcpFbTccPacket
 import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.UnreceivedPacketReport
 import org.jitsi.utils.NEVER
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.formatMilli
 import org.jitsi.utils.joinToRangedString
 import org.jitsi.utils.logging2.Logger
@@ -285,7 +285,7 @@ class ClassicTransportCcEngine(
         val bandwidthEstimatorStats: BandwidthEstimator.StatisticsSnapshot
     ) : TransportCcEngine.StatisticsSnapshot() {
         override fun toJson(): ObjectNode {
-            return OrderedJsonObject().also {
+            return JsonNodeFactory.instance.objectNode().also {
                 it.put("name", ClassicTransportCcEngine::class.java.simpleName)
                 it.put("numPacketsReported", numPacketsReported)
                 it.put("numPacketsReportedLost", numPacketsReportedLost)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/LossListener.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/LossListener.kt
@@ -16,7 +16,7 @@
 
 package org.jitsi.nlj.rtp
 
-import org.jitsi.utils.OrderedJsonObject
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import org.jitsi.utils.secs
 import org.jitsi.utils.stats.RateTracker
 
@@ -49,7 +49,7 @@ class LossTracker : LossListener {
         val packetsLost: Long,
         val packetsReceived: Long
     ) {
-        fun toJson() = OrderedJsonObject().apply {
+        fun toJson() = JsonNodeFactory.instance.objectNode().apply {
             put("packets_lost", packetsLost)
             put("packets_received", packetsReceived)
         }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj.rtp
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.rtcp.RtcpListener
 import org.jitsi.nlj.util.Bandwidth
@@ -67,7 +68,7 @@ abstract class TransportCcEngine : RtcpListener {
     abstract fun stop()
 
     abstract class StatisticsSnapshot {
-        abstract fun toJson(): Map<*, *>
+        abstract fun toJson(): ObjectNode
     }
 
     interface BandwidthListener {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimator.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimator.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.nlj.rtp.bandwidthestimation
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.rtp.TransportCcEngine
 import org.jitsi.nlj.util.Bandwidth
 import org.jitsi.nlj.util.DataSize
@@ -336,11 +337,15 @@ abstract class BandwidthEstimator(
         /**
          * Returns a JSON representation of this [StatisticsSnapshot] object.
          */
-        fun toJson(): OrderedJsonObject = OrderedJsonObject().apply {
+        fun toJson(): ObjectNode = OrderedJsonObject().apply {
             stats.forEach { (name, value) ->
                 when (value) {
                     is Bandwidth -> put(name, value.bps)
-                    else -> put(name, value)
+                    is Long -> put(name, value)
+                    is Int -> put(name, value)
+                    is Double -> put(name, value)
+                    is Boolean -> put(name, value)
+                    else -> put(name, value.toString())
                 }
             }
         }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimator.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimator.kt
@@ -16,13 +16,13 @@
 
 package org.jitsi.nlj.rtp.bandwidthestimation
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.rtp.TransportCcEngine
 import org.jitsi.nlj.util.Bandwidth
 import org.jitsi.nlj.util.DataSize
 import org.jitsi.nlj.util.bps
 import org.jitsi.utils.NEVER
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.formatMilli
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
@@ -337,7 +337,7 @@ abstract class BandwidthEstimator(
         /**
          * Returns a JSON representation of this [StatisticsSnapshot] object.
          */
-        fun toJson(): ObjectNode = OrderedJsonObject().apply {
+        fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
             stats.forEach { (name, value) ->
                 when (value) {
                     is Bandwidth -> put(name, value.bps)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcNetworkController.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcNetworkController.kt
@@ -17,6 +17,7 @@
 
 package org.jitsi.nlj.rtp.bandwidthestimation2
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.util.Bandwidth
 import org.jitsi.nlj.util.DataSize
@@ -27,7 +28,6 @@ import org.jitsi.nlj.util.min
 import org.jitsi.nlj.util.times
 import org.jitsi.utils.MAX_DURATION
 import org.jitsi.utils.MIN_DURATION
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.isFinite
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
@@ -619,7 +619,7 @@ class GoogCcNetworkController(
         val inAlr: Boolean
     ) {
         fun toJson(): ObjectNode {
-            return OrderedJsonObject().apply {
+            return JsonNodeFactory.instance.objectNode().apply {
                 put("time", time.toEpochMilli())
                 put("rtt", rtt.toDouble())
                 put("target", target.bps)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcNetworkController.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcNetworkController.kt
@@ -17,6 +17,7 @@
 
 package org.jitsi.nlj.rtp.bandwidthestimation2
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.util.Bandwidth
 import org.jitsi.nlj.util.DataSize
 import org.jitsi.nlj.util.bps
@@ -617,25 +618,25 @@ class GoogCcNetworkController(
         /* Additions to the fields from goog_cc_printer */
         val inAlr: Boolean
     ) {
-        fun toJson(): OrderedJsonObject {
+        fun toJson(): ObjectNode {
             return OrderedJsonObject().apply {
                 put("time", time.toEpochMilli())
                 put("rtt", rtt.toDouble())
                 put("target", target.bps)
                 put("stable_target", stableTarget.bps)
-                put("pacing", pacing?.bps ?: Double.NaN)
-                put("padding", padding?.bps ?: Double.NaN)
+                put("pacing", pacing?.bps?.toDouble() ?: Double.NaN)
+                put("padding", padding?.bps?.toDouble() ?: Double.NaN)
                 put("window", window.bytes)
                 put("rate_control_state", rateControlState.name)
-                put("stable_estimate", stableEstimate?.bps ?: Double.NaN)
+                put("stable_estimate", stableEstimate?.bps?.toDouble() ?: Double.NaN)
                 put("trendline", trendline)
                 put("trendline_modified_offset", trendlineModifiedOffset)
                 put("trendline_modified_threshold", trendlineOffsetThreshold)
-                put("acknowledged_rate", acknowledgedRate?.bps ?: Double.NaN)
+                put("acknowledged_rate", acknowledgedRate?.bps?.toDouble() ?: Double.NaN)
                 put("loss_ratio", lossRatio)
                 put("send_side_target", sendSideTarget.bps)
                 put("last_loss_based_state", lossBasedState.name)
-                put("data_window", dataWindow?.bytes ?: Double.NaN)
+                put("data_window", dataWindow?.bytes?.toDouble() ?: Double.NaN)
                 put("pushback_target", pushbackTarget.bps)
                 put("in_alr", inAlr)
             }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcTransportCcEngine.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcTransportCcEngine.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj.rtp.bandwidthestimation2
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
@@ -29,7 +30,6 @@ import org.jitsi.rtp.rtcp.RtcpRrPacket
 import org.jitsi.rtp.rtcp.RtcpSrPacket
 import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.RtcpFbRembPacket
 import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.RtcpFbTccPacket
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
 import org.jitsi.utils.logging2.Logger
@@ -358,7 +358,7 @@ class GoogCcTransportCcEngine(
         val networkControllerState: GoogCcNetworkController.StatisticsSnapshot
     ) : TransportCcEngine.StatisticsSnapshot() {
         override fun toJson(): ObjectNode {
-            return OrderedJsonObject().apply {
+            return JsonNodeFactory.instance.objectNode().apply {
                 put("name", GoogCcTransportCcEngine::class.java.simpleName)
                 set<ObjectNode>("transport_adapter", transportAdapterState.toJson())
                 set<ObjectNode>("network_controller", networkControllerState.toJson())

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcTransportCcEngine.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcTransportCcEngine.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj.rtp.bandwidthestimation2
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.nlj.rtp.TransportCcEngine
@@ -356,11 +357,11 @@ class GoogCcTransportCcEngine(
         val transportAdapterState: TransportFeedbackAdapter.StatisticsSnapshot,
         val networkControllerState: GoogCcNetworkController.StatisticsSnapshot
     ) : TransportCcEngine.StatisticsSnapshot() {
-        override fun toJson(): Map<*, *> {
+        override fun toJson(): ObjectNode {
             return OrderedJsonObject().apply {
                 put("name", GoogCcTransportCcEngine::class.java.simpleName)
-                put("transport_adapter", transportAdapterState.toJson())
-                put("network_controller", networkControllerState.toJson())
+                set<ObjectNode>("transport_adapter", transportAdapterState.toJson())
+                set<ObjectNode>("network_controller", networkControllerState.toJson())
             }
         }
     }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/TransportFeedbackAdapter.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/TransportFeedbackAdapter.kt
@@ -17,6 +17,7 @@
 
 package org.jitsi.nlj.rtp.bandwidthestimation2
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.PacketOrigin
 import org.jitsi.nlj.util.DataSize
@@ -422,16 +423,16 @@ class TransportFeedbackAdapter(
         val currentOffset: Instant,
         val lastTransportFeedbackBaseTime: Instant
     ) {
-        fun toJson(): OrderedJsonObject {
+        fun toJson(): ObjectNode {
             return OrderedJsonObject().apply {
                 put("in_flight_bytes", inFlight.bytes)
                 put("pending_untracked_size", pendingUntrackedSize.bytes)
-                put("last_send_time", lastSendTime.toEpochMilliOrInf())
-                put("last_untracked_send_time", lastUntrackedSendTime.toEpochMilliOrInf())
+                put("last_send_time", lastSendTime.toEpochMilliOrInf().toString())
+                put("last_untracked_send_time", lastUntrackedSendTime.toEpochMilliOrInf().toString())
                 put("last_ack_seq_num", lastAckSeqNum)
                 put("history_size", historySize)
-                put("current_offset", currentOffset.toEpochMilliOrInf())
-                put("last_transport_feedback_base_time", lastTransportFeedbackBaseTime.toEpochMilliOrInf())
+                put("current_offset", currentOffset.toEpochMilliOrInf().toString())
+                put("last_transport_feedback_base_time", lastTransportFeedbackBaseTime.toEpochMilliOrInf().toString())
             }
         }
     }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/TransportFeedbackAdapter.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/TransportFeedbackAdapter.kt
@@ -17,6 +17,7 @@
 
 package org.jitsi.nlj.rtp.bandwidthestimation2
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.PacketOrigin
@@ -29,7 +30,6 @@ import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.ccfb.RtcpFbCcfbPacket
 import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.ReceivedPacketReport
 import org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc.RtcpFbTccPacket
 import org.jitsi.rtp.rtp.RtpPacket
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.TimeUtils
 import org.jitsi.utils.isFinite
 import org.jitsi.utils.isInfinite
@@ -424,7 +424,7 @@ class TransportFeedbackAdapter(
         val lastTransportFeedbackBaseTime: Instant
     ) {
         fun toJson(): ObjectNode {
-            return OrderedJsonObject().apply {
+            return JsonNodeFactory.instance.objectNode().apply {
                 put("in_flight_bytes", inFlight.bytes)
                 put("pending_untracked_size", pendingUntrackedSize.bytes)
                 put("last_send_time", lastSendTime.toEpochMilliOrInf().toString())

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDRtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDRtpLayerDesc.kt
@@ -70,7 +70,7 @@ class Av1DDRtpLayerDesc(
      * Extracts a [NodeStatsBlock] from an [RtpLayerDesc].
      */
     override fun debugState() = super.debugState().apply {
-        this["dt"] = dt
+        put("dt", dt)
     }
 
     override fun indexString(): String = indexString(index)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vpx/VpxRtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vpx/VpxRtpLayerDesc.kt
@@ -184,8 +184,8 @@ constructor(
      * Extracts a [NodeStatsBlock] from an [RtpLayerDesc].
      */
     override fun debugState() = super.debugState().apply {
-        this["tid"] = tid
-        this["sid"] = sid
+        put("tid", tid)
+        put("sid", sid)
     }
 
     override fun indexString(): String = indexString(index)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/DelayStats.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/DelayStats.kt
@@ -16,7 +16,7 @@
 
 package org.jitsi.nlj.stats
 
-import org.jitsi.utils.OrderedJsonObject
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.utils.stats.BucketStats
 import java.util.concurrent.atomic.LongAdder
 
@@ -35,7 +35,7 @@ class PacketDelayStats(thresholds: List<Long> = defaultThresholds) : DelayStats(
 
     fun addUnknown() = numPacketsWithoutTimestamps.increment()
 
-    override fun toJson(format: Format): OrderedJsonObject {
+    override fun toJson(format: Format): ObjectNode {
         return super.toJson(format).apply {
             put("packets_without_timestamps", numPacketsWithoutTimestamps.sum())
         }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.nlj.stats
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.rtcp.RtcpListener
 import org.jitsi.nlj.rtp.LossTracker
@@ -24,7 +25,6 @@ import org.jitsi.rtp.rtcp.RtcpReportBlock
 import org.jitsi.rtp.rtcp.RtcpRrPacket
 import org.jitsi.rtp.rtcp.RtcpSrPacket
 import org.jitsi.utils.LRUCache
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.cdebug
 import org.jitsi.utils.logging2.createChildLogger
@@ -58,7 +58,7 @@ class EndpointConnectionStats(
         val incomingLossStats: LossTracker.Snapshot,
         val outgoingLossStats: LossTracker.Snapshot
     ) {
-        fun toJson(): ObjectNode = OrderedJsonObject().apply {
+        fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
             put("rtt", rtt)
             set<ObjectNode>("incoming_loss_stats", incomingLossStats.toJson())
             set<ObjectNode>("outgoing_loss_stats", outgoingLossStats.toJson())

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.nlj.stats
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.rtcp.RtcpListener
 import org.jitsi.nlj.rtp.LossTracker
 import org.jitsi.rtp.rtcp.RtcpPacket
@@ -57,10 +58,10 @@ class EndpointConnectionStats(
         val incomingLossStats: LossTracker.Snapshot,
         val outgoingLossStats: LossTracker.Snapshot
     ) {
-        fun toJson() = OrderedJsonObject().apply {
+        fun toJson(): ObjectNode = OrderedJsonObject().apply {
             put("rtt", rtt)
-            put("incoming_loss_stats", incomingLossStats.toJson())
-            put("outgoing_loss_stats", outgoingLossStats.toJson())
+            set<ObjectNode>("incoming_loss_stats", incomingLossStats.toJson())
+            set<ObjectNode>("outgoing_loss_stats", outgoingLossStats.toJson())
         }
     }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/NodeStatsBlock.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/NodeStatsBlock.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.nlj.stats
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.util.appendLnIndent
 import org.jitsi.utils.OrderedJsonObject
 
@@ -62,6 +63,10 @@ class NodeStatsBlock(val name: String) {
      * Adds a block with a given name from a from a JSON-ish key-value object map.
      */
     fun addJson(name: String, json: Map<*, *>) {
+        addBlock(fromJson(name, json))
+    }
+
+    fun addJson(name: String, json: ObjectNode) {
         addBlock(fromJson(name, json))
     }
 
@@ -156,15 +161,24 @@ class NodeStatsBlock(val name: String) {
     /**
      * Returns a JSON representation of this [NodeStatsBlock].
      */
-    fun toJson(): OrderedJsonObject = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = OrderedJsonObject().apply {
         stats.forEach { (name, value) ->
             when (value) {
-                is NodeStatsBlock -> put(name, value.toJson())
-                else -> put(name, value)
+                is NodeStatsBlock -> set<ObjectNode>(name, value.toJson())
+                is Long -> put(name, value)
+                is Double -> put(name, value)
+                is Boolean -> put(name, value)
+                is String -> put(name, value)
+                else -> put(name, value.toString())
             }
         }
         compoundStats.forEach { (name, function) ->
-            put(name, function.invoke(this@NodeStatsBlock))
+            val num = function.invoke(this@NodeStatsBlock)
+            when (num) {
+                is Long -> put(name, num)
+                is Double -> put(name, num)
+                else -> put(name, num.toLong())
+            }
         }
     }
 
@@ -184,6 +198,17 @@ class NodeStatsBlock(val name: String) {
                     is Number -> addNumber(key.toString(), value)
                     is Boolean -> addBoolean(key.toString(), value)
                     else -> addString(key.toString(), value.toString())
+                }
+            }
+        }
+
+        fun fromJson(name: String, json: ObjectNode): NodeStatsBlock = NodeStatsBlock(name).apply {
+            json.fields().forEach { (key, value) ->
+                when {
+                    value.isObject -> addBlock(fromJson(key, value as ObjectNode))
+                    value.isNumber -> addNumber(key, value.numberValue())
+                    value.isBoolean -> addBoolean(key, value.booleanValue())
+                    else -> addString(key, value.asText())
                 }
             }
         }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/NodeStatsBlock.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/NodeStatsBlock.kt
@@ -16,9 +16,9 @@
 
 package org.jitsi.nlj.stats
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.util.appendLnIndent
-import org.jitsi.utils.OrderedJsonObject
 
 class NodeStatsBlock(val name: String) {
     private val stats = mutableMapOf<String, Any>()
@@ -161,7 +161,7 @@ class NodeStatsBlock(val name: String) {
     /**
      * Returns a JSON representation of this [NodeStatsBlock].
      */
-    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         stats.forEach { (name, value) ->
             when (value) {
                 is NodeStatsBlock -> set<ObjectNode>(name, value.toJson())

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/PacketStreamStats.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/PacketStreamStats.kt
@@ -15,10 +15,10 @@
  */
 package org.jitsi.nlj.stats
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import org.jitsi.nlj.transform.node.incoming.BitrateCalculator
 import org.jitsi.nlj.util.Bandwidth
 import org.jitsi.nlj.util.bytes
-import org.jitsi.utils.OrderedJsonObject
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -80,7 +80,7 @@ class PacketStreamStats {
          */
         val packets: Long
     ) {
-        fun toJson() = OrderedJsonObject().apply {
+        fun toJson() = JsonNodeFactory.instance.objectNode().apply {
             put("bitrate_bps", bitrate.bps)
             put("packetrate", packetRate)
             put("total_bytes", bytes)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/TransceiverStats.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/TransceiverStats.kt
@@ -16,12 +16,12 @@
 
 package org.jitsi.nlj.stats
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.rtp.TransportCcEngine
 import org.jitsi.nlj.transform.node.incoming.IncomingStatisticsSnapshot
 import org.jitsi.nlj.transform.node.incoming.VideoParser
 import org.jitsi.nlj.transform.node.outgoing.OutgoingStatisticsSnapshot
-import org.jitsi.utils.OrderedJsonObject
 
 data class TransceiverStats(
     val endpointConnectionStats: EndpointConnectionStats.Snapshot,
@@ -30,7 +30,7 @@ data class TransceiverStats(
     val outgoingPacketStreamStats: PacketStreamStats.Snapshot,
     val tccEngineStats: TransportCcEngine.StatisticsSnapshot
 ) {
-    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         set<ObjectNode>("endpoint_connection_stats", endpointConnectionStats.toJson())
         set<ObjectNode>("rtp_receiver_stats", rtpReceiverStats.toJson())
         set<ObjectNode>("outgoing_stats", outgoingStats.toJson())
@@ -44,7 +44,7 @@ data class RtpReceiverStats(
     val packetStreamStats: PacketStreamStats.Snapshot,
     val videoParserStats: VideoParser.Stats.Snapshot
 ) {
-    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         set<ObjectNode>("incoming_stats", incomingStats.toJson())
         set<ObjectNode>("packet_stream_stats", packetStreamStats.toJson())
         set<ObjectNode>("video_parser_stats", videoParserStats.toJson())

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/TransceiverStats.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/TransceiverStats.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.nlj.stats
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.rtp.TransportCcEngine
 import org.jitsi.nlj.transform.node.incoming.IncomingStatisticsSnapshot
 import org.jitsi.nlj.transform.node.incoming.VideoParser
@@ -29,12 +30,12 @@ data class TransceiverStats(
     val outgoingPacketStreamStats: PacketStreamStats.Snapshot,
     val tccEngineStats: TransportCcEngine.StatisticsSnapshot
 ) {
-    fun toJson() = OrderedJsonObject().apply {
-        put("endpoint_connection_stats", endpointConnectionStats.toJson())
-        put("rtp_receiver_stats", rtpReceiverStats.toJson())
-        put("outgoing_stats", outgoingStats.toJson())
-        put("outgoing_packet_stream_stats", outgoingPacketStreamStats.toJson())
-        put("tcc_engine_stats", tccEngineStats.toJson())
+    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+        set<ObjectNode>("endpoint_connection_stats", endpointConnectionStats.toJson())
+        set<ObjectNode>("rtp_receiver_stats", rtpReceiverStats.toJson())
+        set<ObjectNode>("outgoing_stats", outgoingStats.toJson())
+        set<ObjectNode>("outgoing_packet_stream_stats", outgoingPacketStreamStats.toJson())
+        set<ObjectNode>("tcc_engine_stats", tccEngineStats.toJson())
     }
 }
 
@@ -43,9 +44,9 @@ data class RtpReceiverStats(
     val packetStreamStats: PacketStreamStats.Snapshot,
     val videoParserStats: VideoParser.Stats.Snapshot
 ) {
-    fun toJson() = OrderedJsonObject().apply {
-        put("incoming_stats", incomingStats.toJson())
-        put("packet_stream_stats", packetStreamStats.toJson())
-        put("video_parser_stats", videoParserStats.toJson())
+    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+        set<ObjectNode>("incoming_stats", incomingStats.toJson())
+        set<ObjectNode>("packet_stream_stats", packetStreamStats.toJson())
+        set<ObjectNode>("video_parser_stats", videoParserStats.toJson())
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/NodeVisitor.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/NodeVisitor.kt
@@ -16,12 +16,12 @@
 
 package org.jitsi.nlj.transform
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.DebugStateMode
 import org.jitsi.nlj.Event
 import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.node.DemuxerNode
 import org.jitsi.nlj.transform.node.Node
-import org.jitsi.utils.OrderedJsonObject
 
 abstract class NodeVisitor {
     open fun visit(node: Node) {
@@ -59,14 +59,14 @@ class NodeStatsVisitor(val nodeStatsBlock: NodeStatsBlock) : NodeVisitor() {
     }
 }
 
-class NodeDebugStateVisitor(val o: OrderedJsonObject, val mode: DebugStateMode) : NodeVisitor() {
+class NodeDebugStateVisitor(val o: ObjectNode, val mode: DebugStateMode) : NodeVisitor() {
     override fun doWork(node: Node) {
         val debugState = when (mode) {
             DebugStateMode.FULL -> node.getNodeStats().toJson()
             else -> node.statsJson()
         }
-        if (debugState.isNotEmpty()) {
-            o[node.name] = debugState
+        if (!debugState.isEmpty) {
+            o.set<ObjectNode>(node.name, debugState)
         }
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/AudioRedHandler.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/AudioRedHandler.kt
@@ -89,13 +89,13 @@ class AudioRedHandler(
     }
 
     override fun statsJson() = super.statsJson().apply {
-        this["red_packets_decapsulated"] = stats.redPacketsDecapsulated
-        this["red_packets_forwarded"] = stats.redPacketsForwarded
-        this["audio_packets_encapsulated"] = stats.audioPacketsEncapsulated
-        this["audio_packets_forwarded"] = stats.audioPacketsForwarded
-        this["lost_packets_recovered"] = stats.lostPacketsRecovered
-        this["redundancy_packets_added"] = stats.redundancyPacketsAdded
-        this["invalid_red_packets_dropped"] = stats.invalidRedPacketsDropped
+        put("red_packets_decapsulated", stats.redPacketsDecapsulated)
+        put("red_packets_forwarded", stats.redPacketsForwarded)
+        put("audio_packets_encapsulated", stats.audioPacketsEncapsulated)
+        put("audio_packets_forwarded", stats.audioPacketsForwarded)
+        put("lost_packets_recovered", stats.lostPacketsRecovered)
+        put("redundancy_packets_added", stats.redundancyPacketsAdded)
+        put("invalid_red_packets_dropped", stats.invalidRedPacketsDropped)
     }
 
     override fun stop() = super.stop().also {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj.transform.node
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.Event
 import org.jitsi.nlj.EventHandler
@@ -29,7 +30,6 @@ import org.jitsi.nlj.util.BufferPool
 import org.jitsi.nlj.util.PacketPredicate
 import org.jitsi.nlj.util.addMbps
 import org.jitsi.nlj.util.addRatio
-import org.jitsi.utils.OrderedJsonObject
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArraySet
@@ -54,7 +54,7 @@ sealed class Node(
     protected val nodeEntryString = "Entered node $name"
     protected val nodeExitString = "Exited node $name"
 
-    open fun statsJson(): ObjectNode = OrderedJsonObject()
+    open fun statsJson(): ObjectNode = JsonNodeFactory.instance.objectNode()
 
     open fun visit(visitor: NodeVisitor) {
         visitor.visit(this)
@@ -311,7 +311,7 @@ sealed class StatsKeepingNode(name: String) : Node(name) {
          * Gets the aggregated statistics for all classes as a JSON map.
          */
         fun getStatsJson(): ObjectNode {
-            val jsonObject = OrderedJsonObject()
+            val jsonObject = JsonNodeFactory.instance.objectNode()
             globalStats.forEach { (className, stats) ->
                 jsonObject.set<ObjectNode>(className, stats.toJson())
             }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj.transform.node
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.Event
 import org.jitsi.nlj.EventHandler
 import org.jitsi.nlj.PacketHandler
@@ -29,7 +30,6 @@ import org.jitsi.nlj.util.PacketPredicate
 import org.jitsi.nlj.util.addMbps
 import org.jitsi.nlj.util.addRatio
 import org.jitsi.utils.OrderedJsonObject
-import org.json.simple.JSONObject
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArraySet
@@ -54,7 +54,7 @@ sealed class Node(
     protected val nodeEntryString = "Entered node $name"
     protected val nodeExitString = "Exited node $name"
 
-    open fun statsJson(): OrderedJsonObject = OrderedJsonObject()
+    open fun statsJson(): ObjectNode = OrderedJsonObject()
 
     open fun visit(visitor: NodeVisitor) {
         visitor.visit(this)
@@ -310,12 +310,12 @@ sealed class StatsKeepingNode(name: String) : Node(name) {
         /**
          * Gets the aggregated statistics for all classes as a JSON map.
          */
-        fun getStatsJson(): JSONObject {
-            val jsonObject = JSONObject()
+        fun getStatsJson(): ObjectNode {
+            val jsonObject = OrderedJsonObject()
             globalStats.forEach { (className, stats) ->
-                jsonObject[className] = stats.toJson()
+                jsonObject.set<ObjectNode>(className, stats.toJson())
             }
-            jsonObject["num_payload_verification_failures"] = PayloadVerificationPlugin.numFailures.get()
+            jsonObject.put("num_payload_verification_failures", PayloadVerificationPlugin.numFailures.get())
             return jsonObject
         }
     }
@@ -354,12 +354,12 @@ sealed class StatsKeepingNode(name: String) : Node(name) {
                 addNumber("max_packet_process_time_ms", maxProcessingDurationMs)
             }
         }
-        fun appendTo(json: OrderedJsonObject) {
-            json["num_input_packets"] = numInputPackets
-            json["num_output_packets"] = numOutputPackets
-            json["num_discarded_packets"] = numDiscardedPackets
-            json["total_time_spent_ns"] = totalProcessingDurationNs
-            json["max_packet_process_time_ms"] = maxProcessingDurationMs
+        fun appendTo(json: ObjectNode) {
+            json.put("num_input_packets", numInputPackets)
+            json.put("num_output_packets", numOutputPackets)
+            json.put("num_discarded_packets", numDiscardedPackets)
+            json.put("total_time_spent_ns", totalProcessingDurationNs)
+            json.put("max_packet_process_time_ms", maxProcessingDurationMs)
         }
     }
 }
@@ -556,7 +556,7 @@ abstract class DemuxerNode(name: String) : StatsKeepingNode("$name demuxer") {
 
     override fun statsJson() = super.statsJson().apply {
         transformPaths.forEach { path ->
-            this["packets_accepted_${path.name}"] = path.packetsAccepted
+            put("packets_accepted_${path.name}", path.packetsAccepted)
         }
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/SrtpTransformerNode.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/SrtpTransformerNode.kt
@@ -140,12 +140,12 @@ abstract class SrtpTransformerNode(name: String) : MultipleOutputTransformerNode
     }
 
     override fun statsJson() = super.statsJson().apply {
-        this["num_srtp_processed"] = numSrtpProcessed
-        this["num_srtp_fail"] = numSrtpFail
-        this["num_srtp_auth_fail"] = numSrtpAuthFail
-        this["num_srtp_replay_fail"] = numSrtpReplayFail
-        this["num_srtp_replay_old"] = numSrtpReplayOld
-        this["num_srtp_invalid_packet"] = numSrtpInvalidPacket
+        put("num_srtp_processed", numSrtpProcessed)
+        put("num_srtp_fail", numSrtpFail)
+        put("num_srtp_auth_fail", numSrtpAuthFail)
+        put("num_srtp_replay_fail", numSrtpReplayFail)
+        put("num_srtp_replay_old", numSrtpReplayOld)
+        put("num_srtp_invalid_packet", numSrtpInvalidPacket)
     }
 
     override fun stop() {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/debug/PayloadVerificationPlugin.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/debug/PayloadVerificationPlugin.kt
@@ -16,11 +16,11 @@
 
 package org.jitsi.nlj.transform.node.debug
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.transform.node.Node
 import org.jitsi.nlj.transform.node.NodePlugin
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -36,7 +36,7 @@ class PayloadVerificationPlugin {
         val numFailures = AtomicInteger()
 
         @JvmStatic
-        fun getStatsJson(): ObjectNode = OrderedJsonObject().apply {
+        fun getStatsJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
             put("num_payload_verification_failures", numFailures.get())
         }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/debug/PayloadVerificationPlugin.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/debug/PayloadVerificationPlugin.kt
@@ -16,11 +16,12 @@
 
 package org.jitsi.nlj.transform.node.debug
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.transform.node.Node
 import org.jitsi.nlj.transform.node.NodePlugin
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
-import org.json.simple.JSONObject
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -35,7 +36,9 @@ class PayloadVerificationPlugin {
         val numFailures = AtomicInteger()
 
         @JvmStatic
-        fun getStatsJson() = JSONObject().apply { this["num_payload_verification_failures"] = numFailures.get() }
+        fun getStatsJson(): ObjectNode = OrderedJsonObject().apply {
+            put("num_payload_verification_failures", numFailures.get())
+        }
 
         override fun observe(after: Node, packetInfo: PacketInfo) {
             if (PacketInfo.enablePayloadVerification &&

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/AudioLevelReader.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/AudioLevelReader.kt
@@ -104,10 +104,10 @@ class AudioLevelReader(
         }
 
         override fun statsJson() = super.statsJson().apply {
-            this["num_audio_levels"] = stats.numAudioLevels
-            this["num_silence_packets_discarded"] = stats.numDiscardedSilence
-            this["num_force_mute_discarded"] = stats.numDiscardedForceMute
-            this["num_ranking_discarded"] = stats.numDiscardedRanking
+            put("num_audio_levels", stats.numAudioLevels)
+            put("num_silence_packets_discarded", stats.numDiscardedSilence)
+            put("num_force_mute_discarded", stats.numDiscardedForceMute)
+            put("num_ranking_discarded", stats.numDiscardedRanking)
         }
 
         override fun trace(f: () -> Unit) = f.invoke()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/DuplicateTermination.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/DuplicateTermination.kt
@@ -52,7 +52,7 @@ class DuplicateTermination() : TransformerNode("Duplicate termination") {
     }
 
     override fun statsJson() = super.statsJson().apply {
-        this["num_duplicate_packets_dropped"] = numDuplicatePacketsDropped
+        put("num_duplicate_packets_dropped", numDuplicatePacketsDropped)
     }
 
     override fun trace(f: () -> Unit) = f.invoke()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj.transform.node.incoming
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.format.RtxPayloadType
 import org.jitsi.nlj.stats.JitterStats
@@ -98,9 +99,9 @@ class IncomingStatisticsSnapshot(
      */
     val ssrcStats: Map<Long, IncomingSsrcStats.Snapshot>
 ) {
-    fun toJson(): OrderedJsonObject = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = OrderedJsonObject().apply {
         ssrcStats.forEach { (ssrc, snapshot) ->
-            put(ssrc, snapshot.toJson())
+            set<ObjectNode>(ssrc.toString(), snapshot.toJson())
         }
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj.transform.node.incoming
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.format.RtxPayloadType
@@ -29,7 +30,6 @@ import org.jitsi.rtp.util.isNextAfter
 import org.jitsi.rtp.util.numPacketsTo
 import org.jitsi.rtp.util.rolledOverTo
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
@@ -99,7 +99,7 @@ class IncomingStatisticsSnapshot(
      */
     val ssrcStats: Map<Long, IncomingSsrcStats.Snapshot>
 ) {
-    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         ssrcStats.forEach { (ssrc, snapshot) ->
             set<ObjectNode>(ssrc.toString(), snapshot.toJson())
         }
@@ -327,7 +327,7 @@ class IncomingSsrcStats(
             }
         }
 
-        fun toJson() = OrderedJsonObject().apply {
+        fun toJson() = JsonNodeFactory.instance.objectNode().apply {
             put("num_received_packets", numReceivedPackets)
             put("num_received_bytes", numReceivedBytes)
             put("max_seq_num", maxSeqNum)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/PaddingTermination.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/PaddingTermination.kt
@@ -56,8 +56,8 @@ class PaddingTermination(parentLogger: Logger) : TransformerNode("Padding termin
     }
 
     override fun statsJson() = super.statsJson().apply {
-        this["num_padded_packets_seen"] = numPaddedPacketsSeen
-        this["num_padding_only_packets_seen"] = numPaddingOnlyPacketsSeen
+        put("num_padded_packets_seen", numPaddedPacketsSeen)
+        put("num_padding_only_packets_seen", numPaddingOnlyPacketsSeen)
     }
 
     override fun trace(f: () -> Unit) = f.invoke()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
@@ -135,9 +135,9 @@ class RtcpTermination(
     }
 
     override fun statsJson() = super.statsJson().apply {
-        this["num_failed_to_forward"] = numFailedToForward
+        put("num_failed_to_forward", numFailedToForward)
         packetReceiveCounts.forEach { (type, count) ->
-            this["num_${type}_rx"] = count
+            put("num_${type}_rx", count)
         }
     }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtxHandler.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtxHandler.kt
@@ -102,8 +102,8 @@ class RtxHandler(
     }
 
     override fun statsJson() = super.statsJson().apply {
-        this["num_rtx_packets_received"] = numRtxPacketsReceived
-        this["num_padding_packets_received"] = numPaddingPacketsReceived
+        put("num_rtx_packets_received", numRtxPacketsReceived)
+        put("num_padding_packets_received", numPaddingPacketsReceived)
     }
 
     override fun trace(f: () -> Unit) = f.invoke()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
@@ -251,10 +251,10 @@ class TccGeneratorNode(
     }
 
     override fun statsJson() = super.statsJson().apply {
-        this["num_tcc_packets_sent"] = numTccSent
-        this["tcc_feedback_bitrate_bps"] = tccFeedbackBitrate.rate.bps
-        this["tcc_extension_id"] = tccExtensionId.toString()
-        this["num_multiple_tcc_packets"] = numMultipleTccPackets
-        this["enabled"] = enabled
+        put("num_tcc_packets_sent", numTccSent)
+        put("tcc_feedback_bitrate_bps", tccFeedbackBitrate.rate.bps)
+        put("tcc_extension_id", tccExtensionId.toString())
+        put("num_multiple_tcc_packets", numMultipleTccPackets)
+        put("enabled", enabled)
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoMuteNode.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoMuteNode.kt
@@ -24,8 +24,8 @@ class VideoMuteNode : ObserverNode("VideoMuteNode") {
     }
 
     override fun statsJson() = super.statsJson().apply {
-        this["num_video_packets_discarded"] = numMutedPackets
-        this["force_mute"] = forceMute
+        put("num_video_packets_discarded", numMutedPackets)
+        put("force_mute", forceMute)
     }
 
     override fun trace(f: () -> Unit) = f.invoke()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj.transform.node.incoming
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.Event
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.PacketInfo
@@ -259,10 +260,10 @@ class VideoParser(
             addNumber("num_keyframes", numKeyframes)
             addNumber("num_layering_changes", numLayeringChanges)
         }
-        fun addToJson(o: OrderedJsonObject) {
-            o["num_packets_dropped_unknown_pt"] = numPacketsDroppedUnknownPt
-            o["num_keyframes"] = numKeyframes
-            o["num_layering_changes"] = numLayeringChanges
+        fun addToJson(o: ObjectNode) {
+            o.put("num_packets_dropped_unknown_pt", numPacketsDroppedUnknownPt)
+            o.put("num_keyframes", numKeyframes)
+            o.put("num_layering_changes", numLayeringChanges)
         }
 
         data class Snapshot(

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj.transform.node.incoming
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.Event
 import org.jitsi.nlj.MediaSourceDesc
@@ -37,7 +38,6 @@ import org.jitsi.nlj.transform.node.TransformerNode
 import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
 import org.jitsi.rtp.extensions.bytearray.toHex
 import org.jitsi.rtp.rtp.RtpPacket
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.cdebug
@@ -271,7 +271,7 @@ class VideoParser(
             var numLayeringChanges: Int,
             var numPacketsDroppedUnknownPt: Int
         ) {
-            fun toJson() = OrderedJsonObject().apply {
+            fun toJson() = JsonNodeFactory.instance.objectNode().apply {
                 put("num_packets_dropped_unknown_pt", numPacketsDroppedUnknownPt)
                 put("num_keyframes", numKeyframes)
                 put("num_layering_changes", numLayeringChanges)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/OutgoingStatisticsTracker.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/OutgoingStatisticsTracker.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj.transform.node.outgoing
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.PacketOrigin
@@ -26,7 +27,6 @@ import org.jitsi.nlj.transform.node.incoming.BitrateCalculator
 import org.jitsi.nlj.util.BitrateTracker
 import org.jitsi.nlj.util.bytes
 import org.jitsi.rtp.rtp.RtpPacket
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
 import java.util.concurrent.ConcurrentHashMap
@@ -121,7 +121,7 @@ class OutgoingStatisticsSnapshot(
      */
     val ssrcStats: Map<Long, OutgoingSsrcStats.Snapshot>
 ) {
-    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         ssrcStats.forEach { (ssrc, snapshot) ->
             set<ObjectNode>(ssrc.toString(), snapshot.toJson())
         }
@@ -158,7 +158,7 @@ class OutgoingSsrcStats(
         val octetCount: Int,
         val mostRecentRtpTimestamp: Long
     ) {
-        fun toJson() = OrderedJsonObject().apply {
+        fun toJson() = JsonNodeFactory.instance.objectNode().apply {
             put("packet_count", packetCount)
             put("octet_count", octetCount)
             put("most_recent_rtp_timestamp", mostRecentRtpTimestamp)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/OutgoingStatisticsTracker.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/OutgoingStatisticsTracker.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.nlj.transform.node.outgoing
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.PacketOrigin
 import org.jitsi.nlj.rtp.AudioRtpPacket
@@ -120,9 +121,9 @@ class OutgoingStatisticsSnapshot(
      */
     val ssrcStats: Map<Long, OutgoingSsrcStats.Snapshot>
 ) {
-    fun toJson() = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = OrderedJsonObject().apply {
         ssrcStats.forEach { (ssrc, snapshot) ->
-            put(ssrc, snapshot.toJson())
+            set<ObjectNode>(ssrc.toString(), snapshot.toJson())
         }
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProbingDataSender.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProbingDataSender.kt
@@ -200,14 +200,14 @@ class ProbingDataSender(
     }
 
     fun debugState(mode: DebugStateMode) = OrderedJsonObject().apply {
-        this["num_bytes_of_probing_data_sent_as_rtx"] = numProbingBytesSentRtx
-        this["num_bytes_of_probing_data_sent_as_dummy"] = numProbingBytesSentDummyData
-        this["rtx_supported"] = rtxSupported
+        put("num_bytes_of_probing_data_sent_as_rtx", numProbingBytesSentRtx)
+        put("num_bytes_of_probing_data_sent_as_dummy", numProbingBytesSentDummyData)
+        put("rtx_supported", rtxSupported)
         if (mode == DebugStateMode.FULL) {
-            this["local_video_ssrc"] = localVideoSsrc.toString()
-            this["curr_dummy_timestamp"] = currDummyTimestamp.toString()
-            this["curr_dummy_seq_num"] = currDummySeqNum.toString()
-            this["video_payload_types"] = videoPayloadTypes.toString()
+            put("local_video_ssrc", localVideoSsrc.toString())
+            put("curr_dummy_timestamp", currDummyTimestamp.toString())
+            put("curr_dummy_seq_num", currDummySeqNum.toString())
+            put("video_payload_types", videoPayloadTypes.toString())
         }
     }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProbingDataSender.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProbingDataSender.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.nlj.transform.node.outgoing
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import org.jitsi.nlj.DebugStateMode
 import org.jitsi.nlj.Event
 import org.jitsi.nlj.EventHandler
@@ -31,7 +32,6 @@ import org.jitsi.nlj.util.ReadOnlyStreamInformationStore
 import org.jitsi.rtp.extensions.unsigned.toPositiveInt
 import org.jitsi.rtp.rtp.RtpHeader
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
 import org.jitsi.utils.logging2.Logger
@@ -199,7 +199,7 @@ class ProbingDataSender(
         }
     }
 
-    fun debugState(mode: DebugStateMode) = OrderedJsonObject().apply {
+    fun debugState(mode: DebugStateMode) = JsonNodeFactory.instance.objectNode().apply {
         put("num_bytes_of_probing_data_sent_as_rtx", numProbingBytesSentRtx)
         put("num_bytes_of_probing_data_sent_as_dummy", numProbingBytesSentDummyData)
         put("rtx_supported", rtxSupported)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSender.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSender.kt
@@ -121,9 +121,9 @@ class RetransmissionSender(
     }
 
     override fun statsJson() = super.statsJson().apply {
-        this["num_retransmissions_requested"] = numRetransmissionsRequested
-        this["num_retransmissions_rtx_sent"] = numRetransmittedRtxPackets
-        this["num_retransmissions_plain_sent"] = numRetransmittedPlainPackets
+        put("num_retransmissions_requested", numRetransmissionsRequested)
+        put("num_retransmissions_rtx_sent", numRetransmittedRtxPackets)
+        put("num_retransmissions_plain_sent", numRetransmittedPlainPackets)
     }
 
     override fun trace(f: () -> Unit) = f.invoke()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SentRtcpStats.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SentRtcpStats.kt
@@ -40,7 +40,7 @@ class SentRtcpStats : ObserverNode("Sent RTCP stats") {
 
     override fun statsJson() = super.statsJson().apply {
         sentRtcpCounts.forEach { (rtcpType, count) ->
-            this["num_${rtcpType}_tx"] = count
+            put("num_${rtcpType}_tx", count)
         }
     }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/ReceiveSsrcStore.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/ReceiveSsrcStore.kt
@@ -15,6 +15,8 @@
  */
 package org.jitsi.nlj.util
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.utils.MediaType
 import org.jitsi.utils.OrderedJsonObject
 import java.util.concurrent.ConcurrentHashMap
@@ -83,9 +85,13 @@ class ReceiveSsrcStore(
         primaryMediaSsrcs.remove(ssrcAssociation.secondarySsrc)
     }
 
-    fun debugState() = OrderedJsonObject().apply {
-        this["receive_ssrcs"] = receiveSsrcsByMediaType.toMap()
-        this["primary_media_ssrcs"] = primaryMediaSsrcs.toSet()
-        this["primary_video_ssrcs"] = primaryVideoSsrcs.toSet()
+    fun debugState(): ObjectNode = OrderedJsonObject().apply {
+        val mapper = ObjectMapper()
+        set<ObjectNode>(
+            "receive_ssrcs",
+            mapper.valueToTree(receiveSsrcsByMediaType.mapValues { it.value.toString() }.toMap())
+        )
+        set<ObjectNode>("primary_media_ssrcs", mapper.valueToTree(primaryMediaSsrcs.toSet()))
+        set<ObjectNode>("primary_video_ssrcs", mapper.valueToTree(primaryVideoSsrcs.toSet()))
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/ReceiveSsrcStore.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/ReceiveSsrcStore.kt
@@ -16,9 +16,9 @@
 package org.jitsi.nlj.util
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArraySet
 
@@ -85,7 +85,7 @@ class ReceiveSsrcStore(
         primaryMediaSsrcs.remove(ssrcAssociation.secondarySsrc)
     }
 
-    fun debugState(): ObjectNode = OrderedJsonObject().apply {
+    fun debugState(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         val mapper = ObjectMapper()
         set<ObjectNode>(
             "receive_ssrcs",

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/StreamInformation.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/StreamInformation.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.nlj.util
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.DebugStateMode
 import org.jitsi.nlj.format.PayloadType
 import org.jitsi.nlj.format.supportsPli
@@ -58,7 +59,7 @@ interface ReadOnlyStreamInformationStore {
 
     fun getLocalPrimarySsrc(secondarySsrc: Long): Long?
     fun getRemoteSecondarySsrc(primarySsrc: Long, associationType: SsrcAssociationType): Long?
-    fun debugState(mode: DebugStateMode): OrderedJsonObject
+    fun debugState(mode: DebugStateMode): ObjectNode
 
     /**
      * All signaled receive SSRCs
@@ -222,19 +223,21 @@ class StreamInformationStoreImpl : StreamInformationStore {
 
     override fun removeReceiveSsrc(ssrc: Long) = receiveSsrcStore.removeReceiveSsrc(ssrc)
 
-    override fun debugState(mode: DebugStateMode) = OrderedJsonObject().apply {
-        this["supports_pli"] = supportsPli
-        this["supports_fir"] = supportsFir
-        this["rtp_extensions"] = OrderedJsonObject().apply {
+    override fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+        put("supports_pli", supportsPli)
+        put("supports_fir", supportsFir)
+        val rtpExtNode = OrderedJsonObject().apply {
             rtpExtensions.forEach { put(it.id.toString(), it.type.toString()) }
         }
-        this["rtp_payload_types"] = OrderedJsonObject().apply {
+        set<ObjectNode>("rtp_extensions", rtpExtNode)
+        val rtpPayloadNode = OrderedJsonObject().apply {
             rtpPayloadTypes.forEach { put(it.key.toString(), it.value.toString()) }
         }
+        set<ObjectNode>("rtp_payload_types", rtpPayloadNode)
         if (mode == DebugStateMode.FULL) {
-            this["local_ssrc_associations"] = localSsrcAssociations.toString()
-            this["remote_ssrc_associations"] = remoteSsrcAssociations.toString()
-            this["receive_ssrc_store"] = receiveSsrcStore.debugState()
+            put("local_ssrc_associations", localSsrcAssociations.toString())
+            put("remote_ssrc_associations", remoteSsrcAssociations.toString())
+            set<ObjectNode>("receive_ssrc_store", receiveSsrcStore.debugState())
         }
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/StreamInformation.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/StreamInformation.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.nlj.util
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.DebugStateMode
 import org.jitsi.nlj.format.PayloadType
@@ -26,7 +27,6 @@ import org.jitsi.nlj.rtp.RtpExtension
 import org.jitsi.nlj.rtp.RtpExtensionType
 import org.jitsi.nlj.rtp.SsrcAssociationType
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
@@ -223,14 +223,14 @@ class StreamInformationStoreImpl : StreamInformationStore {
 
     override fun removeReceiveSsrc(ssrc: Long) = receiveSsrcStore.removeReceiveSsrc(ssrc)
 
-    override fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+    override fun debugState(mode: DebugStateMode): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("supports_pli", supportsPli)
         put("supports_fir", supportsFir)
-        val rtpExtNode = OrderedJsonObject().apply {
+        val rtpExtNode = JsonNodeFactory.instance.objectNode().apply {
             rtpExtensions.forEach { put(it.id.toString(), it.type.toString()) }
         }
         set<ObjectNode>("rtp_extensions", rtpExtNode)
-        val rtpPayloadNode = OrderedJsonObject().apply {
+        val rtpPayloadNode = JsonNodeFactory.instance.objectNode().apply {
             rtpPayloadTypes.forEach { put(it.key.toString(), it.value.toString()) }
         }
         set<ObjectNode>("rtp_payload_types", rtpPayloadNode)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/Util.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/Util.kt
@@ -15,8 +15,8 @@
  */
 package org.jitsi.nlj.util
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.rtp.Packet
-import org.jitsi.utils.OrderedJsonObject
 import java.time.Duration
 import java.util.Collections
 import java.util.function.Predicate
@@ -75,9 +75,9 @@ inline fun getStackTrace(): String = with(StringBuffer()) {
     toString()
 }
 
-fun OrderedJsonObject.appendAll(other: OrderedJsonObject) = this.also {
-    other.forEach { (key, value) ->
-        this[key] = value
+fun ObjectNode.appendAll(other: ObjectNode): ObjectNode = this.also {
+    other.fields().forEach { (key, value) ->
+        set<ObjectNode>(key, value)
     }
 }
 

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtcp/KeyframeRequesterTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtcp/KeyframeRequesterTest.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.nlj.rtcp
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
@@ -37,7 +38,6 @@ import org.jitsi.nlj.util.RtpExtensionHandler
 import org.jitsi.nlj.util.RtpPayloadTypesChangedHandler
 import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.RtcpFbFirPacket
 import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.RtcpFbPliPacket
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.ms
 import org.jitsi.utils.secs
 import org.jitsi.utils.time.FakeClock
@@ -71,7 +71,7 @@ class KeyframeRequesterTest : ShouldSpec() {
 
         override fun getRemoteSecondarySsrc(primarySsrc: Long, associationType: SsrcAssociationType): Long? = null
 
-        override fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject()
+        override fun debugState(mode: DebugStateMode): ObjectNode = JsonNodeFactory.instance.objectNode()
     }
     private val logger = StdoutLogger()
     private val clock: FakeClock = FakeClock()

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtcp/KeyframeRequesterTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtcp/KeyframeRequesterTest.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.nlj.rtcp
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -70,7 +71,7 @@ class KeyframeRequesterTest : ShouldSpec() {
 
         override fun getRemoteSecondarySsrc(primarySsrc: Long, associationType: SsrcAssociationType): Long? = null
 
-        override fun debugState(mode: DebugStateMode) = OrderedJsonObject()
+        override fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject()
     }
     private val logger = StdoutLogger()
     private val clock: FakeClock = FakeClock()

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/stats/DelayStatsTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/stats/DelayStatsTest.kt
@@ -15,12 +15,12 @@
  */
 package org.jitsi.nlj.stats
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import org.jitsi.utils.OrderedJsonObject
 import java.lang.IllegalArgumentException
 
 class DelayStatsTest : ShouldSpec() {
@@ -50,13 +50,13 @@ class DelayStatsTest : ShouldSpec() {
                 delayStats.addDelay(150)
                 delayStats.addDelay(1500)
                 val bucketsJson = delayStats.toJson()["buckets"]
-                bucketsJson.shouldBeInstanceOf<OrderedJsonObject>()
+                bucketsJson.shouldBeInstanceOf<ObjectNode>()
 
-                bucketsJson["0_to_2_ms"] shouldBe 100
-                bucketsJson["2_to_5_ms"] shouldBe 100
-                bucketsJson["5_to_200_ms"] shouldBe 1
-                bucketsJson["200_to_999_ms"] shouldBe 0
-                bucketsJson["999_to_max_ms"] shouldBe 1
+                bucketsJson["0_to_2_ms"]?.longValue() shouldBe 100
+                bucketsJson["2_to_5_ms"]?.longValue() shouldBe 100
+                bucketsJson["5_to_200_ms"]?.longValue() shouldBe 1
+                bucketsJson["200_to_999_ms"]?.longValue() shouldBe 0
+                bucketsJson["999_to_max_ms"]?.longValue() shouldBe 1
             }
 
             should("calculate p99 and p999 correctly") {

--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -46,19 +46,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <version>1.1.1</version>
-      <!-- json-simple 1.1.1 incorrectly listed junit as a compile dependency rather than a test dependency.
-       This has been fixed in its github repo but a new release hasn't been pushed to maven. -->
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>33.4.0-jre</version>

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -39,7 +39,8 @@ import org.jitsi.videobridge.xmpp.*;
 import org.jitsi.xmpp.extensions.colibri2.*;
 import org.jitsi.xmpp.util.*;
 import org.jivesoftware.smack.packet.*;
-import org.json.simple.*;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.jxmpp.jid.*;
 
 import java.util.*;
@@ -1338,15 +1339,14 @@ public class Conference
      * @param mode determines how much detail to include in the debug state.
      * @param endpointId the ID of the endpoint to include. If set to {@code null}, all endpoints will be included.
      */
-    @SuppressWarnings("unchecked")
-    public JSONObject getDebugState(@NotNull DebugStateMode mode, @Nullable String endpointId)
+    public ObjectNode getDebugState(@NotNull DebugStateMode mode, @Nullable String endpointId)
     {
         if (mode == DebugStateMode.STATS && !isRtcStatsEnabled)
         {
-            return new JSONObject();
+            return JsonNodeFactory.instance.objectNode();
         }
 
-        JSONObject debugState = new JSONObject();
+        ObjectNode debugState = JsonNodeFactory.instance.objectNode();
         debugState.put("id", id);
 
         // Keep this camelCase for compatibility with jvb-rtcstats-push
@@ -1368,11 +1368,11 @@ public class Conference
         }
         if (mode == DebugStateMode.FULL || mode == DebugStateMode.STATS)
         {
-            debugState.put("speech_activity", speechActivity.getDebugState(mode));
+            debugState.set("speech_activity", speechActivity.getDebugState(mode));
         }
 
-        JSONObject endpoints = new JSONObject();
-        debugState.put("endpoints", endpoints);
+        ObjectNode endpoints = JsonNodeFactory.instance.objectNode();
+        debugState.set("endpoints", endpoints);
         for (Endpoint e : endpointsCache)
         {
             if (endpointId == null || endpointId.equals(e.getId()))
@@ -1383,13 +1383,13 @@ public class Conference
                 }
                 else
                 {
-                    endpoints.put(e.getId(), e.debugState(mode));
+                    endpoints.set(e.getId(), e.debugState(mode));
                 }
             }
         }
 
-        JSONObject relays = new JSONObject();
-        debugState.put("relays", relays);
+        ObjectNode relays = JsonNodeFactory.instance.objectNode();
+        debugState.set("relays", relays);
         for (Relay r : relaysById.values())
         {
             if (mode == DebugStateMode.SHORT)
@@ -1398,13 +1398,13 @@ public class Conference
             }
             else
             {
-                relays.put(r.getId(), r.debugState(mode));
+                relays.set(r.getId(), r.debugState(mode));
             }
         }
 
         if (mode != DebugStateMode.SHORT)
         {
-            debugState.put("exporter", exporter.debugState());
+            debugState.set("exporter", exporter.debugState());
         }
 
         return debugState;

--- a/jvb/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
@@ -20,7 +20,9 @@ import org.jitsi.nlj.*;
 import org.jitsi.utils.dsi.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.videobridge.util.*;
-import org.json.simple.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.util.*;
 import java.util.stream.*;
@@ -394,10 +396,10 @@ public class ConferenceSpeechActivity
      * Gets a JSON representation of the parts of this object's state that
      * are deemed useful for debugging.
      */
-    @SuppressWarnings("unchecked")
-    public JSONObject getDebugState(@NotNull DebugStateMode mode)
+    public ObjectNode getDebugState(@NotNull DebugStateMode mode)
     {
-        JSONObject debugState = new JSONObject();
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode debugState = JsonNodeFactory.instance.objectNode();
 
         AbstractEndpoint dominantEndpoint = getDominantEndpoint();
         debugState.put("dominantEndpoint", dominantEndpoint == null ? "null" : dominantEndpoint.getId());
@@ -407,15 +409,22 @@ public class ConferenceSpeechActivity
         }
 
         DominantSpeakerIdentification<String> dsi = this.dominantSpeakerIdentification;
-        debugState.put("dominantSpeakerIdentification", dsi == null ? null : dsi.doGetJSON());
+        if (dsi != null)
+        {
+            debugState.set("dominantSpeakerIdentification", dsi.doGetJSON());
+        }
+        else
+        {
+            debugState.putNull("dominantSpeakerIdentification");
+        }
         synchronized (syncRoot)
         {
-            debugState.put(
-                    "endpointsBySpeechActivity",
-                    endpointsBySpeechActivity.stream().map(AbstractEndpoint::getId).collect(Collectors.toList()));
-            debugState.put(
-                    "endpointsInLastNOrder",
-                    endpointsInLastNOrder.stream().map(AbstractEndpoint::getId).collect(Collectors.toList()));
+            debugState.set("endpointsBySpeechActivity",
+                mapper.valueToTree(endpointsBySpeechActivity.stream().map(AbstractEndpoint::getId)
+                    .collect(Collectors.toList())));
+            debugState.set("endpointsInLastNOrder",
+                mapper.valueToTree(endpointsInLastNOrder.stream().map(AbstractEndpoint::getId)
+                    .collect(Collectors.toList())));
         }
 
         return debugState;

--- a/jvb/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/EndpointMessageTransport.java
@@ -26,7 +26,8 @@ import org.jitsi.videobridge.message.*;
 import org.jitsi.videobridge.metrics.*;
 import org.jitsi.videobridge.relay.*;
 import org.jitsi.videobridge.websocket.*;
-import org.json.simple.*;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.lang.ref.*;
 import java.util.*;
@@ -467,16 +468,15 @@ public class EndpointMessageTransport
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public JSONObject getDebugState()
+    public ObjectNode getDebugState()
     {
-        JSONObject debugState = super.getDebugState();
+        ObjectNode debugState = super.getDebugState();
         debugState.put("numOutgoingMessagesDropped", numOutgoingMessagesDropped.get());
 
-        JSONObject sentCounts = new JSONObject();
-        sentCounts.putAll(sentMessagesCounts);
-        debugState.put("sent_counts", sentCounts);
+        ObjectNode sentCounts = JsonNodeFactory.instance.objectNode();
+        sentMessagesCounts.forEach((k, v) -> sentCounts.put(k, v.get()));
+        debugState.set("sent_counts", sentCounts);
 
         return debugState;
     }

--- a/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Videobridge.java
@@ -32,7 +32,8 @@ import org.jitsi.videobridge.xmpp.*;
 import org.jitsi.xmpp.extensions.colibri2.*;
 import org.jitsi.xmpp.extensions.health.*;
 import org.jivesoftware.smack.packet.*;
-import org.json.simple.*;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.jxmpp.jid.*;
 import org.jxmpp.jid.impl.*;
 import org.jxmpp.stringprep.*;
@@ -484,10 +485,9 @@ public class Videobridge
      * to include. If not specified, all of the conference's endpoints will be
      * included.
      */
-    @SuppressWarnings("unchecked")
-    public OrderedJsonObject getDebugState(String conferenceId, String endpointId, DebugStateMode mode)
+    public ObjectNode getDebugState(String conferenceId, String endpointId, DebugStateMode mode)
     {
-        OrderedJsonObject debugState = new OrderedJsonObject();
+        ObjectNode debugState = JsonNodeFactory.instance.objectNode();
 
         if (mode == DebugStateMode.FULL || mode == DebugStateMode.SHORT)
         {
@@ -495,7 +495,7 @@ public class Videobridge
             debugState.put("drain", drainMode);
             debugState.put("time", System.currentTimeMillis());
 
-            debugState.put("load_management", jvbLoadManager.getStats());
+            debugState.set("load_management", jvbLoadManager.getStats());
 
             Double jitter = PacketTransitStats.getBridgeJitter();
             if (jitter != null)
@@ -504,14 +504,14 @@ public class Videobridge
             }
         }
 
-        JSONObject conferences = new JSONObject();
-        debugState.put("conferences", conferences);
+        ObjectNode conferences = JsonNodeFactory.instance.objectNode();
+        debugState.set("conferences", conferences);
         if (StringUtils.isBlank(conferenceId))
         {
             getConferences().stream()
                     .filter(c -> mode != DebugStateMode.STATS || c.isRtcStatsEnabled())
                     .forEach(conference ->
-                conferences.put(
+                conferences.set(
                         conference.getID(),
                         conference.getDebugState(mode, null)));
         }
@@ -524,9 +524,14 @@ public class Videobridge
                 conference = this.conferencesById.get(conferenceId);
             }
 
-            conferences.put(
-                    conferenceId,
-                    conference == null ? "null" : conference.getDebugState(mode, endpointId));
+            if (conference == null)
+            {
+                conferences.put(conferenceId, "null");
+            }
+            else
+            {
+                conferences.set(conferenceId, conference.getDebugState(mode, endpointId));
+            }
         }
 
         return debugState;

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/AdaptiveSourceProjection.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/AdaptiveSourceProjection.java
@@ -27,7 +27,8 @@ import org.jitsi.utils.logging2.Logger;
 import org.jitsi.videobridge.cc.av1.*;
 import org.jitsi.videobridge.cc.vp8.*;
 import org.jitsi.videobridge.cc.vp9.*;
-import org.json.simple.*;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.lang.*;
 import java.util.*;
@@ -375,18 +376,22 @@ public class AdaptiveSourceProjection
      * Gets a JSON representation of the parts of this object's state that
      * are deemed useful for debugging.
      */
-    @SuppressWarnings("unchecked")
-    public JSONObject getDebugState(@NotNull DebugStateMode mode)
+    public ObjectNode getDebugState(@NotNull DebugStateMode mode)
     {
-        JSONObject debugState = new JSONObject();
+        ObjectNode debugState = JsonNodeFactory.instance.objectNode();
 
         debugState.put("targetSsrc", targetSsrc);
         AdaptiveSourceProjectionContext contextCopy = context;
         if (mode == DebugStateMode.FULL)
         {
-            debugState.put(
-                    "context",
-                    contextCopy == null ? null : contextCopy.getDebugState());
+            if (contextCopy == null)
+            {
+                debugState.putNull("context");
+            }
+            else
+            {
+                debugState.set("context", contextCopy.getDebugState());
+            }
         }
         else if (mode == DebugStateMode.STATS)
         {
@@ -394,7 +399,7 @@ public class AdaptiveSourceProjection
                     "context",
                     contextCopy == null ? "null" : contextCopy.getClass().getSimpleName());
         }
-        debugState.put("needsKeyframe", contextCopy == null ? "N/A" : contextCopy.needsKeyframe());
+        debugState.put("needsKeyframe", contextCopy == null ? "N/A" : Boolean.toString(contextCopy.needsKeyframe()));
         debugState.put("targetIndex", targetIndex);
 
         return debugState;

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/AdaptiveSourceProjectionContext.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/AdaptiveSourceProjectionContext.java
@@ -18,7 +18,7 @@ package org.jitsi.videobridge.cc;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.jitsi.nlj.*;
 import org.jitsi.rtp.rtcp.*;
-import org.json.simple.*;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Implementations of this interface are responsible for projecting a specific
@@ -95,5 +95,5 @@ public interface AdaptiveSourceProjectionContext
      * Gets a JSON representation of the parts of this object's state that
      * are deemed useful for debugging.
      */
-    JSONObject getDebugState();
+    ObjectNode getDebugState();
 }

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/GenericAdaptiveSourceProjectionContext.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/GenericAdaptiveSourceProjectionContext.java
@@ -21,7 +21,8 @@ import org.jitsi.nlj.rtp.*;
 import org.jitsi.rtp.rtcp.*;
 import org.jitsi.rtp.util.*;
 import org.jitsi.utils.logging2.*;
-import org.json.simple.*;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * A generic implementation of an adaptive source projection context that can be
@@ -335,10 +336,9 @@ class GenericAdaptiveSourceProjectionContext
      * @return
      */
     @Override
-    @SuppressWarnings("unchecked")
-    public JSONObject getDebugState()
+    public ObjectNode getDebugState()
     {
-        JSONObject debugState = new JSONObject();
+        ObjectNode debugState = JsonNodeFactory.instance.objectNode();
         debugState.put(
                 "class",
                 GenericAdaptiveSourceProjectionContext.class.getSimpleName());

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveSourceProjectionContext.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/vp8/VP8AdaptiveSourceProjectionContext.java
@@ -24,7 +24,9 @@ import org.jitsi.rtp.util.*;
 import org.jitsi.utils.logging.*;
 import org.jitsi.utils.logging2.Logger;
 import org.jitsi.videobridge.cc.*;
-import org.json.simple.*;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.time.*;
 import java.util.*;
@@ -706,25 +708,23 @@ public class VP8AdaptiveSourceProjectionContext
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("unchecked")
-    public synchronized JSONObject getDebugState()
+    public synchronized ObjectNode getDebugState()
     {
-        JSONObject debugState = new JSONObject();
+        ObjectNode debugState = JsonNodeFactory.instance.objectNode();
         debugState.put(
                 "class",
                 VP8AdaptiveSourceProjectionContext.class.getSimpleName());
 
-        JSONArray mapSizes = new JSONArray();
+        ArrayNode mapSizes = JsonNodeFactory.instance.arrayNode();
         for (Map.Entry<Long, VP8FrameMap> entry: vp8FrameMaps.entrySet())
         {
-            JSONObject sizeInfo = new JSONObject();
+            ObjectNode sizeInfo = JsonNodeFactory.instance.objectNode();
             sizeInfo.put("ssrc", entry.getKey());
             sizeInfo.put("size", entry.getValue().size());
             mapSizes.add(sizeInfo);
         }
-        debugState.put(
-                "vp8FrameMaps", mapSizes);
-        debugState.put("vp8QualityFilter", vp8QualityFilter.getDebugState());
+        debugState.set("vp8FrameMaps", mapSizes);
+        debugState.set("vp8QualityFilter", vp8QualityFilter.getDebugState());
 
         return debugState;
     }

--- a/jvb/src/main/java/org/jitsi/videobridge/cc/vp8/VP8QualityFilter.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/vp8/VP8QualityFilter.java
@@ -20,7 +20,8 @@ import org.jetbrains.annotations.*;
 import org.jetbrains.annotations.Nullable;
 import org.jitsi.nlj.*;
 import org.jitsi.utils.logging2.*;
-import org.json.simple.*;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.lang.SuppressWarnings;
 import java.time.*;
@@ -369,9 +370,9 @@ class VP8QualityFilter
             value = "IS2_INCONSISTENT_SYNC",
             justification = "We intentionally avoid synchronizing while reading" +
                     " fields only used in debug output.")
-    public JSONObject getDebugState()
+    public ObjectNode getDebugState()
     {
-        JSONObject debugState = new JSONObject();
+        ObjectNode debugState = JsonNodeFactory.instance.objectNode();
         debugState.put(
                 "mostRecentKeyframeGroupArrivalTimeMs",
             mostRecentKeyframeGroupArrivalTime != null ? mostRecentKeyframeGroupArrivalTime.toEpochMilli() : -1L);

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/drain/Drain.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/drain/Drain.java
@@ -20,7 +20,8 @@ import org.eclipse.jetty.http.*;
 import org.jitsi.videobridge.*;
 import org.jitsi.videobridge.rest.*;
 import org.jitsi.videobridge.rest.annotations.*;
-import org.json.simple.*;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import jakarta.inject.*;
 import jakarta.ws.rs.*;
@@ -63,13 +64,12 @@ public class Drain
         return setDrainMode(false);
     }
 
-    @SuppressWarnings("unchecked")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public String getDrainState()
     {
-        JSONObject obj = new JSONObject();
+        ObjectNode obj = JsonNodeFactory.instance.objectNode();
         obj.put("drain", videobridge.getDrainMode());
-        return obj.toJSONString();
+        return obj.toString();
     }
 }

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClient.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClient.java
@@ -19,8 +19,9 @@ package org.jitsi.videobridge.rest.root.colibri.mucclient;
 import org.jitsi.videobridge.rest.*;
 import org.jitsi.videobridge.rest.annotations.*;
 import org.jitsi.videobridge.xmpp.*;
-import org.json.simple.*;
-import org.json.simple.parser.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import jakarta.inject.*;
 import jakarta.servlet.http.*;
@@ -40,39 +41,53 @@ public class MucClient
     @Path("/add")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response addMucClient(String requestBody) throws ParseException
+    public Response addMucClient(String requestBody)
     {
         //NOTE: unfortunately MucClientConfiguration is not a compliant bean (it doesn't have
         // a no-arg ctor) so we can't parse the json directly into a MucClientConfiguration
         // instance and just take that as an argument here, we have to read the json
         // ourselves.
-        Object o = new JSONParser().parse(requestBody);
-        if (!(o instanceof JSONObject))
+        try
+        {
+            JsonNode node = new ObjectMapper().readTree(requestBody);
+            if (!(node instanceof ObjectNode))
+            {
+                return Response.status(HttpServletResponse.SC_BAD_REQUEST).build();
+            }
+            if (xmppConnection.addMucClient((ObjectNode)node))
+            {
+                return Response.ok().build();
+            }
+            return Response.status(HttpServletResponse.SC_BAD_REQUEST).build();
+        }
+        catch (Exception e)
         {
             return Response.status(HttpServletResponse.SC_BAD_REQUEST).build();
         }
-        if (xmppConnection.addMucClient((JSONObject)o))
-        {
-            return Response.ok().build();
-        }
-        return Response.status(HttpServletResponse.SC_BAD_REQUEST).build();
     }
 
     @Path("/remove")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response removeMucClient(String requestBody) throws ParseException
+    public Response removeMucClient(String requestBody)
     {
-        Object o = new JSONParser().parse(requestBody);
-        if (!(o instanceof JSONObject))
+        try
+        {
+            JsonNode node = new ObjectMapper().readTree(requestBody);
+            if (!(node instanceof ObjectNode))
+            {
+                return Response.status(HttpServletResponse.SC_BAD_REQUEST).build();
+            }
+            if (xmppConnection.removeMucClient((ObjectNode)node))
+            {
+                return Response.ok().build();
+            }
+            return Response.status(HttpServletResponse.SC_BAD_REQUEST).build();
+        }
+        catch (Exception e)
         {
             return Response.status(HttpServletResponse.SC_BAD_REQUEST).build();
         }
-        if (xmppConnection.removeMucClient((JSONObject)o))
-        {
-            return Response.ok().build();
-        }
-        return Response.status(HttpServletResponse.SC_BAD_REQUEST).build();
     }
 
     @Path("/list")

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/stats/Stats.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/stats/Stats.java
@@ -31,6 +31,6 @@ public class Stats
     @Produces(MediaType.APPLICATION_JSON)
     public String getStats()
     {
-        return VideobridgeStatisticsShim.INSTANCE.getStatsJson().toJSONString();
+        return VideobridgeStatisticsShim.INSTANCE.getStatsJson().toString();
     }
 }

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/v2/conferences/Conferences.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/colibri/v2/conferences/Conferences.java
@@ -23,9 +23,11 @@ import org.jitsi.videobridge.rest.annotations.*;
 import org.jitsi.videobridge.rest.exceptions.*;
 import org.jitsi.xmpp.extensions.colibri2.*;
 import org.jitsi.xmpp.extensions.colibri2.json.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.jivesoftware.smack.packet.*;
-import org.json.simple.*;
-import org.json.simple.parser.*;
 
 import jakarta.inject.*;
 import jakarta.ws.rs.*;
@@ -36,6 +38,8 @@ import java.util.*;
 @EnabledByConfig(RestApis.COLIBRI)
 public class Conferences
 {
+    private static final ObjectMapper jsonMapper = new ObjectMapper();
+
     @Inject
     private Videobridge videobridge;
 
@@ -77,7 +81,7 @@ public class Conferences
 
         ConferenceSpeechActivity conferenceSpeechActivity = conference.getSpeechActivity();
 
-        return conferenceSpeechActivity.getDebugState(DebugStateMode.FULL).toJSONString();
+        return conferenceSpeechActivity.getDebugState(DebugStateMode.FULL).toString();
     }
 
     @POST
@@ -85,16 +89,16 @@ public class Conferences
     @Produces(MediaType.APPLICATION_JSON)
     public String createConference(String requestBody)
     {
-        Object requestJson;
+        JsonNode requestJson;
         try
         {
-            requestJson = new JSONParser().parse(requestBody);
-            if (!(requestJson instanceof JSONObject))
+            requestJson = jsonMapper.readTree(requestBody);
+            if (!(requestJson instanceof ObjectNode))
             {
                 throw new BadRequestException();
             }
         }
-        catch (ParseException pe)
+        catch (JsonProcessingException pe)
         {
             throw new BadRequestExceptionWithMessage(
                     "Failed to create conference, could not parse JSON: " + pe.getMessage());
@@ -105,7 +109,7 @@ public class Conferences
         try
         {
             conferenceModifyIQ
-                = Colibri2JSONDeserializer.deserializeConferenceModify((JSONObject) requestJson).build();
+                = Colibri2JSONDeserializer.deserializeConferenceModify((ObjectNode) requestJson).build();
         }
         catch (Exception e)
         {
@@ -126,16 +130,16 @@ public class Conferences
         {
             throw new NotFoundException();
         }
-        Object requestJson;
+        JsonNode requestJson;
         try
         {
-            requestJson = new JSONParser().parse(requestBody);
-            if (!(requestJson instanceof JSONObject))
+            requestJson = jsonMapper.readTree(requestBody);
+            if (!(requestJson instanceof ObjectNode))
             {
                 throw new BadRequestException();
             }
         }
-        catch (ParseException e)
+        catch (JsonProcessingException e)
         {
             throw new BadRequestException();
         }
@@ -144,7 +148,7 @@ public class Conferences
         try
         {
             conferenceModifyIQBuilder
-                = Colibri2JSONDeserializer.deserializeConferenceModify((JSONObject) requestJson);
+                = Colibri2JSONDeserializer.deserializeConferenceModify((ObjectNode) requestJson);
         }
         catch (Exception e)
         {
@@ -173,8 +177,8 @@ public class Conferences
             throw new InternalServerErrorExceptionWithMessage("Non-error, non-colibri IQ result");
         }
 
-        JSONObject responseJson = Colibri2JSONSerializer.serializeConferenceModified((ConferenceModifiedIQ)responseIq);
+        ObjectNode responseJson = Colibri2JSONSerializer.serializeConferenceModified((ConferenceModifiedIQ)responseIq);
 
-        return responseJson.toJSONString();
+        return responseJson.toString();
     }
 }

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/Debug.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/debug/Debug.java
@@ -38,7 +38,8 @@ import jakarta.inject.*;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.*;
 import jakarta.ws.rs.core.MediaType;
-import org.json.simple.JSONObject;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.net.*;
 
@@ -320,21 +321,21 @@ public class Debug
     @Produces(MediaType.APPLICATION_JSON)
     public String bridgeDebug(@DefaultValue("false") @QueryParam("full") boolean full)
     {
-        OrderedJsonObject debugState = videobridge.getDebugState(
+        ObjectNode debugState = videobridge.getDebugState(
                 null,
                 null,
                 full ? DebugStateMode.FULL : DebugStateMode.SHORT);
 
         // Append the health status.
         Result result = healthCheckService.getResult();
-        JSONObject health = new JSONObject();
+        ObjectNode health = JsonNodeFactory.instance.objectNode();
         health.put("success", result.getSuccess());
         health.put("hardFailure", result.getHardFailure());
         health.put("responseCode", result.getResponseCode());
         health.put("message", result.getMessage());
-        debugState.put("health", health);
+        debugState.set("health", health);
 
-        return debugState.toJSONString();
+        return debugState.toString();
     }
 
     @GET
@@ -344,11 +345,11 @@ public class Debug
             @PathParam("confId") String confId,
             @DefaultValue("true") @QueryParam("full") boolean full)
     {
-        OrderedJsonObject confJson = videobridge.getDebugState(
+        ObjectNode confJson = videobridge.getDebugState(
                 confId,
                 null,
                 full ? DebugStateMode.FULL : DebugStateMode.SHORT);
-        return confJson.toJSONString();
+        return confJson.toString();
     }
 
     @GET
@@ -359,11 +360,11 @@ public class Debug
             @PathParam("epId") String epId,
             @DefaultValue("true") @QueryParam("full") boolean full)
     {
-        OrderedJsonObject confJson = videobridge.getDebugState(
+        ObjectNode confJson = videobridge.getDebugState(
                 confId,
                 epId,
                 full ? DebugStateMode.FULL : DebugStateMode.SHORT);
-        return confJson.toJSONString();
+        return confJson.toString();
     }
 
     @GET
@@ -374,34 +375,34 @@ public class Debug
         switch (feature)
         {
             case NODE_STATS: {
-                return StatsKeepingNode.Companion.getStatsJson().toJSONString();
+                return StatsKeepingNode.Companion.getStatsJson().toString();
             }
             case POOL_STATS: {
-                return ByteBufferPool.getStatsJson().toJSONString();
+                return ByteBufferPool.getStatsJson().toString();
             }
             case QUEUE_STATS: {
-                return QueueStats.getQueueStats().toJSONString();
+                return QueueStats.getQueueStats().toString();
             }
             case TRANSIT_STATS: {
-                return PacketTransitStats.getStatsJson().toJSONString();
+                return PacketTransitStats.getStatsJson().toString();
             }
             case TASK_POOL_STATS: {
-                return TaskPools.getStatsJson().toJSONString();
+                return TaskPools.getStatsJson().toString();
             }
             case XMPP_DELAY_STATS: {
-                return XmppConnection.getStatsJson().toJSONString();
+                return XmppConnection.getStatsJson().toString();
             }
             case PAYLOAD_VERIFICATION: {
-                return PayloadVerificationPlugin.getStatsJson().toJSONString();
+                return PayloadVerificationPlugin.getStatsJson().toString();
             }
             case ICE_STATS: {
-                return IceStatistics.Companion.getStats().toJson().toJSONString();
+                return IceStatistics.Companion.getStats().toJson().toString();
             }
             case CONFERENCE_PACKET_STATS: {
-                return ConferencePacketStats.stats.toJson().toJSONString();
+                return ConferencePacketStats.stats.toJson().toString();
             }
             case TOSSED_PACKET_STATS: {
-                return VideobridgeMetrics.tossedPacketsEnergy.get().toJSONString();
+                return VideobridgeMetrics.tossedPacketsEnergy.get().toString();
             }
             default: {
                 throw new NotFoundException();

--- a/jvb/src/main/java/org/jitsi/videobridge/rest/root/stats/Stats.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/rest/root/stats/Stats.java
@@ -19,7 +19,7 @@ import jakarta.inject.*;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import org.jitsi.nlj.*;
-import org.jitsi.utils.*;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.jitsi.videobridge.*;
 import org.jitsi.videobridge.rest.*;
 import org.jitsi.videobridge.rest.annotations.*;
@@ -35,11 +35,11 @@ public class Stats
     @Produces(MediaType.APPLICATION_JSON)
     public String rtcstats()
     {
-        OrderedJsonObject debugState = videobridge.getDebugState(
+        ObjectNode debugState = videobridge.getDebugState(
                 null,
                 null,
                 DebugStateMode.STATS);
 
-        return debugState.toJSONString();
+        return debugState.toString();
     }
 }

--- a/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/ByteBufferPool.java
@@ -16,9 +16,10 @@
 
 package org.jitsi.videobridge.util;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.jetbrains.annotations.*;
 import org.jitsi.nlj.util.*;
-import org.jitsi.utils.*;
 import org.jitsi.utils.logging2.*;
 
 import java.util.*;
@@ -232,9 +233,9 @@ public class ByteBufferPool
     /**
      * Gets a JSON representation of the statistics about the pool.
      */
-    public static OrderedJsonObject getStatsJson()
+    public static ObjectNode getStatsJson()
     {
-        OrderedJsonObject stats = new OrderedJsonObject();
+        ObjectNode stats = JsonNodeFactory.instance.objectNode();
         long numLargeRequestsSum = numLargeRequests.sum();
 
         stats.put("num_large_requests", numLargeRequestsSum);
@@ -254,9 +255,9 @@ public class ByteBufferPool
                 (100.0 * allAllocations) / numRequestsSum);
             stats.put("stored_bytes", storedBytes);
 
-            stats.put("pool1", pool1.getStats());
-            stats.put("pool2", pool2.getStats());
-            stats.put("pool3", pool3.getStats());
+            stats.set("pool1", pool1.getStats());
+            stats.set("pool2", pool2.getStats());
+            stats.set("pool3", pool3.getStats());
         }
 
         if (bookkeepingEnabled)

--- a/jvb/src/main/java/org/jitsi/videobridge/util/PartitionedByteBufferPool.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/PartitionedByteBufferPool.java
@@ -16,11 +16,12 @@
 
 package org.jitsi.videobridge.util;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.jetbrains.annotations.*;
-import org.jitsi.utils.*;
 import org.jitsi.utils.logging2.*;
 import org.jitsi.utils.stats.*;
-import org.json.simple.*;
 
 import java.time.*;
 import java.util.concurrent.*;
@@ -121,10 +122,9 @@ class PartitionedByteBufferPool
     /**
      * Adds statistics for this pool to the given JSON object.
      */
-    @SuppressWarnings("unchecked")
-    OrderedJsonObject getStats()
+    ObjectNode getStats()
     {
-        OrderedJsonObject stats = new OrderedJsonObject();
+        ObjectNode stats = JsonNodeFactory.instance.objectNode();
 
         stats.put("default_size", defaultBufferSize);
 
@@ -132,7 +132,7 @@ class PartitionedByteBufferPool
         long returns = 0;
         long allocations = 0;
         long storedBytes = 0;
-        JSONArray partitionStats = new JSONArray();
+        ArrayNode partitionStats = JsonNodeFactory.instance.arrayNode();
 
         for (Partition p : partitions)
         {
@@ -151,7 +151,7 @@ class PartitionedByteBufferPool
             "allocation_percent",
             100D * allocations / Math.max(1, requests));
 
-        stats.put("partitions", partitionStats);
+        stats.set("partitions", partitionStats);
         return stats;
     }
 
@@ -387,11 +387,10 @@ class PartitionedByteBufferPool
         /**
          * Gets a snapshot of the statistics of this partition in JSON format.
          */
-        @SuppressWarnings("unchecked")
-        private OrderedJsonObject getStatsJson()
+        private ObjectNode getStatsJson()
         {
             long now = System.currentTimeMillis();
-            OrderedJsonObject stats = new OrderedJsonObject();
+            ObjectNode stats = JsonNodeFactory.instance.objectNode();
             stats.put("id", id);
 
             long numRequestsSum = numRequests.sum();

--- a/jvb/src/main/java/org/jitsi/videobridge/util/TaskPools.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/util/TaskPools.java
@@ -18,7 +18,8 @@ package org.jitsi.videobridge.util;
 
 import org.jitsi.utils.concurrent.*;
 import org.jitsi.utils.logging2.*;
-import org.json.simple.*;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.util.concurrent.*;
 
@@ -50,10 +51,9 @@ public class TaskPools
     }
 
 
-    @SuppressWarnings("unchecked")
-    public static JSONObject getStatsJson(ExecutorService es)
+    public static ObjectNode getStatsJson(ExecutorService es)
     {
-        JSONObject debugState = new JSONObject();
+        ObjectNode debugState = JsonNodeFactory.instance.objectNode();
         debugState.put("executor_class", es.getClass().getSimpleName());
 
         if (es instanceof ThreadPoolExecutor)
@@ -72,13 +72,12 @@ public class TaskPools
         return debugState;
     }
 
-    @SuppressWarnings("unchecked")
-    public static JSONObject getStatsJson()
+    public static ObjectNode getStatsJson()
     {
-        JSONObject debugState = new JSONObject();
+        ObjectNode debugState = JsonNodeFactory.instance.objectNode();
 
-        debugState.put("IO_POOL", getStatsJson(IO_POOL));
-        debugState.put("CPU_POOL", getStatsJson(CPU_POOL));
+        debugState.set("IO_POOL", getStatsJson(IO_POOL));
+        debugState.set("CPU_POOL", getStatsJson(CPU_POOL));
 
         return debugState;
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpoint.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.DebugStateMode
 import org.jitsi.nlj.MediaSourceDesc
@@ -22,7 +23,6 @@ import org.jitsi.nlj.VideoType
 import org.jitsi.nlj.format.PayloadType
 import org.jitsi.nlj.rtp.RtpExtension
 import org.jitsi.utils.NEVER
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.event.EventEmitter
 import org.jitsi.utils.event.SyncEventEmitter
 import org.jitsi.utils.logging2.Logger
@@ -237,8 +237,8 @@ abstract class AbstractEndpoint protected constructor(
     abstract fun requestKeyframe()
 
     /** A JSON representation of the parts of this object's state that are deemed useful for debugging. */
-    open fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
-        val receiverVideoConstraints = OrderedJsonObject()
+    open fun debugState(mode: DebugStateMode): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
+        val receiverVideoConstraints = JsonNodeFactory.instance.objectNode()
         this@AbstractEndpoint.receiverVideoConstraints.forEach { (sourceName, receiverConstraints) ->
             receiverVideoConstraints.set<ObjectNode>(sourceName, receiverConstraints.getDebugState())
         }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpoint.kt
@@ -15,12 +15,14 @@
  */
 package org.jitsi.videobridge
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.DebugStateMode
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.VideoType
 import org.jitsi.nlj.format.PayloadType
 import org.jitsi.nlj.rtp.RtpExtension
 import org.jitsi.utils.NEVER
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.event.EventEmitter
 import org.jitsi.utils.event.SyncEventEmitter
 import org.jitsi.utils.logging2.Logger
@@ -30,7 +32,6 @@ import org.jitsi.videobridge.cc.allocation.ReceiverConstraintsMap
 import org.jitsi.videobridge.cc.allocation.VideoConstraints
 import org.jitsi.videobridge.relay.AudioSourceDesc
 import org.jitsi.videobridge.util.TaskPools
-import org.json.simple.JSONObject
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 
@@ -236,15 +237,15 @@ abstract class AbstractEndpoint protected constructor(
     abstract fun requestKeyframe()
 
     /** A JSON representation of the parts of this object's state that are deemed useful for debugging. */
-    open fun debugState(mode: DebugStateMode): JSONObject = JSONObject().apply {
-        val receiverVideoConstraints = JSONObject()
+    open fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+        val receiverVideoConstraints = OrderedJsonObject()
         this@AbstractEndpoint.receiverVideoConstraints.forEach { (sourceName, receiverConstraints) ->
-            receiverVideoConstraints[sourceName] = receiverConstraints.getDebugState()
+            receiverVideoConstraints.set<ObjectNode>(sourceName, receiverConstraints.getDebugState())
         }
-        this["receiver_video_constraints"] = receiverVideoConstraints
-        this["max_receiver_video_constraints"] = HashMap(maxReceiverVideoConstraints)
-        this["expired"] = isExpired
-        this["stats_id"] = statsId
+        set<ObjectNode>("receiver_video_constraints", receiverVideoConstraints)
+        put("max_receiver_video_constraints", HashMap(maxReceiverVideoConstraints).toString())
+        put("expired", isExpired)
+        put("stats_id", statsId)
     }
 
     /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpointMessageTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpointMessageTransport.kt
@@ -15,8 +15,8 @@
  */
 package org.jitsi.videobridge
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.queue.CountingErrorHandler
 import org.jitsi.utils.queue.PacketQueue
@@ -86,8 +86,8 @@ abstract class AbstractEndpointMessageTransport(parentLogger: Logger) : MessageH
     open fun close() {}
 
     open val debugState: ObjectNode
-        get() = OrderedJsonObject().apply {
-            val counts = OrderedJsonObject()
+        get() = JsonNodeFactory.instance.objectNode().apply {
+            val counts = JsonNodeFactory.instance.objectNode()
             getReceivedCounts().forEach { (k, v) -> counts.put(k, v) }
             set<ObjectNode>("received_counts", counts)
         }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpointMessageTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpointMessageTransport.kt
@@ -15,6 +15,8 @@
  */
 package org.jitsi.videobridge
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.queue.CountingErrorHandler
 import org.jitsi.utils.queue.PacketQueue
@@ -24,7 +26,6 @@ import org.jitsi.videobridge.message.MessageHandler
 import org.jitsi.videobridge.metrics.QueueMetrics
 import org.jitsi.videobridge.metrics.VideobridgeMetricsContainer
 import org.jitsi.videobridge.util.TaskPools
-import org.json.simple.JSONObject
 import java.io.IOException
 import java.time.Clock
 
@@ -84,9 +85,11 @@ abstract class AbstractEndpointMessageTransport(parentLogger: Logger) : MessageH
 
     open fun close() {}
 
-    open val debugState: JSONObject
-        get() = JSONObject().apply {
-            this["received_counts"] = JSONObject(getReceivedCounts())
+    open val debugState: ObjectNode
+        get() = OrderedJsonObject().apply {
+            val counts = OrderedJsonObject()
+            getReceivedCounts().forEach { (k, v) -> counts.put(k, v) }
+            set<ObjectNode>("received_counts", counts)
         }
 
     /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.videobridge
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.ice4j.util.Buffer
 import org.jitsi.config.JitsiConfig
 import org.jitsi.dcsctp4j.DcSctpMessage
@@ -91,7 +92,6 @@ import org.jitsi.videobridge.websocket.colibriWebSocketServiceSupplier
 import org.jitsi.xmpp.extensions.colibri.WebSocketPacketExtension
 import org.jitsi.xmpp.extensions.jingle.DtlsFingerprintPacketExtension
 import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension
-import org.json.simple.JSONObject
 import java.nio.ByteBuffer
 import java.security.SecureRandom
 import java.time.Clock
@@ -1032,23 +1032,23 @@ class Endpoint @JvmOverloads constructor(
         }
     }
 
-    override fun debugState(mode: DebugStateMode): JSONObject = super.debugState(mode).apply {
-        put("bitrate_controller", bitrateController.debugState(mode))
-        put("bandwidth_probing", bandwidthProbing.getDebugState())
+    override fun debugState(mode: DebugStateMode): ObjectNode = super.debugState(mode).apply {
+        set<ObjectNode>("bitrate_controller", bitrateController.debugState(mode))
+        set<ObjectNode>("bandwidth_probing", bandwidthProbing.getDebugState())
         put("cryptex", cryptex)
-        put("ice_transport", iceTransport.getDebugState())
-        put("dtls_transport", dtlsTransport.getDebugState())
-        put("transceiver", transceiver.debugState(mode))
+        set<ObjectNode>("ice_transport", iceTransport.getDebugState())
+        set<ObjectNode>("dtls_transport", dtlsTransport.getDebugState())
+        set<ObjectNode>("transceiver", transceiver.debugState(mode))
         put("accept_audio", acceptAudio)
         put("accept_video", acceptVideo)
         put("visitor", visitor)
-        put("message_transport", messageTransport.debugState)
+        set<ObjectNode>("message_transport", messageTransport.debugState)
         if (doSsrcRewriting) {
-            put("audio_ssrcs", audioSsrcs.getDebugState())
-            put("video_ssrcs", videoSsrcs.getDebugState())
+            set<ObjectNode>("audio_ssrcs", audioSsrcs.getDebugState())
+            set<ObjectNode>("video_ssrcs", videoSsrcs.getDebugState())
         }
         sctpTransport?.let {
-            put("sctp", it.getDebugState())
+            set<ObjectNode>("sctp", it.getDebugState())
         }
     }
 
@@ -1062,10 +1062,10 @@ class Endpoint @JvmOverloads constructor(
             bitrateController.expire()
             updateStatsOnExpire()
             transceiver.stop()
-            logger.cdebug { transceiver.debugState(DebugStateMode.FULL).toJSONString() }
-            logger.cdebug { bitrateController.debugState(DebugStateMode.FULL).toJSONString() }
-            logger.cdebug { iceTransport.getDebugState().toJSONString() }
-            logger.cdebug { dtlsTransport.getDebugState().toJSONString() }
+            logger.cdebug { transceiver.debugState(DebugStateMode.FULL).toString() }
+            logger.cdebug { bitrateController.debugState(DebugStateMode.FULL).toString() }
+            logger.cdebug { iceTransport.getDebugState().toString() }
+            logger.cdebug { dtlsTransport.getDebugState().toString() }
 
             logger.info("Spent ${bitrateController.getTotalOversendingTime().seconds} seconds oversending")
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.videobridge
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.VideoType
 import org.jitsi.nlj.codec.vpx.VpxUtils
@@ -32,6 +33,7 @@ import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.rtp.util.RtpUtils
 import org.jitsi.utils.LRUCache
 import org.jitsi.utils.MediaType
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.videobridge.message.AudioSourceMapping
@@ -40,7 +42,6 @@ import org.jitsi.videobridge.message.BridgeChannelMessage
 import org.jitsi.videobridge.message.VideoSourceMapping
 import org.jitsi.videobridge.message.VideoSourcesMap
 import org.jitsi.videobridge.relay.AudioSourceDesc
-import org.json.simple.JSONObject
 
 /**
  * Align common fields from different source types.
@@ -501,9 +502,9 @@ abstract class SsrcCache(val size: Int, val ep: SsrcRewriter, val parentLogger: 
     /**
      * Returns JSON statistics useful for debugging.
      */
-    fun getDebugState(): JSONObject {
+    fun getDebugState(): ObjectNode {
         synchronized(sendSources) {
-            return JSONObject().apply {
+            return OrderedJsonObject().apply {
                 put("max", this@SsrcCache.size)
                 put("received", receivedSsrcs.size)
                 put("sent", sendSources.size)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.videobridge
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.VideoType
@@ -33,7 +34,6 @@ import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.rtp.util.RtpUtils
 import org.jitsi.utils.LRUCache
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.videobridge.message.AudioSourceMapping
@@ -504,7 +504,7 @@ abstract class SsrcCache(val size: Int, val ep: SsrcRewriter, val parentLogger: 
      */
     fun getDebugState(): ObjectNode {
         synchronized(sendSources) {
-            return OrderedJsonObject().apply {
+            return JsonNodeFactory.instance.objectNode().apply {
                 put("max", this@SsrcCache.size)
                 put("received", receivedSsrcs.size)
                 put("sent", sendSources.size)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/BandwidthProbing.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/BandwidthProbing.kt
@@ -16,10 +16,12 @@
 
 package org.jitsi.videobridge.cc
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.rtp.TransportCcEngine
 import org.jitsi.nlj.util.Bandwidth
 import org.jitsi.nlj.util.BitrateTracker
 import org.jitsi.nlj.util.bytes
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.concurrent.PeriodicRunnable
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
@@ -27,7 +29,6 @@ import org.jitsi.utils.ms
 import org.jitsi.utils.secs
 import org.jitsi.videobridge.cc.allocation.BitrateControllerStatusSnapshot
 import org.jitsi.videobridge.cc.config.BandwidthProbingConfig.Companion.config
-import org.json.simple.JSONObject
 import java.util.function.Supplier
 
 class BandwidthProbing(
@@ -132,7 +133,7 @@ class BandwidthProbing(
         }
     }
 
-    fun getDebugState(): JSONObject = JSONObject().apply {
+    fun getDebugState(): ObjectNode = OrderedJsonObject().apply {
         put("enabled", enabled)
         put("latest_bwe", latestBwe)
         put("last_total_needed_bps", lastTotalNeededBps)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/BandwidthProbing.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/BandwidthProbing.kt
@@ -16,12 +16,12 @@
 
 package org.jitsi.videobridge.cc
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.rtp.TransportCcEngine
 import org.jitsi.nlj.util.Bandwidth
 import org.jitsi.nlj.util.BitrateTracker
 import org.jitsi.nlj.util.bytes
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.concurrent.PeriodicRunnable
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
@@ -133,7 +133,7 @@ class BandwidthProbing(
         }
     }
 
-    fun getDebugState(): ObjectNode = OrderedJsonObject().apply {
+    fun getDebugState(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("enabled", enabled)
         put("latest_bwe", latestBwe)
         put("last_total_needed_bps", lastTotalNeededBps)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/AllocationSettings.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/AllocationSettings.kt
@@ -16,6 +16,8 @@
  */
 package org.jitsi.videobridge.cc.allocation
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.nlj.util.bps
@@ -42,16 +44,19 @@ data class AllocationSettings @JvmOverloads constructor(
     /** A non-negative value is assumed as the available bandwidth in bps. A negative value is ignored. */
     val assumedBandwidthBps: Long = -1
 ) {
-    fun toJson() = OrderedJsonObject().apply {
-        put("on_stage_sources", onStageSources)
-        put("selected_sources", selectedSources)
-        put("video_constraints", videoConstraints)
-        put("last_n", lastN)
-        put("default_constraints", defaultConstraints)
-        put("assumed_bandwidth_bps", assumedBandwidthBps)
+    fun toJson(): ObjectNode {
+        val mapper = ObjectMapper()
+        return OrderedJsonObject().apply {
+            set<ObjectNode>("on_stage_sources", mapper.valueToTree(onStageSources))
+            set<ObjectNode>("selected_sources", mapper.valueToTree(selectedSources))
+            set<ObjectNode>("video_constraints", mapper.valueToTree(videoConstraints.mapValues { it.value.toString() }))
+            put("last_n", lastN)
+            put("default_constraints", defaultConstraints.toString())
+            put("assumed_bandwidth_bps", assumedBandwidthBps)
+        }
     }
 
-    override fun toString(): String = toJson().toJSONString()
+    override fun toString(): String = toJson().toString()
 
     fun getConstraints(endpointId: String) = videoConstraints.getOrDefault(endpointId, defaultConstraints)
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/AllocationSettings.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/AllocationSettings.kt
@@ -17,11 +17,11 @@
 package org.jitsi.videobridge.cc.allocation
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.nlj.util.bps
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.LoggerImpl
 import org.jitsi.utils.logging2.createChildLogger
@@ -46,7 +46,7 @@ data class AllocationSettings @JvmOverloads constructor(
 ) {
     fun toJson(): ObjectNode {
         val mapper = ObjectMapper()
-        return OrderedJsonObject().apply {
+        return JsonNodeFactory.instance.objectNode().apply {
             set<ObjectNode>("on_stage_sources", mapper.valueToTree(onStageSources))
             set<ObjectNode>("selected_sources", mapper.valueToTree(selectedSources))
             set<ObjectNode>("video_constraints", mapper.valueToTree(videoConstraints.mapValues { it.value.toString() }))

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocation.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocation.kt
@@ -15,10 +15,10 @@
  */
 package org.jitsi.videobridge.cc.allocation
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.RtpLayerDesc
-import org.jitsi.utils.OrderedJsonObject
 
 /**
  * The result of bandwidth allocation.
@@ -53,13 +53,13 @@ class BandwidthAllocation @JvmOverloads constructor(
     override fun toString(): String = "oversending=$oversending " + allocations.joinToString()
 
     val debugState: ObjectNode
-        get() = OrderedJsonObject().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             put("idealBps", idealBps)
             put("targetBps", targetBps)
             put("oversending", oversending)
             put("has_suspended_sources", hasSuspendedSources)
             put("suspended_sources", suspendedSources.toString())
-            val allocationsNode = OrderedJsonObject().apply {
+            val allocationsNode = JsonNodeFactory.instance.objectNode().apply {
                 allocations.forEach {
                     val name = it.mediaSource?.sourceName ?: it.endpointId
                     set<ObjectNode>(name, it.debugState)
@@ -103,7 +103,7 @@ data class SingleAllocation(
         "ideal=${idealLayer?.height}/${idealLayer?.frameRate} (${idealLayer?.indexString()})]"
 
     val debugState: ObjectNode
-        get() = OrderedJsonObject().apply {
+        get() = JsonNodeFactory.instance.objectNode().apply {
             targetLayer?.debugState()?.let { set<ObjectNode>("target", it) } ?: put("target", null as String?)
             idealLayer?.debugState()?.let { set<ObjectNode>("ideal", it) } ?: put("ideal", null as String?)
         }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocation.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocation.kt
@@ -15,9 +15,10 @@
  */
 package org.jitsi.videobridge.cc.allocation
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.RtpLayerDesc
-import org.json.simple.JSONObject
+import org.jitsi.utils.OrderedJsonObject
 
 /**
  * The result of bandwidth allocation.
@@ -51,20 +52,20 @@ class BandwidthAllocation @JvmOverloads constructor(
 
     override fun toString(): String = "oversending=$oversending " + allocations.joinToString()
 
-    val debugState: JSONObject
-        get() = JSONObject().apply {
+    val debugState: ObjectNode
+        get() = OrderedJsonObject().apply {
             put("idealBps", idealBps)
             put("targetBps", targetBps)
             put("oversending", oversending)
             put("has_suspended_sources", hasSuspendedSources)
-            put("suspended_sources", suspendedSources)
-            val allocations = JSONObject().apply {
+            put("suspended_sources", suspendedSources.toString())
+            val allocationsNode = OrderedJsonObject().apply {
                 allocations.forEach {
                     val name = it.mediaSource?.sourceName ?: it.endpointId
-                    put(name, it.debugState)
+                    set<ObjectNode>(name, it.debugState)
                 }
             }
-            put("allocations", allocations)
+            set<ObjectNode>("allocations", allocationsNode)
         }
 }
 
@@ -101,9 +102,9 @@ data class SingleAllocation(
         "(${targetLayer?.indexString()}) " +
         "ideal=${idealLayer?.height}/${idealLayer?.frameRate} (${idealLayer?.indexString()})]"
 
-    val debugState: JSONObject
-        get() = JSONObject().apply {
-            put("target", targetLayer?.debugState())
-            put("ideal", idealLayer?.debugState())
+    val debugState: ObjectNode
+        get() = OrderedJsonObject().apply {
+            targetLayer?.debugState()?.let { set<ObjectNode>("target", it) } ?: put("target", null as String?)
+            idealLayer?.debugState()?.let { set<ObjectNode>("ideal", it) } ?: put("ideal", null as String?)
         }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.kt
@@ -15,9 +15,11 @@
  */
 package org.jitsi.videobridge.cc.allocation
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.util.bps
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.event.EventEmitter
 import org.jitsi.utils.event.SyncEventEmitter
 import org.jitsi.utils.logging.DiagnosticContext
@@ -26,7 +28,6 @@ import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.videobridge.cc.config.BitrateControllerConfig
 import org.jitsi.videobridge.util.TaskPools
-import org.json.simple.JSONObject
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -108,14 +109,14 @@ internal class BandwidthAllocator<T : MediaSourceContainer>(
         value = ["IS2_INCONSISTENT_SYNC"],
         justification = "We intentionally avoid synchronizing while reading fields only used in debug output."
     )
-    val debugState: JSONObject
+    val debugState: ObjectNode
         get() {
-            val debugState = JSONObject()
-            debugState["trustBwe"] = trustBwe.get()
-            debugState["bweBps"] = bweBps
-            debugState["allocation"] = allocation.debugState
-            debugState["allocationSettings"] = allocationSettings.toJson()
-            debugState["effectiveConstraints"] = effectiveConstraints.mapKeys { it.key.sourceName }
+            val debugState = OrderedJsonObject()
+            debugState.put("trustBwe", trustBwe.get())
+            debugState.put("bweBps", bweBps)
+            debugState.set<ObjectNode>("allocation", allocation.debugState)
+            debugState.set<ObjectNode>("allocationSettings", allocationSettings.toJson())
+            debugState.put("effectiveConstraints", effectiveConstraints.mapKeys { it.key.sourceName }.toString())
             return debugState
         }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.kt
@@ -15,11 +15,11 @@
  */
 package org.jitsi.videobridge.cc.allocation
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.util.bps
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.event.EventEmitter
 import org.jitsi.utils.event.SyncEventEmitter
 import org.jitsi.utils.logging.DiagnosticContext
@@ -111,7 +111,7 @@ internal class BandwidthAllocator<T : MediaSourceContainer>(
     )
     val debugState: ObjectNode
         get() {
-            val debugState = OrderedJsonObject()
+            val debugState = JsonNodeFactory.instance.objectNode()
             debugState.put("trustBwe", trustBwe.get())
             debugState.put("bweBps", bweBps)
             debugState.set<ObjectNode>("allocation", allocation.debugState)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BitrateController.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BitrateController.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.cc.allocation
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.DebugStateMode
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.PacketInfo
@@ -23,6 +24,7 @@ import org.jitsi.nlj.format.PayloadTypeEncoding
 import org.jitsi.nlj.util.Bandwidth
 import org.jitsi.nlj.util.bps
 import org.jitsi.rtp.rtcp.RtcpSrPacket
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.event.SyncEventEmitter
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
@@ -31,7 +33,6 @@ import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.videobridge.cc.config.BitrateControllerConfig.Companion.config
 import org.jitsi.videobridge.message.ReceiverVideoConstraintsMessage
 import org.jitsi.videobridge.util.BooleanStateTimeTracker
-import org.json.simple.JSONObject
 import java.time.Clock
 import java.time.Duration
 import java.util.function.Supplier
@@ -150,9 +151,9 @@ class BitrateController<T : MediaSourceContainer> @JvmOverloads constructor(
     fun transformRtcp(rtcpSrPacket: RtcpSrPacket): Boolean = packetHandler.transformRtcp(rtcpSrPacket)
     fun transformRtp(packetInfo: PacketInfo): Boolean = packetHandler.transformRtp(packetInfo)
 
-    fun debugState(mode: DebugStateMode): JSONObject = JSONObject().apply {
-        put("bitrate_allocator", bandwidthAllocator.debugState)
-        put("packet_handler", packetHandler.debugState(mode))
+    fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+        set<ObjectNode>("bitrate_allocator", bandwidthAllocator.debugState)
+        set<ObjectNode>("packet_handler", packetHandler.debugState(mode))
         put("forwarded_sources", forwardedSources.toString())
         put("oversending", oversendingTimeTracker.state)
         put("total_oversending_time_secs", oversendingTimeTracker.totalTimeOn().seconds)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BitrateController.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BitrateController.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.cc.allocation
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.DebugStateMode
 import org.jitsi.nlj.MediaSourceDesc
@@ -24,7 +25,6 @@ import org.jitsi.nlj.format.PayloadTypeEncoding
 import org.jitsi.nlj.util.Bandwidth
 import org.jitsi.nlj.util.bps
 import org.jitsi.rtp.rtcp.RtcpSrPacket
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.event.SyncEventEmitter
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
@@ -151,7 +151,7 @@ class BitrateController<T : MediaSourceContainer> @JvmOverloads constructor(
     fun transformRtcp(rtcpSrPacket: RtcpSrPacket): Boolean = packetHandler.transformRtcp(rtcpSrPacket)
     fun transformRtp(packetInfo: PacketInfo): Boolean = packetHandler.transformRtp(packetInfo)
 
-    fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+    fun debugState(mode: DebugStateMode): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         set<ObjectNode>("bitrate_allocator", bandwidthAllocator.debugState)
         set<ObjectNode>("packet_handler", packetHandler.debugState(mode))
         put("forwarded_sources", forwardedSources.toString())

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/PacketHandler.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/PacketHandler.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.cc.allocation
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.DebugStateMode
 import org.jitsi.nlj.MediaSourceDesc
@@ -23,7 +24,6 @@ import org.jitsi.nlj.PacketInfo.Companion.enablePayloadVerification
 import org.jitsi.nlj.RtpLayerDesc
 import org.jitsi.nlj.rtp.VideoRtpPacket
 import org.jitsi.rtp.rtcp.RtcpSrPacket
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.event.EventEmitter
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
@@ -172,16 +172,17 @@ internal class PacketHandler(
 
     fun timeSinceFirstMedia(): Duration = firstMedia?.let { Duration.between(it, clock.instant()) } ?: Duration.ZERO
 
-    fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+    fun debugState(mode: DebugStateMode): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("num_dropped_packets_unknown_ssrc", numDroppedPacketsUnknownSsrc.toInt())
         set<ObjectNode>("adaptive_source_projection_map", adaptiveSourceProjectionMap.debugState(mode))
     }
 
-    private fun Map<Long, AdaptiveSourceProjection>.debugState(mode: DebugStateMode) = OrderedJsonObject().also {
-        forEach { (ssrc, adaptiveSourceProjection) ->
-            it.set<ObjectNode>(ssrc.toString(), adaptiveSourceProjection.getDebugState(mode))
+    private fun Map<Long, AdaptiveSourceProjection>.debugState(mode: DebugStateMode) =
+        JsonNodeFactory.instance.objectNode().also {
+            forEach { (ssrc, adaptiveSourceProjection) ->
+                it.set<ObjectNode>(ssrc.toString(), adaptiveSourceProjection.getDebugState(mode))
+            }
         }
-    }
 
     /**
      * Signals to this instance that the allocation chosen by the `BitrateAllocator` has changed.

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/PacketHandler.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/PacketHandler.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.cc.allocation
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.DebugStateMode
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.PacketInfo
@@ -22,13 +23,13 @@ import org.jitsi.nlj.PacketInfo.Companion.enablePayloadVerification
 import org.jitsi.nlj.RtpLayerDesc
 import org.jitsi.nlj.rtp.VideoRtpPacket
 import org.jitsi.rtp.rtcp.RtcpSrPacket
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.event.EventEmitter
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.videobridge.cc.AdaptiveSourceProjection
 import org.jitsi.videobridge.cc.RewriteException
-import org.json.simple.JSONObject
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -171,14 +172,14 @@ internal class PacketHandler(
 
     fun timeSinceFirstMedia(): Duration = firstMedia?.let { Duration.between(it, clock.instant()) } ?: Duration.ZERO
 
-    fun debugState(mode: DebugStateMode): JSONObject = JSONObject().apply {
-        this["num_dropped_packets_unknown_ssrc"] = numDroppedPacketsUnknownSsrc.toInt()
-        this["adaptive_source_projection_map"] = adaptiveSourceProjectionMap.debugState(mode)
+    fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+        put("num_dropped_packets_unknown_ssrc", numDroppedPacketsUnknownSsrc.toInt())
+        set<ObjectNode>("adaptive_source_projection_map", adaptiveSourceProjectionMap.debugState(mode))
     }
 
-    private fun Map<Long, AdaptiveSourceProjection>.debugState(mode: DebugStateMode) = JSONObject().also {
+    private fun Map<Long, AdaptiveSourceProjection>.debugState(mode: DebugStateMode) = OrderedJsonObject().also {
         forEach { (ssrc, adaptiveSourceProjection) ->
-            it[ssrc] = adaptiveSourceProjection.getDebugState(mode)
+            it.set<ObjectNode>(ssrc.toString(), adaptiveSourceProjection.getDebugState(mode))
         }
     }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
@@ -17,8 +17,8 @@
 package org.jitsi.videobridge.cc.allocation
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import org.jitsi.utils.OrderedJsonObject
 
 /**
  * A Map of Endpoint IDs to their receiver video constraints.  Tracks the max height of all
@@ -72,7 +72,7 @@ class ReceiverConstraintsMap {
         return maxSeen
     }
 
-    fun getDebugState(): ObjectNode = OrderedJsonObject().apply {
+    fun getDebugState(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("maxHeight", maxHeight)
         set<ObjectNode>("constraints", ObjectMapper().valueToTree(map.mapValues { it.value.toString() }.toMap()))
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
@@ -16,6 +16,8 @@
 
 package org.jitsi.videobridge.cc.allocation
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.utils.OrderedJsonObject
 
 /**
@@ -70,10 +72,10 @@ class ReceiverConstraintsMap {
         return maxSeen
     }
 
-    fun getDebugState() = OrderedJsonObject().apply {
+    fun getDebugState(): ObjectNode = OrderedJsonObject().apply {
         put("maxHeight", maxHeight)
-        put("constraints", map.toMap())
+        set<ObjectNode>("constraints", ObjectMapper().valueToTree(map.mapValues { it.value.toString() }.toMap()))
     }
 
-    override fun toString() = getDebugState().toJSONString()
+    override fun toString() = getDebugState().toString()
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/VideoConstraints.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/VideoConstraints.kt
@@ -16,7 +16,7 @@
 package org.jitsi.videobridge.cc.allocation
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import org.json.simple.JSONObject
+import org.jitsi.utils.OrderedJsonObject
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class VideoConstraints @JvmOverloads constructor(
@@ -29,10 +29,10 @@ data class VideoConstraints @JvmOverloads constructor(
             "maxFrameRate must be either -1, or >= 0"
         }
     }
-    override fun toString(): String = JSONObject().apply {
-        this["maxHeight"] = maxHeight
-        this["maxFrameRate"] = maxFrameRate
-    }.toJSONString()
+    override fun toString(): String = OrderedJsonObject().apply {
+        put("maxHeight", maxHeight)
+        put("maxFrameRate", maxFrameRate)
+    }.toString()
 
     fun heightIsLimited() = maxHeight != UNLIMITED_HEIGHT
     fun frameRateIsLimited() = maxFrameRate != UNLIMITED_FRAME_RATE

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/VideoConstraints.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/VideoConstraints.kt
@@ -16,7 +16,7 @@
 package org.jitsi.videobridge.cc.allocation
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import org.jitsi.utils.OrderedJsonObject
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class VideoConstraints @JvmOverloads constructor(
@@ -29,7 +29,7 @@ data class VideoConstraints @JvmOverloads constructor(
             "maxFrameRate must be either -1, or >= 0"
         }
     }
-    override fun toString(): String = OrderedJsonObject().apply {
+    override fun toString(): String = JsonNodeFactory.instance.objectNode().apply {
         put("maxHeight", maxHeight)
         put("maxFrameRate", maxFrameRate)
     }.toString()

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionContext.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionContext.kt
@@ -15,6 +15,9 @@
  */
 package org.jitsi.videobridge.cc.av1
 
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.RtpLayerDesc.Companion.getEidFromIndex
 import org.jitsi.nlj.rtp.codec.av1.Av1DDPacket
@@ -26,6 +29,7 @@ import org.jitsi.rtp.rtp.header_extensions.DTI
 import org.jitsi.rtp.rtp.header_extensions.toShortString
 import org.jitsi.rtp.util.RtpUtils
 import org.jitsi.rtp.util.isNewerThan
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
 import org.jitsi.utils.logging2.Logger
@@ -33,8 +37,6 @@ import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.videobridge.cc.AdaptiveSourceProjectionContext
 import org.jitsi.videobridge.cc.RewriteException
 import org.jitsi.videobridge.cc.RtpState
-import org.json.simple.JSONArray
-import org.json.simple.JSONObject
 import java.time.Duration
 import java.time.Instant
 
@@ -661,19 +663,19 @@ class Av1DDAdaptiveSourceProjectionContext(
         lastAv1FrameProjection.getNextTemplateId() ?: 0
     )
 
-    override fun getDebugState(): JSONObject {
-        val debugState = JSONObject()
-        debugState["class"] = Av1DDAdaptiveSourceProjectionContext::class.java.simpleName
+    override fun getDebugState(): ObjectNode {
+        val debugState = OrderedJsonObject()
+        debugState.put("class", Av1DDAdaptiveSourceProjectionContext::class.java.simpleName)
 
-        val mapSizes = JSONArray()
+        val mapSizes: ArrayNode = jacksonObjectMapper().createArrayNode()
         for ((key, value) in av1FrameMaps.entries) {
-            val sizeInfo = JSONObject()
-            sizeInfo["ssrc"] = key
-            sizeInfo["size"] = value.size()
+            val sizeInfo = OrderedJsonObject()
+            sizeInfo.put("ssrc", key)
+            sizeInfo.put("size", value.size())
             mapSizes.add(sizeInfo)
         }
-        debugState["av1FrameMaps"] = mapSizes
-        debugState["av1QualityFilter"] = av1QualityFilter.debugState
+        debugState.set<ObjectNode>("av1FrameMaps", mapSizes)
+        debugState.set<ObjectNode>("av1QualityFilter", av1QualityFilter.debugState)
 
         return debugState
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionContext.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionContext.kt
@@ -29,7 +29,6 @@ import org.jitsi.rtp.rtp.header_extensions.DTI
 import org.jitsi.rtp.rtp.header_extensions.toShortString
 import org.jitsi.rtp.util.RtpUtils
 import org.jitsi.rtp.util.isNewerThan
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
 import org.jitsi.utils.logging2.Logger
@@ -664,12 +663,12 @@ class Av1DDAdaptiveSourceProjectionContext(
     )
 
     override fun getDebugState(): ObjectNode {
-        val debugState = OrderedJsonObject()
+        val debugState = JsonNodeFactory.instance.objectNode()
         debugState.put("class", Av1DDAdaptiveSourceProjectionContext::class.java.simpleName)
 
         val mapSizes: ArrayNode = JsonNodeFactory.instance.arrayNode()
         for ((key, value) in av1FrameMaps.entries) {
-            val sizeInfo = OrderedJsonObject()
+            val sizeInfo = JsonNodeFactory.instance.objectNode()
             sizeInfo.put("ssrc", key)
             sizeInfo.put("size", value.size())
             mapSizes.add(sizeInfo)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionContext.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionContext.kt
@@ -16,8 +16,8 @@
 package org.jitsi.videobridge.cc.av1
 
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.RtpLayerDesc.Companion.getEidFromIndex
 import org.jitsi.nlj.rtp.codec.av1.Av1DDPacket
@@ -667,7 +667,7 @@ class Av1DDAdaptiveSourceProjectionContext(
         val debugState = OrderedJsonObject()
         debugState.put("class", Av1DDAdaptiveSourceProjectionContext::class.java.simpleName)
 
-        val mapSizes: ArrayNode = jacksonObjectMapper().createArrayNode()
+        val mapSizes: ArrayNode = JsonNodeFactory.instance.arrayNode()
         for ((key, value) in av1FrameMaps.entries) {
             val sizeInfo = OrderedJsonObject()
             sizeInfo.put("ssrc", key)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDQualityFilter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDQualityFilter.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.cc.av1
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.nlj.RtpLayerDesc.Companion.SUSPENDED_ENCODING_ID
@@ -26,7 +27,6 @@ import org.jitsi.nlj.rtp.codec.av1.Av1DDRtpLayerDesc.Companion.getDtFromIndex
 import org.jitsi.nlj.rtp.codec.av1.Av1DDRtpLayerDesc.Companion.getIndex
 import org.jitsi.nlj.rtp.codec.av1.containsDecodeTarget
 import org.jitsi.rtp.rtp.header_extensions.DTI
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
@@ -435,7 +435,7 @@ internal class Av1DDQualityFilter(
     )
     val debugState: ObjectNode
         get() {
-            val debugState = OrderedJsonObject()
+            val debugState = JsonNodeFactory.instance.objectNode()
             debugState.put(
                 "mostRecentKeyframeGroupArrivalTimeMs",
                 mostRecentKeyframeGroupArrivalTime?.toEpochMilli() ?: -1

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDQualityFilter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDQualityFilter.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.cc.av1
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.nlj.RtpLayerDesc.Companion.SUSPENDED_ENCODING_ID
 import org.jitsi.nlj.RtpLayerDesc.Companion.SUSPENDED_INDEX
@@ -25,10 +26,10 @@ import org.jitsi.nlj.rtp.codec.av1.Av1DDRtpLayerDesc.Companion.getDtFromIndex
 import org.jitsi.nlj.rtp.codec.av1.Av1DDRtpLayerDesc.Companion.getIndex
 import org.jitsi.nlj.rtp.codec.av1.containsDecodeTarget
 import org.jitsi.rtp.rtp.header_extensions.DTI
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
-import org.json.simple.JSONObject
 import java.time.Duration
 import java.time.Instant
 
@@ -432,15 +433,17 @@ internal class Av1DDQualityFilter(
         value = ["IS2_INCONSISTENT_SYNC"],
         justification = "We intentionally avoid synchronizing while reading fields only used in debug output."
     )
-    val debugState: JSONObject
+    val debugState: ObjectNode
         get() {
-            val debugState = JSONObject()
-            debugState["mostRecentKeyframeGroupArrivalTimeMs"] =
+            val debugState = OrderedJsonObject()
+            debugState.put(
+                "mostRecentKeyframeGroupArrivalTimeMs",
                 mostRecentKeyframeGroupArrivalTime?.toEpochMilli() ?: -1
-            debugState["needsKeyframe"] = needsKeyframe
-            debugState["internalTargetEncoding"] = internalTargetEncoding
-            debugState["internalTargetDt"] = internalTargetDt
-            debugState["currentIndex"] = Av1DDRtpLayerDesc.indexString(currentIndex)
+            )
+            debugState.put("needsKeyframe", needsKeyframe)
+            debugState.put("internalTargetEncoding", internalTargetEncoding)
+            debugState.put("internalTargetDt", internalTargetDt)
+            debugState.put("currentIndex", Av1DDRtpLayerDesc.indexString(currentIndex))
             return debugState
         }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionContext.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionContext.kt
@@ -16,8 +16,8 @@
 package org.jitsi.videobridge.cc.vp9
 
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.RtpLayerDesc.Companion.indexString
 import org.jitsi.nlj.codec.vpx.VpxUtils.Companion.applyExtendedPictureIdDelta
@@ -614,7 +614,7 @@ class Vp9AdaptiveSourceProjectionContext(
         val debugState = OrderedJsonObject()
         debugState.put("class", Vp9AdaptiveSourceProjectionContext::class.java.simpleName)
 
-        val mapSizes: ArrayNode = jacksonObjectMapper().createArrayNode()
+        val mapSizes: ArrayNode = JsonNodeFactory.instance.arrayNode()
         for ((key, value) in vp9PictureMaps.entries) {
             val sizeInfo = OrderedJsonObject()
             sizeInfo.put("ssrc", key)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionContext.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionContext.kt
@@ -15,6 +15,9 @@
  */
 package org.jitsi.videobridge.cc.vp9
 
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.RtpLayerDesc.Companion.indexString
 import org.jitsi.nlj.codec.vpx.VpxUtils.Companion.applyExtendedPictureIdDelta
@@ -28,6 +31,7 @@ import org.jitsi.rtp.util.RtpUtils.Companion.applyTimestampDelta
 import org.jitsi.rtp.util.RtpUtils.Companion.getSequenceNumberDelta
 import org.jitsi.rtp.util.RtpUtils.Companion.getTimestampDiff
 import org.jitsi.rtp.util.isNewerThan
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
 import org.jitsi.utils.logging2.Logger
@@ -35,8 +39,6 @@ import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.videobridge.cc.AdaptiveSourceProjectionContext
 import org.jitsi.videobridge.cc.RewriteException
 import org.jitsi.videobridge.cc.RtpState
-import org.json.simple.JSONArray
-import org.json.simple.JSONObject
 import java.time.Duration
 import java.time.Instant
 
@@ -608,19 +610,19 @@ class Vp9AdaptiveSourceProjectionContext(
     )
 
     @Synchronized
-    override fun getDebugState(): JSONObject {
-        val debugState = JSONObject()
-        debugState["class"] = Vp9AdaptiveSourceProjectionContext::class.java.simpleName
+    override fun getDebugState(): ObjectNode {
+        val debugState = OrderedJsonObject()
+        debugState.put("class", Vp9AdaptiveSourceProjectionContext::class.java.simpleName)
 
-        val mapSizes = JSONArray()
+        val mapSizes: ArrayNode = jacksonObjectMapper().createArrayNode()
         for ((key, value) in vp9PictureMaps.entries) {
-            val sizeInfo = JSONObject()
-            sizeInfo["ssrc"] = key
-            sizeInfo["size"] = value.size()
+            val sizeInfo = OrderedJsonObject()
+            sizeInfo.put("ssrc", key)
+            sizeInfo.put("size", value.size())
             mapSizes.add(sizeInfo)
         }
-        debugState["vp9FrameMaps"] = mapSizes
-        debugState["vp9QualityFilter"] = vp9QualityFilter.debugState
+        debugState.set<ObjectNode>("vp9FrameMaps", mapSizes)
+        debugState.set<ObjectNode>("vp9QualityFilter", vp9QualityFilter.debugState)
 
         return debugState
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionContext.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionContext.kt
@@ -31,7 +31,6 @@ import org.jitsi.rtp.util.RtpUtils.Companion.applyTimestampDelta
 import org.jitsi.rtp.util.RtpUtils.Companion.getSequenceNumberDelta
 import org.jitsi.rtp.util.RtpUtils.Companion.getTimestampDiff
 import org.jitsi.rtp.util.isNewerThan
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging.TimeSeriesLogger
 import org.jitsi.utils.logging2.Logger
@@ -611,12 +610,12 @@ class Vp9AdaptiveSourceProjectionContext(
 
     @Synchronized
     override fun getDebugState(): ObjectNode {
-        val debugState = OrderedJsonObject()
+        val debugState = JsonNodeFactory.instance.objectNode()
         debugState.put("class", Vp9AdaptiveSourceProjectionContext::class.java.simpleName)
 
         val mapSizes: ArrayNode = JsonNodeFactory.instance.arrayNode()
         for ((key, value) in vp9PictureMaps.entries) {
-            val sizeInfo = OrderedJsonObject()
+            val sizeInfo = JsonNodeFactory.instance.objectNode()
             sizeInfo.put("ssrc", key)
             sizeInfo.put("size", value.size())
             mapSizes.add(sizeInfo)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilter.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.cc.vp9
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.nlj.RtpLayerDesc
@@ -24,7 +25,6 @@ import org.jitsi.nlj.RtpLayerDesc.Companion.getEidFromIndex
 import org.jitsi.nlj.RtpLayerDesc.Companion.getSidFromIndex
 import org.jitsi.nlj.RtpLayerDesc.Companion.getTidFromIndex
 import org.jitsi.nlj.RtpLayerDesc.Companion.indexString
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
@@ -450,7 +450,7 @@ internal class Vp9QualityFilter(parentLogger: Logger) {
     )
     val debugState: ObjectNode
         get() {
-            val debugState = OrderedJsonObject()
+            val debugState = JsonNodeFactory.instance.objectNode()
             debugState.put(
                 "mostRecentKeyframeGroupArrivalTimeMs",
                 mostRecentKeyframeGroupArrivalTime?.toEpochMilli() ?: -1

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilter.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.cc.vp9
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.nlj.RtpLayerDesc
 import org.jitsi.nlj.RtpLayerDesc.Companion.SUSPENDED_ENCODING_ID
@@ -23,10 +24,10 @@ import org.jitsi.nlj.RtpLayerDesc.Companion.getEidFromIndex
 import org.jitsi.nlj.RtpLayerDesc.Companion.getSidFromIndex
 import org.jitsi.nlj.RtpLayerDesc.Companion.getTidFromIndex
 import org.jitsi.nlj.RtpLayerDesc.Companion.indexString
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
-import org.json.simple.JSONObject
 import java.time.Duration
 import java.time.Instant
 
@@ -447,16 +448,18 @@ internal class Vp9QualityFilter(parentLogger: Logger) {
         value = ["IS2_INCONSISTENT_SYNC"],
         justification = "We intentionally avoid synchronizing while reading fields only used in debug output."
     )
-    val debugState: JSONObject
+    val debugState: ObjectNode
         get() {
-            val debugState = JSONObject()
-            debugState["mostRecentKeyframeGroupArrivalTimeMs"] =
+            val debugState = OrderedJsonObject()
+            debugState.put(
+                "mostRecentKeyframeGroupArrivalTimeMs",
                 mostRecentKeyframeGroupArrivalTime?.toEpochMilli() ?: -1
-            debugState["needsKeyframe"] = needsKeyframe
-            debugState["internalTargetEncoding"] = internalTargetEncoding
-            debugState["internalTargetSpatialId"] = internalTargetSpatialId
-            debugState["currentIndex"] = indexString(currentIndex)
-            debugState["layersForwarded"] = layers.map { toString().first() }.joinToString(separator = "")
+            )
+            debugState.put("needsKeyframe", needsKeyframe)
+            debugState.put("internalTargetEncoding", internalTargetEncoding)
+            debugState.put("internalTargetSpatialId", internalTargetSpatialId)
+            debugState.put("currentIndex", indexString(currentIndex))
+            debugState.put("layersForwarded", layers.map { toString().first() }.joinToString(separator = ""))
             return debugState
         }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/dcsctp/DcSctpTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/dcsctp/DcSctpTransport.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.dcsctp
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.dcsctp4j.DcSctpMessage
 import org.jitsi.dcsctp4j.DcSctpOptions
 import org.jitsi.dcsctp4j.DcSctpSocketCallbacks
@@ -83,7 +84,7 @@ class DcSctpTransport(
         }
     }
 
-    fun getDebugState(): OrderedJsonObject {
+    fun getDebugState(): ObjectNode {
         val metrics = synchronized(lock) {
             socket?.metrics
         }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/dcsctp/DcSctpTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/dcsctp/DcSctpTransport.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.dcsctp
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.dcsctp4j.DcSctpMessage
 import org.jitsi.dcsctp4j.DcSctpOptions
@@ -25,7 +26,6 @@ import org.jitsi.dcsctp4j.SendOptions
 import org.jitsi.dcsctp4j.SendStatus
 import org.jitsi.dcsctp4j.Timeout
 import org.jitsi.nlj.PacketInfo
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.videobridge.sctp.SctpConfig
@@ -88,7 +88,7 @@ class DcSctpTransport(
         val metrics = synchronized(lock) {
             socket?.metrics
         }
-        return OrderedJsonObject().apply {
+        return JsonNodeFactory.instance.objectNode().apply {
             if (metrics != null) {
                 put("tx_packets_count", metrics.txPacketsCount)
                 put("tx_messages_count", metrics.txMessagesCount)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.export
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.eclipse.jetty.websocket.api.Callback
 import org.eclipse.jetty.websocket.api.Session
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest
@@ -29,12 +30,12 @@ import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.optionalconfig
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.util.PacketInfoQueue
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.videobridge.metrics.VideobridgeMetricsContainer
 import org.jitsi.videobridge.util.ByteBufferPool
 import org.jitsi.videobridge.util.TaskPools
 import org.jitsi.videobridge.websocket.config.WebsocketServiceConfig
-import org.json.simple.JSONObject
 import java.net.URI
 import java.time.Duration
 import java.util.concurrent.ScheduledFuture
@@ -324,7 +325,7 @@ internal class Exporter(
         queue.close()
     }
 
-    fun debugState(): JSONObject = JSONObject().apply {
+    fun debugState(): ObjectNode = OrderedJsonObject().apply {
         put("url", url.toString())
         put("is_connected", isConnected())
         put("is_shutting_down", isShuttingDown.get())

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.export
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.eclipse.jetty.websocket.api.Callback
 import org.eclipse.jetty.websocket.api.Session
@@ -30,7 +31,6 @@ import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.optionalconfig
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.util.PacketInfoQueue
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.videobridge.metrics.VideobridgeMetricsContainer
 import org.jitsi.videobridge.util.ByteBufferPool
@@ -325,7 +325,7 @@ internal class Exporter(
         queue.close()
     }
 
-    fun debugState(): ObjectNode = OrderedJsonObject().apply {
+    fun debugState(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("url", url.toString())
         put("is_connected", isConnected())
         put("is_shutting_down", isShuttingDown.get())

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/ExporterWrapper.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/ExporterWrapper.kt
@@ -15,11 +15,11 @@
  */
 package org.jitsi.videobridge.export
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.mediajson.TranscriptionResultEvent
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.rtp.AudioRtpPacket
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.videobridge.PotentialPacketHandler
@@ -104,7 +104,7 @@ class ExporterWrapper(
         started = true
     }
 
-    fun debugState(): ObjectNode = OrderedJsonObject().apply {
+    fun debugState(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("started", started)
         exporter?.let {
             set<ObjectNode>("exporter", it.debugState())

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/ExporterWrapper.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/ExporterWrapper.kt
@@ -15,16 +15,17 @@
  */
 package org.jitsi.videobridge.export
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.mediajson.TranscriptionResultEvent
 import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.rtp.AudioRtpPacket
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.videobridge.PotentialPacketHandler
 import org.jitsi.videobridge.colibri2.FeatureNotImplementedException
 import org.jitsi.videobridge.util.ByteBufferPool
 import org.jitsi.xmpp.extensions.colibri2.Connect
-import org.json.simple.JSONObject
 
 class ExporterWrapper(
     parentLogger: Logger,
@@ -103,10 +104,10 @@ class ExporterWrapper(
         started = true
     }
 
-    fun debugState() = JSONObject().apply {
+    fun debugState(): ObjectNode = OrderedJsonObject().apply {
         put("started", started)
         exporter?.let {
-            put("exporter", it.debugState())
+            set<ObjectNode>("exporter", it.debugState())
         }
     }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/JvbLoadManager.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/JvbLoadManager.kt
@@ -16,12 +16,12 @@
 
 package org.jitsi.videobridge.load_management
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
 import org.jitsi.utils.NEVER
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.cdebug
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.videobridge.Videobridge
@@ -107,7 +107,7 @@ open class JvbLoadManager<T : JvbLoadMeasurement> @JvmOverloads constructor(
 
     fun getCurrentStressLevel(): Double = mostRecentLoadMeasurement?.div(jvbLoadThreshold) ?: 0.0
 
-    fun getStats() = OrderedJsonObject().apply {
+    fun getStats() = JsonNodeFactory.instance.objectNode().apply {
         put("state", state.toString())
         put("stress", getCurrentStressLevel().toString())
         put("reducer_enabled", reducerEnabled.toString())

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/JvbLoadManager.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/JvbLoadManager.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.videobridge.load_management
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
@@ -111,7 +112,7 @@ open class JvbLoadManager<T : JvbLoadMeasurement> @JvmOverloads constructor(
         put("stress", getCurrentStressLevel().toString())
         put("reducer_enabled", reducerEnabled.toString())
         loadReducer?.let {
-            put("reducer", it.getStats())
+            set<ObjectNode>("reducer", it.getStats())
         }
     }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/JvbLoadReducer.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/JvbLoadReducer.kt
@@ -16,7 +16,7 @@
 
 package org.jitsi.videobridge.load_management
 
-import org.jitsi.utils.OrderedJsonObject
+import com.fasterxml.jackson.databind.node.ObjectNode
 import java.time.Duration
 
 interface JvbLoadReducer {
@@ -35,7 +35,7 @@ interface JvbLoadReducer {
      */
     fun impactTime(): Duration
 
-    fun getStats(): OrderedJsonObject
+    fun getStats(): ObjectNode
 
     companion object {
         const val CONFIG_BASE = "videobridge.load-management.load-reducers"

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/LastNReducer.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/LastNReducer.kt
@@ -16,10 +16,10 @@
 
 package org.jitsi.videobridge.load_management
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.metaconfig.from
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.cdebug
 import org.jitsi.utils.logging2.cinfo
 import org.jitsi.utils.logging2.createLogger
@@ -117,7 +117,7 @@ class LastNReducer(
 
     override fun impactTime(): Duration = impactTime
 
-    override fun getStats() = OrderedJsonObject().apply {
+    override fun getStats() = JsonNodeFactory.instance.objectNode().apply {
         put("jvbLastN", jvbLastN.jvbLastN)
     }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.relay
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.ice4j.util.Buffer
 import org.jitsi.dcsctp4j.DcSctpMessage
@@ -66,7 +67,6 @@ import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.RtcpFbPliPacket
 import org.jitsi.rtp.rtp.RtpHeader
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.utils.MediaType
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.cdebug
 import org.jitsi.utils.logging2.createChildLogger
@@ -332,7 +332,7 @@ class Relay @JvmOverloads constructor(
         TransportConfig.queueSize
     )
 
-    fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+    fun debugState(mode: DebugStateMode): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         set<ObjectNode>("ice_transport", iceTransport.getDebugState())
         set<ObjectNode>("dtls_transport", dtlsTransport.getDebugState())
         set<ObjectNode>("transceiver", transceiver.debugState(mode))
@@ -343,8 +343,8 @@ class Relay @JvmOverloads constructor(
         }
 
         if (mode == DebugStateMode.FULL) {
-            val remoteEndpoints = OrderedJsonObject()
-            val endpointsBySsrcMap = OrderedJsonObject()
+            val remoteEndpoints = JsonNodeFactory.instance.objectNode()
+            val endpointsBySsrcMap = JsonNodeFactory.instance.objectNode()
             synchronized(endpointsLock) {
                 for (r in relayedEndpoints.values) {
                     remoteEndpoints.set<ObjectNode>(r.id, r.debugState(mode))
@@ -355,7 +355,7 @@ class Relay @JvmOverloads constructor(
             }
             set<ObjectNode>("remote_endpoints", remoteEndpoints)
             set<ObjectNode>("endpoints_by_ssrc", endpointsBySsrcMap)
-            val endpointSenders = OrderedJsonObject()
+            val endpointSenders = JsonNodeFactory.instance.objectNode()
             for (s in senders.values) {
                 endpointSenders.set<ObjectNode>(s.id, s.getDebugState(mode))
             }
@@ -1105,7 +1105,7 @@ class Relay @JvmOverloads constructor(
         val packetsSent = AtomicLong(0)
 
         private fun getJson(): ObjectNode {
-            val jsonObject = OrderedJsonObject()
+            val jsonObject = JsonNodeFactory.instance.objectNode()
             jsonObject.put("bytes_received", bytesReceived.get())
             jsonObject.put("bytes_sent", bytesSent.get())
             jsonObject.put("packets_received", packetsReceived.get())

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.relay
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.ice4j.util.Buffer
 import org.jitsi.dcsctp4j.DcSctpMessage
 import org.jitsi.dcsctp4j.ErrorKind
@@ -65,6 +66,7 @@ import org.jitsi.rtp.rtcp.rtcpfb.payload_specific_fb.RtcpFbPliPacket
 import org.jitsi.rtp.rtp.RtpHeader
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.utils.MediaType
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.cdebug
 import org.jitsi.utils.logging2.createChildLogger
@@ -99,7 +101,6 @@ import org.jitsi.xmpp.extensions.colibri.WebSocketPacketExtension
 import org.jitsi.xmpp.extensions.colibri2.Sctp
 import org.jitsi.xmpp.extensions.jingle.DtlsFingerprintPacketExtension
 import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension
-import org.json.simple.JSONObject
 import java.nio.ByteBuffer
 import java.time.Clock
 import java.time.Instant
@@ -331,34 +332,34 @@ class Relay @JvmOverloads constructor(
         TransportConfig.queueSize
     )
 
-    fun debugState(mode: DebugStateMode): JSONObject = JSONObject().apply {
-        put("ice_transport", iceTransport.getDebugState())
-        put("dtls_transport", dtlsTransport.getDebugState())
-        put("transceiver", transceiver.debugState(mode))
+    fun debugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+        set<ObjectNode>("ice_transport", iceTransport.getDebugState())
+        set<ObjectNode>("dtls_transport", dtlsTransport.getDebugState())
+        set<ObjectNode>("transceiver", transceiver.debugState(mode))
         put("mesh_id", meshId)
-        put("message_transport", messageTransport.debugState)
+        set<ObjectNode>("message_transport", messageTransport.debugState)
         sctpTransport?.let {
-            put("sctp", it.getDebugState())
+            set<ObjectNode>("sctp", it.getDebugState())
         }
 
         if (mode == DebugStateMode.FULL) {
-            val remoteEndpoints = JSONObject()
-            val endpointsBySsrcMap = JSONObject()
+            val remoteEndpoints = OrderedJsonObject()
+            val endpointsBySsrcMap = OrderedJsonObject()
             synchronized(endpointsLock) {
                 for (r in relayedEndpoints.values) {
-                    remoteEndpoints[r.id] = r.debugState(mode)
+                    remoteEndpoints.set<ObjectNode>(r.id, r.debugState(mode))
                 }
                 for ((s, e) in endpointsBySsrc) {
-                    endpointsBySsrcMap[s] = e.id
+                    endpointsBySsrcMap.put(s.toString(), e.id)
                 }
             }
-            put("remote_endpoints", remoteEndpoints)
-            put("endpoints_by_ssrc", endpointsBySsrcMap)
-            val endpointSenders = JSONObject()
+            set<ObjectNode>("remote_endpoints", remoteEndpoints)
+            set<ObjectNode>("endpoints_by_ssrc", endpointsBySsrcMap)
+            val endpointSenders = OrderedJsonObject()
             for (s in senders.values) {
-                endpointSenders[s.id] = s.getDebugState(mode)
+                endpointSenders.set<ObjectNode>(s.id, s.getDebugState(mode))
             }
-            put("senders", endpointSenders)
+            set<ObjectNode>("senders", endpointSenders)
         }
     }
 
@@ -1047,9 +1048,9 @@ class Relay @JvmOverloads constructor(
             updateStatsOnExpire()
             transceiver.stop()
             srtpTransformers?.close()
-            logger.cdebug { transceiver.debugState(DebugStateMode.FULL).toJSONString() }
-            logger.cdebug { iceTransport.getDebugState().toJSONString() }
-            logger.cdebug { dtlsTransport.getDebugState().toJSONString() }
+            logger.cdebug { transceiver.debugState(DebugStateMode.FULL).toString() }
+            logger.cdebug { iceTransport.getDebugState().toString() }
+            logger.cdebug { dtlsTransport.getDebugState().toString() }
 
             transceiver.teardown()
             messageTransport.close()
@@ -1103,12 +1104,12 @@ class Relay @JvmOverloads constructor(
         val bytesSent = AtomicLong(0)
         val packetsSent = AtomicLong(0)
 
-        private fun getJson(): JSONObject {
-            val jsonObject = JSONObject()
-            jsonObject["bytes_received"] = bytesReceived.get()
-            jsonObject["bytes_sent"] = bytesSent.get()
-            jsonObject["packets_received"] = packetsReceived.get()
-            jsonObject["packets_sent"] = packetsSent.get()
+        private fun getJson(): ObjectNode {
+            val jsonObject = OrderedJsonObject()
+            jsonObject.put("bytes_received", bytesReceived.get())
+            jsonObject.put("bytes_sent", bytesSent.get())
+            jsonObject.put("packets_received", packetsReceived.get())
+            jsonObject.put("packets_sent", packetsSent.get())
             return jsonObject
         }
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayEndpointSender.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayEndpointSender.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.videobridge.relay
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.DebugStateMode
 import org.jitsi.nlj.Features
 import org.jitsi.nlj.PacketHandler
@@ -31,6 +32,7 @@ import org.jitsi.nlj.util.PacketInfoQueue
 import org.jitsi.nlj.util.StreamInformationStore
 import org.jitsi.nlj.util.StreamInformationStoreImpl
 import org.jitsi.rtp.rtcp.RtcpPacket
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.cdebug
@@ -41,7 +43,6 @@ import org.jitsi.videobridge.metrics.QueueMetrics
 import org.jitsi.videobridge.metrics.VideobridgeMetricsContainer
 import org.jitsi.videobridge.transport.ice.IceTransport
 import org.jitsi.videobridge.util.TaskPools
-import org.json.simple.JSONObject
 import java.time.Instant
 
 /**
@@ -120,11 +121,11 @@ class RelayEndpointSender(
 
     fun getOutgoingStats() = rtpSender.getPacketStreamStats()
 
-    fun getDebugState(mode: DebugStateMode) = JSONObject().apply {
-        this["expired"] = expired
-        this["id"] = id
-        this["sender"] = rtpSender.debugState(mode)
-        this["stream_information_store"] = streamInformationStore.debugState(mode)
+    fun getDebugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+        put("expired", expired)
+        put("id", id)
+        set<ObjectNode>("sender", rtpSender.debugState(mode))
+        set<ObjectNode>("stream_information_store", streamInformationStore.debugState(mode))
     }
 
     fun expire() {
@@ -136,7 +137,7 @@ class RelayEndpointSender(
         try {
             updateStatsOnExpire()
             rtpSender.stop()
-            logger.cdebug { getDebugState(DebugStateMode.FULL).toJSONString() }
+            logger.cdebug { getDebugState(DebugStateMode.FULL).toString() }
             rtpSender.tearDown()
         } catch (t: Throwable) {
             logger.error("Exception while expiring: ", t)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayEndpointSender.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayEndpointSender.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.videobridge.relay
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.DebugStateMode
 import org.jitsi.nlj.Features
@@ -32,7 +33,6 @@ import org.jitsi.nlj.util.PacketInfoQueue
 import org.jitsi.nlj.util.StreamInformationStore
 import org.jitsi.nlj.util.StreamInformationStoreImpl
 import org.jitsi.rtp.rtcp.RtcpPacket
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.cdebug
@@ -121,7 +121,7 @@ class RelayEndpointSender(
 
     fun getOutgoingStats() = rtpSender.getPacketStreamStats()
 
-    fun getDebugState(mode: DebugStateMode): ObjectNode = OrderedJsonObject().apply {
+    fun getDebugState(mode: DebugStateMode): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("expired", expired)
         put("id", id)
         set<ObjectNode>("sender", rtpSender.debugState(mode))

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
@@ -15,10 +15,12 @@
  */
 package org.jitsi.videobridge.relay
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.eclipse.jetty.websocket.api.Callback
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest
 import org.eclipse.jetty.websocket.client.WebSocketClient
 import org.eclipse.jetty.websocket.core.CloseStatus
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.videobridge.AbstractEndpointMessageTransport
 import org.jitsi.videobridge.VersionConfig
@@ -38,7 +40,6 @@ import org.jitsi.videobridge.message.VideoTypeMessage
 import org.jitsi.videobridge.metrics.VideobridgeMetrics
 import org.jitsi.videobridge.websocket.ColibriWebSocket
 import org.jitsi.videobridge.websocket.config.WebsocketServiceConfig
-import org.json.simple.JSONObject
 import java.lang.ref.WeakReference
 import java.net.URI
 import java.util.concurrent.ConcurrentHashMap
@@ -416,13 +417,13 @@ class RelayMessageTransport(
         }
     }
 
-    override val debugState: JSONObject
+    override val debugState: ObjectNode
         get() {
             val debugState = super.debugState
-            debugState["numOutgoingMessagesDropped"] = numOutgoingMessagesDropped.get()
-            val sentCounts = JSONObject()
-            sentCounts.putAll(sentMessagesCounts)
-            debugState["sent_counts"] = sentCounts
+            debugState.put("numOutgoingMessagesDropped", numOutgoingMessagesDropped.get())
+            val sentCounts = OrderedJsonObject()
+            sentMessagesCounts.forEach { (k, v) -> sentCounts.put(k, v.get()) }
+            debugState.set<ObjectNode>("sent_counts", sentCounts)
             return debugState
         }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
@@ -15,12 +15,12 @@
  */
 package org.jitsi.videobridge.relay
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.eclipse.jetty.websocket.api.Callback
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest
 import org.eclipse.jetty.websocket.client.WebSocketClient
 import org.eclipse.jetty.websocket.core.CloseStatus
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.videobridge.AbstractEndpointMessageTransport
 import org.jitsi.videobridge.VersionConfig
@@ -421,7 +421,7 @@ class RelayMessageTransport(
         get() {
             val debugState = super.debugState
             debugState.put("numOutgoingMessagesDropped", numOutgoingMessagesDropped.get())
-            val sentCounts = OrderedJsonObject()
+            val sentCounts = JsonNodeFactory.instance.objectNode()
             sentMessagesCounts.forEach { (k, v) -> sentCounts.put(k, v.get()) }
             debugState.set<ObjectNode>("sent_counts", sentCounts)
             return debugState

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayedEndpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayedEndpoint.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.relay
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.DebugStateMode
 import org.jitsi.nlj.Features
 import org.jitsi.nlj.MediaSourceDesc
@@ -44,7 +45,6 @@ import org.jitsi.videobridge.Conference
 import org.jitsi.videobridge.cc.allocation.VideoConstraints
 import org.jitsi.videobridge.message.AddReceiverMessage
 import org.jitsi.videobridge.util.TaskPools
-import org.json.simple.JSONObject
 import java.time.Instant
 
 /**
@@ -195,11 +195,11 @@ class RelayedEndpoint(
 
     fun getIncomingStats() = rtpReceiver.getStats().packetStreamStats
 
-    override fun debugState(mode: DebugStateMode): JSONObject = super.debugState(mode).apply {
+    override fun debugState(mode: DebugStateMode): ObjectNode = super.debugState(mode).apply {
         if (mode == DebugStateMode.FULL) {
-            this["stream_information_store"] = streamInformationStore.debugState(mode)
-            this["receiver"] = rtpReceiver.debugState(mode)
-            this["media_sources"] = _mediaSources.debugState()
+            set<ObjectNode>("stream_information_store", streamInformationStore.debugState(mode))
+            set<ObjectNode>("receiver", rtpReceiver.debugState(mode))
+            set<ObjectNode>("media_sources", _mediaSources.debugState())
         }
     }
 
@@ -225,7 +225,7 @@ class RelayedEndpoint(
         try {
             updateStatsOnExpire()
             rtpReceiver.stop()
-            logger.cdebug { debugState(DebugStateMode.FULL).toJSONString() }
+            logger.cdebug { debugState(DebugStateMode.FULL).toString() }
             rtpReceiver.tearDown()
         } catch (t: Throwable) {
             logger.error("Exception while expiring: ", t)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/ConferencePacketStats.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/ConferencePacketStats.kt
@@ -15,9 +15,11 @@
  */
 package org.jitsi.videobridge.stats
 
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.videobridge.metrics.Metrics
-import org.json.simple.JSONArray
-import org.json.simple.JSONObject
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -51,9 +53,9 @@ class ConferencePacketStats private constructor() {
         }
     }
 
-    fun toJson() = JSONObject().apply {
-        val packetRates = JSONArray()
-        val bitrates = JSONArray()
+    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+        val packetRates: ArrayNode = jacksonObjectMapper().createArrayNode()
+        val bitrates: ArrayNode = jacksonObjectMapper().createArrayNode()
 
         (0..MAX_SIZE).forEach { conferenceSize ->
             stats[conferenceSize]?.let {
@@ -62,8 +64,8 @@ class ConferencePacketStats private constructor() {
             }
         }
 
-        put("packets", packetRates)
-        put("bytes", bitrates)
+        set<ObjectNode>("packets", packetRates)
+        set<ObjectNode>("bytes", bitrates)
         put("total_packets", totalPackets.get())
         put("total_bytes", totalBytes.get())
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/ConferencePacketStats.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/ConferencePacketStats.kt
@@ -18,7 +18,6 @@ package org.jitsi.videobridge.stats
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.videobridge.metrics.Metrics
 import java.util.concurrent.atomic.AtomicLong
 
@@ -53,7 +52,7 @@ class ConferencePacketStats private constructor() {
         }
     }
 
-    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         val packetRates: ArrayNode = JsonNodeFactory.instance.arrayNode()
         val bitrates: ArrayNode = JsonNodeFactory.instance.arrayNode()
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/ConferencePacketStats.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/ConferencePacketStats.kt
@@ -16,8 +16,8 @@
 package org.jitsi.videobridge.stats
 
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.videobridge.metrics.Metrics
 import java.util.concurrent.atomic.AtomicLong
@@ -54,8 +54,8 @@ class ConferencePacketStats private constructor() {
     }
 
     fun toJson(): ObjectNode = OrderedJsonObject().apply {
-        val packetRates: ArrayNode = jacksonObjectMapper().createArrayNode()
-        val bitrates: ArrayNode = jacksonObjectMapper().createArrayNode()
+        val packetRates: ArrayNode = JsonNodeFactory.instance.arrayNode()
+        val bitrates: ArrayNode = JsonNodeFactory.instance.arrayNode()
 
         (0..MAX_SIZE).forEach { conferenceSize ->
             stats[conferenceSize]?.let {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/PacketTransitStats.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/PacketTransitStats.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.stats
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
 import org.jitsi.nlj.PacketInfo
@@ -101,12 +102,12 @@ object PacketTransitStats {
     }
 
     @JvmStatic
-    val statsJson: OrderedJsonObject
+    val statsJson: ObjectNode
         get() {
             val stats = OrderedJsonObject()
-            stats["e2e_packet_delay"] = getPacketDelayStats()
+            stats.set<ObjectNode>("e2e_packet_delay", getPacketDelayStats())
             bridgeJitterStats?.let {
-                stats["overall_bridge_jitter"] = it.jitter
+                stats.put("overall_bridge_jitter", it.jitter)
             }
             return stats
         }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/PacketTransitStats.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/PacketTransitStats.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.stats
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.config.JitsiConfig
 import org.jitsi.metaconfig.config
@@ -23,7 +24,6 @@ import org.jitsi.nlj.stats.BridgeJitterStats
 import org.jitsi.nlj.stats.PacketDelayStats
 import org.jitsi.rtp.extensions.looksLikeRtcp
 import org.jitsi.rtp.extensions.looksLikeRtp
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.utils.stats.BucketStats
 import org.jitsi.videobridge.Endpoint
@@ -104,7 +104,7 @@ object PacketTransitStats {
     @JvmStatic
     val statsJson: ObjectNode
         get() {
-            val stats = OrderedJsonObject()
+            val stats = JsonNodeFactory.instance.objectNode()
             stats.set<ObjectNode>("e2e_packet_delay", getPacketDelayStats())
             bridgeJitterStats?.let {
                 stats.put("overall_bridge_jitter", it.jitter)
@@ -116,7 +116,7 @@ object PacketTransitStats {
     val bridgeJitter
         get() = bridgeJitterStats?.jitter
 
-    private fun getPacketDelayStats() = OrderedJsonObject().apply {
+    private fun getPacketDelayStats() = JsonNodeFactory.instance.objectNode().apply {
         rtpPacketDelayStats?.let {
             put("rtp", it.toJson(format = BucketStats.Format.CumulativeRight))
         }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/QueueStats.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/QueueStats.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.stats
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.RtpReceiverImpl
 import org.jitsi.nlj.RtpSenderImpl
 import org.jitsi.utils.OrderedJsonObject
@@ -24,51 +25,49 @@ import org.jitsi.videobridge.AbstractEndpointMessageTransport
 import org.jitsi.videobridge.Endpoint
 import org.jitsi.videobridge.relay.Relay
 import org.jitsi.videobridge.relay.RelayEndpointSender
-import org.json.simple.JSONObject
 
 object QueueStats {
     /** Gets statistics for the different `PacketQueue`s that this bridge uses. */
     @JvmStatic
-    fun getQueueStats() = JSONObject().apply {
-        this["srtp_send_queue"] = getJsonFromQueueStatisticsAndErrorHandler(
+    fun getQueueStats(): ObjectNode = OrderedJsonObject().apply {
+        getJsonFromQueueStatisticsAndErrorHandler(
             Endpoint.queueErrorCounter,
             "Endpoint-outgoing-packet-queue"
-        )
-        this["relay_srtp_send_queue"] = getJsonFromQueueStatisticsAndErrorHandler(
+        )?.let { set<ObjectNode>("srtp_send_queue", it) }
+        getJsonFromQueueStatisticsAndErrorHandler(
             Relay.queueErrorCounter,
             "Relay-outgoing-packet-queue"
-        )
-        this["relay_endpoint_sender_srtp_send_queue"] = getJsonFromQueueStatisticsAndErrorHandler(
+        )?.let { set<ObjectNode>("relay_srtp_send_queue", it) }
+        getJsonFromQueueStatisticsAndErrorHandler(
             RelayEndpointSender.queueErrorCounter,
             "RelayEndpointSender-outgoing-packet-queue"
-        )
-        this["rtp_receiver_queue"] = getJsonFromQueueStatisticsAndErrorHandler(
+        )?.let { set<ObjectNode>("relay_endpoint_sender_srtp_send_queue", it) }
+        getJsonFromQueueStatisticsAndErrorHandler(
             RtpReceiverImpl.queueErrorCounter,
             "rtp-receiver-incoming-packet-queue"
-        )
-        this["rtp_sender_queue"] = getJsonFromQueueStatisticsAndErrorHandler(
+        )?.let { set<ObjectNode>("rtp_receiver_queue", it) }
+        getJsonFromQueueStatisticsAndErrorHandler(
             RtpSenderImpl.queueErrorCounter,
             "rtp-sender-incoming-packet-queue"
-        )
-        this["colibri_queue"] = getStatistics()["colibri-queue"]
-        this[AbstractEndpointMessageTransport.INCOMING_MESSAGE_QUEUE_ID] =
-            getJsonFromQueueStatisticsAndErrorHandler(
-                null,
-                AbstractEndpointMessageTransport.INCOMING_MESSAGE_QUEUE_ID
-            )
+        )?.let { set<ObjectNode>("rtp_sender_queue", it) }
+        getStatistics().get("colibri-queue")?.let { set<com.fasterxml.jackson.databind.JsonNode>("colibri_queue", it) }
+        getJsonFromQueueStatisticsAndErrorHandler(
+            null,
+            AbstractEndpointMessageTransport.INCOMING_MESSAGE_QUEUE_ID
+        )?.let { set<ObjectNode>(AbstractEndpointMessageTransport.INCOMING_MESSAGE_QUEUE_ID, it) }
     }
 
     private fun getJsonFromQueueStatisticsAndErrorHandler(
         countingErrorHandler: CountingErrorHandler?,
         queueName: String
-    ): OrderedJsonObject? {
-        var json = getStatistics()[queueName] as OrderedJsonObject?
+    ): ObjectNode? {
+        var json = getStatistics().get(queueName) as? ObjectNode
         if (countingErrorHandler != null) {
             if (json == null) {
                 json = OrderedJsonObject()
-                json["dropped_packets"] = countingErrorHandler.numPacketsDropped
+                json.put("dropped_packets", countingErrorHandler.numPacketsDropped)
             }
-            json["exceptions"] = countingErrorHandler.numExceptions
+            json.put("exceptions", countingErrorHandler.numExceptions)
         }
 
         return json

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/QueueStats.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/QueueStats.kt
@@ -15,10 +15,10 @@
  */
 package org.jitsi.videobridge.stats
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.RtpReceiverImpl
 import org.jitsi.nlj.RtpSenderImpl
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.queue.CountingErrorHandler
 import org.jitsi.utils.queue.QueueStatistics.Companion.getStatistics
 import org.jitsi.videobridge.AbstractEndpointMessageTransport
@@ -29,7 +29,7 @@ import org.jitsi.videobridge.relay.RelayEndpointSender
 object QueueStats {
     /** Gets statistics for the different `PacketQueue`s that this bridge uses. */
     @JvmStatic
-    fun getQueueStats(): ObjectNode = OrderedJsonObject().apply {
+    fun getQueueStats(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         getJsonFromQueueStatisticsAndErrorHandler(
             Endpoint.queueErrorCounter,
             "Endpoint-outgoing-packet-queue"
@@ -64,7 +64,7 @@ object QueueStats {
         var json = getStatistics().get(queueName) as? ObjectNode
         if (countingErrorHandler != null) {
             if (json == null) {
-                json = OrderedJsonObject()
+                json = JsonNodeFactory.instance.objectNode()
                 json.put("dropped_packets", countingErrorHandler.numPacketsDropped)
             }
             json.put("exceptions", countingErrorHandler.numExceptions)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/VideobridgeStatisticsShim.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/VideobridgeStatisticsShim.kt
@@ -15,7 +15,9 @@
  */
 package org.jitsi.videobridge.stats
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.rtcp.RembHandler
+import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.videobridge.EndpointConnectionStatusMonitor
 import org.jitsi.videobridge.VersionConfig
 import org.jitsi.videobridge.health.JvbHealthChecker
@@ -77,7 +79,6 @@ import org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension.TOTAL_PACKETS_SEN
 import org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension.TOTAL_PACKETS_SENT_OCTO
 import org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension.TOTAL_PARTICIPANTS
 import org.jitsi.xmpp.extensions.colibri.ColibriStatsExtension.VERSION
-import org.json.simple.JSONObject
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.TimeZone
@@ -88,9 +89,9 @@ import java.util.TimeZone
  * /colibri/stats
  */
 object VideobridgeStatisticsShim {
-    fun getStatsJson() = JSONObject().apply {
+    fun getStatsJson(): ObjectNode = OrderedJsonObject().apply {
         getStats().forEach { (k, v) ->
-            this[k] = v
+            put(k, v.toString())
         }
     }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/VideobridgeStatisticsShim.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/VideobridgeStatisticsShim.kt
@@ -15,9 +15,9 @@
  */
 package org.jitsi.videobridge.stats
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.rtcp.RembHandler
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.videobridge.EndpointConnectionStatusMonitor
 import org.jitsi.videobridge.VersionConfig
 import org.jitsi.videobridge.health.JvbHealthChecker
@@ -89,7 +89,7 @@ import java.util.TimeZone
  * /colibri/stats
  */
 object VideobridgeStatisticsShim {
-    fun getStatsJson(): ObjectNode = OrderedJsonObject().apply {
+    fun getStatsJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         getStats().forEach { (k, v) ->
             when (v) {
                 is Boolean -> put(k, v)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/VideobridgeStatisticsShim.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/VideobridgeStatisticsShim.kt
@@ -91,7 +91,14 @@ import java.util.TimeZone
 object VideobridgeStatisticsShim {
     fun getStatsJson(): ObjectNode = OrderedJsonObject().apply {
         getStats().forEach { (k, v) ->
-            put(k, v.toString())
+            when (v) {
+                is Boolean -> put(k, v)
+                is Long -> put(k, v)
+                is Int -> put(k, v)
+                is Double -> put(k, v)
+                is Float -> put(k, v)
+                else -> put(k, v.toString())
+            }
         }
     }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/dtls/DtlsTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/dtls/DtlsTransport.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.videobridge.transport.dtls
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.ice4j.util.Buffer
 import org.jitsi.nlj.dtls.DtlsClient
 import org.jitsi.nlj.dtls.DtlsServer
@@ -214,7 +215,7 @@ class DtlsTransport(parentLogger: Logger, id: String) {
         }
     }
 
-    fun getDebugState(): OrderedJsonObject = stats.toJson().apply {
+    fun getDebugState(): ObjectNode = stats.toJson().apply {
         put("running", running.get())
         put("role", dtlsStack.role?.javaClass?.simpleName ?: "null")
         put("is_connected", isConnected)
@@ -226,7 +227,7 @@ class DtlsTransport(parentLogger: Logger, id: String) {
         var numPacketsSent: Int = 0,
         var numOutgoingPacketsDroppedNoHandler: Int = 0
     ) {
-        fun toJson(): OrderedJsonObject = OrderedJsonObject().apply {
+        fun toJson(): ObjectNode = OrderedJsonObject().apply {
             put("num_packets_received", numPacketsReceived)
             put("num_incoming_packets_dropped_no_handler", numIncomingPacketsDroppedNoHandler)
             put("num_packets_sent", numPacketsSent)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/dtls/DtlsTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/dtls/DtlsTransport.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.videobridge.transport.dtls
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.ice4j.util.Buffer
 import org.jitsi.nlj.dtls.DtlsClient
@@ -23,7 +24,6 @@ import org.jitsi.nlj.dtls.DtlsServer
 import org.jitsi.nlj.dtls.DtlsStack
 import org.jitsi.nlj.srtp.TlsRole
 import org.jitsi.nlj.util.BufferPool
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.utils.queue.PacketQueue
@@ -227,7 +227,7 @@ class DtlsTransport(parentLogger: Logger, id: String) {
         var numPacketsSent: Int = 0,
         var numOutgoingPacketsDroppedNoHandler: Int = 0
     ) {
-        fun toJson(): ObjectNode = OrderedJsonObject().apply {
+        fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
             put("num_packets_received", numPacketsReceived)
             put("num_incoming_packets_dropped_no_handler", numIncomingPacketsDroppedNoHandler)
             put("num_packets_sent", numPacketsSent)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceStatistics.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceStatistics.kt
@@ -15,8 +15,8 @@
  */
 package org.jitsi.videobridge.transport.ice
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.stats.BucketStats
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
@@ -38,7 +38,7 @@ class IceStatistics {
         statsByHarvesterName.computeIfAbsent(harvesterName) { Stats() }.add(rttMs = rttMs)
     }
 
-    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+    fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         set<ObjectNode>("all", combinedStats.toJson())
         statsByHarvesterName.forEach { (harvesterName, stats) ->
             set<ObjectNode>(harvesterName, stats.toJson())
@@ -61,7 +61,7 @@ class IceStatistics {
             buckets.addValue((rttMs + 0.5).toLong())
         }
 
-        fun toJson(): ObjectNode = OrderedJsonObject().apply {
+        fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
             put("average", sum.sum() / count.toDouble())
             set<ObjectNode>("buckets", buckets.toJson())
         }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceStatistics.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceStatistics.kt
@@ -15,6 +15,7 @@
  */
 package org.jitsi.videobridge.transport.ice
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.stats.BucketStats
 import java.util.concurrent.ConcurrentHashMap
@@ -37,10 +38,10 @@ class IceStatistics {
         statsByHarvesterName.computeIfAbsent(harvesterName) { Stats() }.add(rttMs = rttMs)
     }
 
-    fun toJson() = OrderedJsonObject().apply {
-        put("all", combinedStats.toJson())
+    fun toJson(): ObjectNode = OrderedJsonObject().apply {
+        set<ObjectNode>("all", combinedStats.toJson())
         statsByHarvesterName.forEach { (harvesterName, stats) ->
-            put(harvesterName, stats.toJson())
+            set<ObjectNode>(harvesterName, stats.toJson())
         }
     }
 
@@ -60,9 +61,9 @@ class IceStatistics {
             buckets.addValue((rttMs + 0.5).toLong())
         }
 
-        fun toJson() = OrderedJsonObject().apply {
+        fun toJson(): ObjectNode = OrderedJsonObject().apply {
             put("average", sum.sum() / count.toDouble())
-            put("buckets", buckets.toJson())
+            set<ObjectNode>("buckets", buckets.toJson())
         }
     }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.videobridge.transport.ice
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.google.common.net.InetAddresses
 import org.ice4j.Transport
@@ -32,7 +33,6 @@ import org.ice4j.util.Buffer
 import org.ice4j.util.BufferHandler
 import org.jitsi.rtp.Packet
 import org.jitsi.rtp.rtp.RtpPacket
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.cdebug
 import org.jitsi.utils.logging2.createChildLogger
@@ -286,7 +286,7 @@ class IceTransport @JvmOverloads constructor(
         }
     }
 
-    fun getDebugState(): ObjectNode = OrderedJsonObject().apply {
+    fun getDebugState(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         put("keepAliveStrategy", IceConfig.config.keepAliveStrategy.toString())
         put("nominationStrategy", IceConfig.config.nominationStrategy.toString())
         put("advertisePrivateCandidates", IceConfig.config.advertisePrivateCandidates)
@@ -461,7 +461,7 @@ class IceTransport @JvmOverloads constructor(
         val numPacketsSent = LongAdder()
         val numOutgoingPacketsDroppedStopped = LongAdder()
 
-        fun toJson(): ObjectNode = OrderedJsonObject().apply {
+        fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
             put("num_packets_received", numPacketsReceived.sum())
             put("num_incoming_packets_dropped_no_handler", numIncomingPacketsDroppedNoHandler.sum())
             put("num_packets_sent", numPacketsSent.sum())

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.videobridge.transport.ice
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import com.google.common.net.InetAddresses
 import org.ice4j.Transport
 import org.ice4j.TransportAddress
@@ -285,7 +286,7 @@ class IceTransport @JvmOverloads constructor(
         }
     }
 
-    fun getDebugState(): OrderedJsonObject = OrderedJsonObject().apply {
+    fun getDebugState(): ObjectNode = OrderedJsonObject().apply {
         put("keepAliveStrategy", IceConfig.config.keepAliveStrategy.toString())
         put("nominationStrategy", IceConfig.config.nominationStrategy.toString())
         put("advertisePrivateCandidates", IceConfig.config.advertisePrivateCandidates)
@@ -293,7 +294,7 @@ class IceTransport @JvmOverloads constructor(
         put("iceWriteable", iceWriteable.get())
         put("iceConnected", iceConnected.get())
         put("iceFailed", iceFailed.get())
-        putAll(packetStats.toJson())
+        setAll<ObjectNode>(packetStats.toJson())
     }
 
     fun describe(pe: IceUdpTransportPacketExtension) {
@@ -460,7 +461,7 @@ class IceTransport @JvmOverloads constructor(
         val numPacketsSent = LongAdder()
         val numOutgoingPacketsDroppedStopped = LongAdder()
 
-        fun toJson(): OrderedJsonObject = OrderedJsonObject().apply {
+        fun toJson(): ObjectNode = OrderedJsonObject().apply {
             put("num_packets_received", numPacketsReceived.sum())
             put("num_incoming_packets_dropped_no_handler", numIncomingPacketsDroppedNoHandler.sum())
             put("num_packets_sent", numPacketsSent.sum())

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
@@ -17,8 +17,8 @@
 package org.jitsi.videobridge.xmpp
 
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.nlj.stats.DelayStats
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.cdebug
@@ -170,7 +170,7 @@ class XmppConnection : IQListener {
      * @return JSON string of the list of ids
      */
     fun getMucClientIds(): String {
-        val arr: ArrayNode = jacksonObjectMapper().createArrayNode()
+        val arr: ArrayNode = JsonNodeFactory.instance.arrayNode()
         mucClientManager.mucClientIds.forEach { arr.add(it) }
         return arr.toString()
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
@@ -16,6 +16,9 @@
 
 package org.jitsi.videobridge.xmpp
 
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.nlj.stats.DelayStats
 import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.cdebug
@@ -37,8 +40,6 @@ import org.jivesoftware.smack.packet.ExtensionElement
 import org.jivesoftware.smack.packet.IQ
 import org.jivesoftware.smack.packet.StanzaError
 import org.jivesoftware.smackx.iqversion.packet.Version
-import org.json.simple.JSONArray
-import org.json.simple.JSONObject
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -123,15 +124,15 @@ class XmppConnection : IQListener {
      * is in the required format and either a new {@link MucClient} was added
      * or a client with the same ID already existed).
      */
-    fun addMucClient(jsonObject: JSONObject): Boolean {
-        if (jsonObject["id"] !is String) {
+    fun addMucClient(jsonObject: ObjectNode): Boolean {
+        val idNode = jsonObject.get("id")
+        if (idNode == null || !idNode.isTextual) {
             return false
         }
-        val config = MucClientConfiguration(jsonObject["id"] as String)
-        for (key in jsonObject.keys) {
-            val value = jsonObject[key]
-            if (key is String && value is String && key != "id") {
-                config.setProperty(key, value)
+        val config = MucClientConfiguration(idNode.asText())
+        jsonObject.fields().forEach { (key, value) ->
+            if (value.isTextual && key != "id") {
+                config.setProperty(key, value.asText())
             }
         }
         if (!config.isComplete) {
@@ -169,7 +170,9 @@ class XmppConnection : IQListener {
      * @return JSON string of the list of ids
      */
     fun getMucClientIds(): String {
-        return JSONArray().apply { addAll(mucClientManager.mucClientIds) }.toJSONString()
+        val arr: ArrayNode = jacksonObjectMapper().createArrayNode()
+        mucClientManager.mucClientIds.forEach { arr.add(it) }
+        return arr.toString()
     }
 
     /**
@@ -188,14 +191,14 @@ class XmppConnection : IQListener {
      * the expected format, or if no MUC client with the specified ID exists),
      * returns {@code false}.
      */
-    fun removeMucClient(jsonObject: JSONObject): Boolean {
-        val id = jsonObject["id"]
-        if (id !is String) {
-            logger.info("Invalid ID: $id")
+    fun removeMucClient(jsonObject: ObjectNode): Boolean {
+        val idNode = jsonObject.get("id")
+        if (idNode == null || !idNode.isTextual) {
+            logger.info("Invalid ID: $idNode")
             return false
         }
-        logger.info("Removing muc client $id")
-        return mucClientManager.removeMucClient(id)
+        logger.info("Removing muc client ${idNode.asText()}")
+        return mucClientManager.removeMucClient(idNode.asText())
     }
 
     /**
@@ -329,11 +332,11 @@ class XmppConnection : IQListener {
         )
 
         @JvmStatic
-        fun getStatsJson(): OrderedJsonObject = OrderedJsonObject().apply {
-            put("colibri", colibriDelayStats.toJson())
-            put("colibri_processing", colibriProcessingDelayStats.toJson())
-            put("health", healthDelayStats.toJson())
-            put("version", versionDelayStats.toJson())
+        fun getStatsJson(): ObjectNode = OrderedJsonObject().apply {
+            set<ObjectNode>("colibri", colibriDelayStats.toJson())
+            set<ObjectNode>("colibri_processing", colibriProcessingDelayStats.toJson())
+            set<ObjectNode>("health", healthDelayStats.toJson())
+            set<ObjectNode>("version", versionDelayStats.toJson())
         }
     }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.nlj.stats.DelayStats
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.logging2.cdebug
 import org.jitsi.utils.logging2.createLogger
 import org.jitsi.videobridge.metrics.VideobridgeMetrics
@@ -332,7 +331,7 @@ class XmppConnection : IQListener {
         )
 
         @JvmStatic
-        fun getStatsJson(): ObjectNode = OrderedJsonObject().apply {
+        fun getStatsJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
             set<ObjectNode>("colibri", colibriDelayStats.toJson())
             set<ObjectNode>("colibri_processing", colibriProcessingDelayStats.toJson())
             set<ObjectNode>("health", healthDelayStats.toJson())

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/ConferenceTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/ConferenceTest.kt
@@ -15,12 +15,12 @@
  */
 package org.jitsi.videobridge
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 import org.jitsi.ConfigTest
 import org.jitsi.nlj.DebugStateMode
-import org.json.simple.JSONObject
-import org.json.simple.parser.JSONParser
 import org.jxmpp.jid.impl.JidCreate
 
 /**
@@ -39,7 +39,7 @@ class ConferenceTest : ConfigTest() {
                 createLocalEndpoint("abcdabcd", true, false, false, false)
                 endpointCount shouldBe 1
                 DebugStateMode.entries.forEach { mode ->
-                    getDebugState(mode, null).shouldBeValidJson()
+                    getDebugState(mode, null).shouldBeValidJsonConf()
                 }
             }
         }
@@ -49,11 +49,11 @@ class ConferenceTest : ConfigTest() {
                 createRelay("relay-id", "mesh-id", true, true)
                 hasRelays() shouldBe true
                 DebugStateMode.entries.forEach { mode ->
-                    getDebugState(mode, null).shouldBeValidJson()
+                    getDebugState(mode, null).shouldBeValidJsonConf()
                 }
             }
         }
     }
 }
 
-fun JSONObject.shouldBeValidJson() = JSONParser().parse(this.toJSONString())
+fun ObjectNode.shouldBeValidJsonConf() = ObjectMapper().readTree(this.toString())

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/VideobridgeTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/VideobridgeTest.kt
@@ -15,6 +15,8 @@
  */
 package org.jitsi.videobridge
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.core.test.TestCase
@@ -25,13 +27,11 @@ import io.mockk.verify
 import org.jitsi.config.withNewConfig
 import org.jitsi.nlj.DebugStateMode
 import org.jitsi.shutdown.ShutdownServiceImpl
-import org.jitsi.utils.OrderedJsonObject
 import org.jitsi.utils.concurrent.FakeScheduledExecutorService
 import org.jitsi.videobridge.metrics.VideobridgeMetrics
 import org.jitsi.videobridge.shutdown.ShutdownConfig
 import org.jitsi.videobridge.shutdown.ShutdownState
 import org.jitsi.videobridge.util.TaskPools
-import org.json.simple.parser.JSONParser
 
 class VideobridgeTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode = IsolationMode.InstancePerLeaf
@@ -95,6 +95,6 @@ class VideobridgeTest : ShouldSpec() {
     }
 }
 
-fun OrderedJsonObject.shouldBeValidJson() {
-    JSONParser().parse(this.toJSONString())
+fun ObjectNode.shouldBeValidJson() {
+    ObjectMapper().readTree(this.toString())
 }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.TextNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
@@ -31,8 +33,6 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import org.jitsi.nlj.VideoType
 import org.jitsi.videobridge.cc.allocation.VideoConstraints
 import org.jitsi.videobridge.message.BridgeChannelMessage.Companion.parse
-import org.json.simple.JSONObject
-import org.json.simple.parser.JSONParser
 
 @Suppress("BlockingMethodInNonBlockingContext")
 class BridgeChannelMessageTest : ShouldSpec() {
@@ -42,11 +42,11 @@ class BridgeChannelMessageTest : ShouldSpec() {
                 // Any message will do, this one is just simple
                 val message = ClientHelloMessage()
 
-                val parsed = JSONParser().parse(message.toJson())
-                parsed.shouldBeInstanceOf<JSONObject>()
+                val parsed = jacksonObjectMapper().readTree(message.toJson())
+                parsed.shouldBeInstanceOf<ObjectNode>()
                 val parsedColibriClass = parsed["colibriClass"]
-                parsedColibriClass.shouldBeInstanceOf<String>()
-                parsedColibriClass shouldBe ClientHelloMessage.TYPE
+                parsedColibriClass.shouldBeInstanceOf<TextNode>()
+                parsedColibriClass.asText() shouldBe ClientHelloMessage.TYPE
             }
         }
         context("parsing an invalid message") {
@@ -550,9 +550,9 @@ class BridgeChannelMessageTest : ShouldSpec() {
 
             val objectMapper = ObjectMapper()
             fun toJsonJackson(m: DominantSpeakerMessage): String = objectMapper.writeValueAsString(m)
-            fun toJsonJsonSimple(m: DominantSpeakerMessage) = JSONObject().apply {
-                this["dominantSpeakerEndpoint"] = m.dominantSpeakerEndpoint
-            }.toJSONString()
+            fun toJsonJsonSimple(m: DominantSpeakerMessage) = jacksonObjectMapper().createObjectNode().apply {
+                put("dominantSpeakerEndpoint", m.dominantSpeakerEndpoint)
+            }.toString()
 
             fun toJsonStringConcat(m: DominantSpeakerMessage) =
                 "{\"colibriClass\":\"DominantSpeakerEndpointChangeEvent\",\"dominantSpeakerEndpoint\":\"" +

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClientTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/rest/root/colibri/mucclient/MucClientTest.kt
@@ -16,6 +16,8 @@
 
 package org.jitsi.videobridge.rest.root.colibri.mucclient
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -28,8 +30,6 @@ import org.glassfish.jersey.test.JerseyTest
 import org.glassfish.jersey.test.TestProperties
 import org.jitsi.videobridge.rest.MockBinder
 import org.jitsi.videobridge.xmpp.XmppConnection
-import org.json.simple.JSONArray
-import org.json.simple.JSONObject
 import org.junit.Test
 
 class MucClientTest : JerseyTest() {
@@ -51,11 +51,11 @@ class MucClientTest : JerseyTest() {
 
     @Test
     fun testAddMuc() {
-        val jsonConfigSlot = slot<JSONObject>()
+        val jsonConfigSlot = slot<ObjectNode>()
 
         every { xmppConnection.addMucClient(capture(jsonConfigSlot)) } returns true
 
-        val json = JSONObject().apply {
+        val json = jacksonObjectMapper().createObjectNode().apply {
             put("id", "id")
             put("hostname", "hostname")
             put("username", "username")
@@ -64,18 +64,19 @@ class MucClientTest : JerseyTest() {
             put("muc_nickname", "muc_nickname")
         }
 
-        val resp = target("$baseUrl/add").request().post(Entity.json(json.toJSONString()))
+        val resp = target("$baseUrl/add").request().post(Entity.json(json.toString()))
         resp.status shouldBe HttpStatus.OK_200
-        jsonConfigSlot.captured shouldBe json
+        // Compare JSON content (ObjectNode captured from request vs ObjectNode sent)
+        jsonConfigSlot.captured["id"]?.asText() shouldBe "id"
     }
 
     @Test
     fun testAddMucFailure() {
-        val jsonConfigSlot = slot<JSONObject>()
+        val jsonConfigSlot = slot<ObjectNode>()
 
         every { xmppConnection.addMucClient(capture(jsonConfigSlot)) } returns false
 
-        val json = JSONObject().apply {
+        val json = jacksonObjectMapper().createObjectNode().apply {
             put("id", "id")
             put("hostname", "hostname")
             put("username", "username")
@@ -84,42 +85,42 @@ class MucClientTest : JerseyTest() {
             put("muc_nickname", "muc_nickname")
         }
 
-        val resp = target("$baseUrl/add").request().post(Entity.json(json.toJSONString()))
+        val resp = target("$baseUrl/add").request().post(Entity.json(json.toString()))
         resp.status shouldBe HttpStatus.BAD_REQUEST_400
     }
 
     @Test
     fun testRemoveMuc() {
-        val jsonConfigSlot = slot<JSONObject>()
+        val jsonConfigSlot = slot<ObjectNode>()
 
         every { xmppConnection.removeMucClient(capture(jsonConfigSlot)) } returns true
 
-        val json = JSONObject().apply {
+        val json = jacksonObjectMapper().createObjectNode().apply {
             put("id", "id")
         }
 
-        val resp = target("$baseUrl/remove").request().post(Entity.json(json.toJSONString()))
+        val resp = target("$baseUrl/remove").request().post(Entity.json(json.toString()))
         resp.status shouldBe HttpStatus.OK_200
-        jsonConfigSlot.captured shouldBe json
+        jsonConfigSlot.captured["id"]?.asText() shouldBe "id"
     }
 
     @Test
     fun testRemoveMucFailure() {
         every { xmppConnection.removeMucClient(any()) } returns false
 
-        val json = JSONObject().apply {
+        val json = jacksonObjectMapper().createObjectNode().apply {
             put("id", "id")
         }
-        val resp = target("$baseUrl/remove").request().post(Entity.json(json.toJSONString()))
+        val resp = target("$baseUrl/remove").request().post(Entity.json(json.toString()))
         resp.status shouldBe HttpStatus.BAD_REQUEST_400
     }
 
     @Test
     fun testGetIds() {
-        val fakeIds = JSONArray().apply {
+        val fakeIds = jacksonObjectMapper().createArrayNode().apply {
             add("id1")
         }
-        every { xmppConnection.getMucClientIds() } returns fakeIds.toJSONString()
+        every { xmppConnection.getMucClientIds() } returns fakeIds.toString()
 
         val resp = target("$baseUrl/list").request().get()
         resp.readEntity(String::class.java) shouldBe "[\"id1\"]"

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/rest/root/colibri/stats/StatsTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/rest/root/colibri/stats/StatsTest.kt
@@ -16,6 +16,8 @@
 
 package org.jitsi.videobridge.rest.root.colibri.stats
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import jakarta.ws.rs.core.Application
@@ -24,8 +26,6 @@ import org.eclipse.jetty.http.HttpStatus
 import org.glassfish.jersey.server.ResourceConfig
 import org.glassfish.jersey.test.JerseyTest
 import org.glassfish.jersey.test.TestProperties
-import org.json.simple.JSONObject
-import org.json.simple.parser.JSONParser
 import org.junit.Test
 
 class StatsTest : JerseyTest() {
@@ -46,7 +46,7 @@ class StatsTest : JerseyTest() {
         val resp = target(baseUrl).request().get()
         resp.status shouldBe HttpStatus.OK_200
         resp.mediaType shouldBe MediaType.APPLICATION_JSON_TYPE
-        val parsed = JSONParser().parse(resp.readEntity(String::class.java))
-        parsed.shouldBeInstanceOf<JSONObject>()
+        val parsed = jacksonObjectMapper().readTree(resp.readEntity(String::class.java))
+        parsed.shouldBeInstanceOf<ObjectNode>()
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
         <kotest.version>5.9.1</kotest.version>
         <junit.version>5.13.4</junit.version>
         <junit.platform.version>1.13.4</junit.platform.version>
-        <jitsi.utils.version>1.0-146-g45b9f50</jitsi.utils.version>
-        <jicoco.version>1.1-170-g3f48c50</jicoco.version>
+        <jitsi.utils.version>1.0-150-g4ab9a3b</jitsi.utils.version>
+        <jicoco.version>1.1-171-gb3b9e1f</jicoco.version>
         <mockk.version>1.14.5</mockk.version>
         <ktlint-maven-plugin.version>3.2.0</ktlint-maven-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
@@ -133,7 +133,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-xmpp-extensions</artifactId>
-                <version>1.0-107-ge5f6370</version>
+                <version>1.0-112-gfe4b514</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/rtp/pom.xml
+++ b/rtp/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>jitsi-utils</artifactId>
             <version>${jitsi.utils.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-annotations -->
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/Av1DependencyDescriptorHeaderExtension.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/Av1DependencyDescriptorHeaderExtension.kt
@@ -16,11 +16,11 @@
 package org.jitsi.rtp.rtp.header_extensions
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.rtp.util.BitReader
 import org.jitsi.rtp.util.BitWriter
-import org.jitsi.utils.OrderedJsonObject
 
 /**
  * The subset of the fields of an AV1 Dependency Descriptor that can be parsed statelessly.
@@ -253,7 +253,7 @@ class Av1DependencyDescriptorHeaderExtension(
 
     override fun toString(): String {
         val mapper = ObjectMapper()
-        return OrderedJsonObject().apply {
+        return JsonNodeFactory.instance.objectNode().apply {
             put("startOfFrame", startOfFrame)
             put("endOfFrame", endOfFrame)
             put("frameDependencyTemplateId", frameDependencyTemplateId)
@@ -484,7 +484,7 @@ class Av1TemplateDependencyStructure(
 
     override fun toString(): String {
         val mapper = ObjectMapper()
-        return OrderedJsonObject().apply {
+        return JsonNodeFactory.instance.objectNode().apply {
             put("templateIdOffset", templateIdOffset)
             set<com.fasterxml.jackson.databind.node.ObjectNode>(
                 "templateInfo",
@@ -868,7 +868,7 @@ open class FrameInfo(
 
     fun toJson(): String {
         val mapper = ObjectMapper()
-        return OrderedJsonObject().apply {
+        return JsonNodeFactory.instance.objectNode().apply {
             put("spatialId", spatialId)
             put("temporalId", temporalId)
             set<com.fasterxml.jackson.databind.node.ObjectNode>("dti", mapper.valueToTree(dti.map { it.name }))
@@ -902,7 +902,7 @@ class DecodeTargetLayer(
     val temporalId: Int
 ) {
     override fun toString(): String {
-        return OrderedJsonObject().apply {
+        return JsonNodeFactory.instance.objectNode().apply {
             put("spatialId", spatialId)
             put("temporalId", temporalId)
         }.toString()
@@ -914,7 +914,7 @@ data class Resolution(
     val height: Int
 ) {
     override fun toString(): String {
-        return OrderedJsonObject().apply {
+        return JsonNodeFactory.instance.objectNode().apply {
             put("width", width)
             put("height", height)
         }.toString()

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/Av1DependencyDescriptorHeaderExtension.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/Av1DependencyDescriptorHeaderExtension.kt
@@ -259,27 +259,24 @@ class Av1DependencyDescriptorHeaderExtension(
             put("frameDependencyTemplateId", frameDependencyTemplateId)
             put("frameNumber", frameNumber)
             newTemplateDependencyStructure?.let {
-                set<com.fasterxml.jackson.databind.node.ObjectNode>(
-                    "templateStructure",
-                    mapper.valueToTree(it.toString())
-                )
+                put("templateStructure", it.toString())
             }
             customDtis?.let {
-                set<com.fasterxml.jackson.databind.node.ObjectNode>(
+                set<com.fasterxml.jackson.databind.node.ArrayNode>(
                     "customDTIs",
-                    mapper.valueToTree(it)
+                    mapper.valueToTree<com.fasterxml.jackson.databind.node.ArrayNode>(it)
                 )
             }
             customFdiffs?.let {
-                set<com.fasterxml.jackson.databind.node.ObjectNode>(
+                set<com.fasterxml.jackson.databind.node.ArrayNode>(
                     "customFdiffs",
-                    mapper.valueToTree(it)
+                    mapper.valueToTree<com.fasterxml.jackson.databind.node.ArrayNode>(it)
                 )
             }
             customChains?.let {
-                set<com.fasterxml.jackson.databind.node.ObjectNode>(
+                set<com.fasterxml.jackson.databind.node.ArrayNode>(
                     "customChains",
-                    mapper.valueToTree(it)
+                    mapper.valueToTree<com.fasterxml.jackson.databind.node.ArrayNode>(it)
                 )
             }
             activeDecodeTargetsBitmask?.let {
@@ -491,7 +488,7 @@ class Av1TemplateDependencyStructure(
             put("templateIdOffset", templateIdOffset)
             set<com.fasterxml.jackson.databind.node.ObjectNode>(
                 "templateInfo",
-                mapper.valueToTree(
+                mapper.valueToTree<com.fasterxml.jackson.databind.node.ObjectNode>(
                     templateInfo.map {
                         it.toString()
                     }.toIndexedMap()
@@ -499,11 +496,13 @@ class Av1TemplateDependencyStructure(
             )
             set<com.fasterxml.jackson.databind.node.ObjectNode>(
                 "decodeTargetProtectedBy",
-                mapper.valueToTree(decodeTargetProtectedBy.toIndexedMap())
+                mapper.valueToTree<com.fasterxml.jackson.databind.node.ObjectNode>(
+                    decodeTargetProtectedBy.toIndexedMap()
+                )
             )
             set<com.fasterxml.jackson.databind.node.ObjectNode>(
                 "decodeTargetLayers",
-                mapper.valueToTree(
+                mapper.valueToTree<com.fasterxml.jackson.databind.node.ObjectNode>(
                     decodeTargetLayers.map {
                         it.toString()
                     }.toIndexedMap()
@@ -512,7 +511,7 @@ class Av1TemplateDependencyStructure(
             if (maxRenderResolutions.isNotEmpty()) {
                 set<com.fasterxml.jackson.databind.node.ObjectNode>(
                     "maxRenderResolutions",
-                    mapper.valueToTree(
+                    mapper.valueToTree<com.fasterxml.jackson.databind.node.ObjectNode>(
                         maxRenderResolutions.map {
                             it.toString()
                         }.toIndexedMap()
@@ -873,8 +872,8 @@ open class FrameInfo(
             put("spatialId", spatialId)
             put("temporalId", temporalId)
             set<com.fasterxml.jackson.databind.node.ObjectNode>("dti", mapper.valueToTree(dti.map { it.name }))
-            set<com.fasterxml.jackson.databind.node.ObjectNode>("fdiff", mapper.valueToTree(fdiff))
-            set<com.fasterxml.jackson.databind.node.ObjectNode>("chains", mapper.valueToTree(chains))
+            set<com.fasterxml.jackson.databind.node.ArrayNode>("fdiff", mapper.valueToTree(fdiff))
+            set<com.fasterxml.jackson.databind.node.ArrayNode>("chains", mapper.valueToTree(chains))
         }.toString()
     }
 

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/Av1DependencyDescriptorHeaderExtension.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/Av1DependencyDescriptorHeaderExtension.kt
@@ -15,12 +15,12 @@
  */
 package org.jitsi.rtp.rtp.header_extensions
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.rtp.util.BitReader
 import org.jitsi.rtp.util.BitWriter
 import org.jitsi.utils.OrderedJsonObject
-import org.json.simple.JSONAware
 
 /**
  * The subset of the fields of an AV1 Dependency Descriptor that can be parsed statelessly.
@@ -70,8 +70,7 @@ class Av1DependencyDescriptorHeaderExtension(
     frameDependencyTemplateId,
     frameNumber,
     newTemplateDependencyStructure
-),
-    JSONAware {
+) {
     val frameInfo: FrameInfo by lazy {
         val templateIndex = (frameDependencyTemplateId + 64 - structure.templateIdOffset) % 64
         if (templateIndex >= structure.templateCount) {
@@ -252,16 +251,37 @@ class Av1DependencyDescriptorHeaderExtension(
         writer.writeBits(writer.remainingBits, 0)
     }
 
-    override fun toJSONString(): String {
+    override fun toString(): String {
+        val mapper = ObjectMapper()
         return OrderedJsonObject().apply {
             put("startOfFrame", startOfFrame)
             put("endOfFrame", endOfFrame)
             put("frameDependencyTemplateId", frameDependencyTemplateId)
             put("frameNumber", frameNumber)
-            newTemplateDependencyStructure?.let { put("templateStructure", it) }
-            customDtis?.let { put("customDTIs", it) }
-            customFdiffs?.let { put("customFdiffs", it) }
-            customChains?.let { put("customChains", it) }
+            newTemplateDependencyStructure?.let {
+                set<com.fasterxml.jackson.databind.node.ObjectNode>(
+                    "templateStructure",
+                    mapper.valueToTree(it.toString())
+                )
+            }
+            customDtis?.let {
+                set<com.fasterxml.jackson.databind.node.ObjectNode>(
+                    "customDTIs",
+                    mapper.valueToTree(it)
+                )
+            }
+            customFdiffs?.let {
+                set<com.fasterxml.jackson.databind.node.ObjectNode>(
+                    "customFdiffs",
+                    mapper.valueToTree(it)
+                )
+            }
+            customChains?.let {
+                set<com.fasterxml.jackson.databind.node.ObjectNode>(
+                    "customChains",
+                    mapper.valueToTree(it)
+                )
+            }
             activeDecodeTargetsBitmask?.let {
                 if (newTemplateDependencyStructure == null ||
                     it != ((1 shl newTemplateDependencyStructure.decodeTargetCount) - 1)
@@ -269,10 +289,8 @@ class Av1DependencyDescriptorHeaderExtension(
                     put("activeDecodeTargets", Integer.toBinaryString(it))
                 }
             }
-        }.toJSONString()
+        }.toString()
     }
-
-    override fun toString(): String = toJSONString()
 }
 
 fun Int.bitsForFdiff() = when {
@@ -296,7 +314,7 @@ class Av1TemplateDependencyStructure(
     val maxRenderResolutions: List<Resolution>,
     val maxSpatialId: Int,
     val maxTemporalId: Int
-) : JSONAware {
+) {
     val templateCount
         get() = templateInfo.size
 
@@ -467,21 +485,44 @@ class Av1TemplateDependencyStructure(
         return mask
     }
 
-    override fun toJSONString(): String {
+    override fun toString(): String {
+        val mapper = ObjectMapper()
         return OrderedJsonObject().apply {
             put("templateIdOffset", templateIdOffset)
-            put("templateInfo", templateInfo.toIndexedMap())
-            put("decodeTargetProtectedBy", decodeTargetProtectedBy.toIndexedMap())
-            put("decodeTargetLayers", decodeTargetLayers.toIndexedMap())
+            set<com.fasterxml.jackson.databind.node.ObjectNode>(
+                "templateInfo",
+                mapper.valueToTree(
+                    templateInfo.map {
+                        it.toString()
+                    }.toIndexedMap()
+                )
+            )
+            set<com.fasterxml.jackson.databind.node.ObjectNode>(
+                "decodeTargetProtectedBy",
+                mapper.valueToTree(decodeTargetProtectedBy.toIndexedMap())
+            )
+            set<com.fasterxml.jackson.databind.node.ObjectNode>(
+                "decodeTargetLayers",
+                mapper.valueToTree(
+                    decodeTargetLayers.map {
+                        it.toString()
+                    }.toIndexedMap()
+                )
+            )
             if (maxRenderResolutions.isNotEmpty()) {
-                put("maxRenderResolutions", maxRenderResolutions.toIndexedMap())
+                set<com.fasterxml.jackson.databind.node.ObjectNode>(
+                    "maxRenderResolutions",
+                    mapper.valueToTree(
+                        maxRenderResolutions.map {
+                            it.toString()
+                        }.toIndexedMap()
+                    )
+                )
             }
             put("maxSpatialId", maxSpatialId)
             put("maxTemporalId", maxTemporalId)
-        }.toJSONString()
+        }.toString()
     }
-
-    override fun toString() = toJSONString()
 }
 
 fun nsBits(n: Int, v: Int): Int {
@@ -798,7 +839,7 @@ open class FrameInfo(
     open val dti: List<DTI>,
     open val fdiff: List<Int>,
     open val chains: List<Int>
-) : JSONAware {
+) {
     val fdiffCnt
         get() = fdiff.size
 
@@ -826,14 +867,15 @@ open class FrameInfo(
         return "spatialId=$spatialId, temporalId=$temporalId, dti=$dti, fdiff=$fdiff, chains=$chains"
     }
 
-    override fun toJSONString(): String {
+    fun toJson(): String {
+        val mapper = ObjectMapper()
         return OrderedJsonObject().apply {
             put("spatialId", spatialId)
             put("temporalId", temporalId)
-            put("dti", dti)
-            put("fdiff", fdiff)
-            put("chains", chains)
-        }.toJSONString()
+            set<com.fasterxml.jackson.databind.node.ObjectNode>("dti", mapper.valueToTree(dti.map { it.name }))
+            set<com.fasterxml.jackson.databind.node.ObjectNode>("fdiff", mapper.valueToTree(fdiff))
+            set<com.fasterxml.jackson.databind.node.ObjectNode>("chains", mapper.valueToTree(chains))
+        }.toString()
     }
 
     /** Whether the frame has a dependency on a frame earlier than this "picture", the other frames of this
@@ -859,24 +901,24 @@ class TemplateFrameInfo(
 class DecodeTargetLayer(
     val spatialId: Int,
     val temporalId: Int
-) : JSONAware {
-    override fun toJSONString(): String {
+) {
+    override fun toString(): String {
         return OrderedJsonObject().apply {
             put("spatialId", spatialId)
             put("temporalId", temporalId)
-        }.toJSONString()
+        }.toString()
     }
 }
 
 data class Resolution(
     val width: Int,
     val height: Int
-) : JSONAware {
-    override fun toJSONString(): String {
+) {
+    override fun toString(): String {
         return OrderedJsonObject().apply {
             put("width", width)
             put("height", height)
-        }.toJSONString()
+        }.toString()
     }
 }
 

--- a/rtp/src/test/kotlin/org/jitsi/rtp/rtp/header_extensions/DumpAv1DependencyDescriptor.kt
+++ b/rtp/src/test/kotlin/org/jitsi/rtp/rtp/header_extensions/DumpAv1DependencyDescriptor.kt
@@ -26,7 +26,7 @@ fun main(args: Array<String>) {
             val reader = Av1DependencyDescriptorReader(descBinary, 0, descBinary.size)
             val desc = reader.parse(structure)
             desc.newTemplateDependencyStructure?.let { structure = it }
-            println(desc.toJSONString())
+            println(desc.toString())
             val frameInfo = desc.frameInfo
             println(frameInfo)
         } catch (e: Exception) {


### PR DESCRIPTION
Replace the `org.json.simple` dependency with Jackson.

- Migrate all `JSONObject`/`JSONArray` usages to `ObjectNode`/`ArrayNode` across `jvb`, `jitsi-media-transform`, and `rtp` modules
- Debug state methods now return `ObjectNode`
- Update `jitsi-utils` to `1.0-SNAPSHOT`, `jicoco` to `1.1-SNAPSHOT`, `jitsi-xmpp-extensions` to `1.0-SNAPSHOT`
- `Conferences.java` still uses `json-simple` transitively via `jitsi-xmpp-extensions` Colibri2 JSON API (will be removed once that dependency is updated)