### PR TITLE
fix: Pin Jackson via jackson-bom; align to a single version

### DIFF
--- a/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/message/BridgeChannelMessageTest.kt
@@ -24,10 +24,12 @@ import com.fasterxml.jackson.databind.node.TextNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotInclude
 import io.kotest.matchers.types.shouldBeInstanceOf
 import org.jitsi.nlj.VideoType
@@ -156,6 +158,23 @@ class BridgeChannelMessageTest : ShouldSpec() {
                 parsed2.otherFields["other_field2"] shouldBe 97
                 parsed2.otherFields.containsKey("other_null") shouldBe true
                 parsed2.otherFields.containsKey("nonexistent") shouldBe false
+            }
+
+            // EndpointMessage deserializes via a constructor creator ("to"). jackson-databind 2.18.x has a
+            // regression that drops @JsonAnySetter fields for creator-based types, which stripped msgPayload
+            // from forwarded EndpointMessages. This guards the round-trip (parse -> set from -> serialize).
+            should("preserve any-fields when forwarding (msgPayload is not stripped)") {
+                val payload =
+                    """{"colibriClass":"EndpointMessage","msgPayload":{"type":"face-box","faceBox":{"left":33,"right":64,"width":31}},"to":""}"""
+                val parsed3 = parse(payload) as EndpointMessage
+                parsed3.to shouldBe ""
+                withClue("otherFields=${parsed3.otherFields}") {
+                    parsed3.otherFields.containsKey("msgPayload") shouldBe true
+                }
+                parsed3.from = "3b213301"
+                withClue("json=${parsed3.toJson()}") {
+                    parsed3.toJson() shouldContain "msgPayload"
+                }
             }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
         <spotbugs.version>4.9.4</spotbugs.version>
         <spotbugs-maven-plugin.version>4.9.4.2</spotbugs-maven-plugin.version>
-        <jackson.version>2.17.1</jackson.version>
+        <jackson.version>2.19.4</jackson.version>
         <jacoco.version>0.8.13</jacoco.version>
         <bouncycastle.version>1.83</bouncycastle.version>
         <jersey.version>3.1.11</jersey.version>
@@ -80,6 +80,17 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Pin all Jackson artifacts to a single version. Transitive deps (jersey, jicoco) otherwise
+                 leave the databind version to Maven mediation, which can resolve to 2.18.x. jackson-databind
+                 2.18.x has a regression that silently drops @JsonAnySetter properties for types deserialized
+                 via a constructor creator (e.g. EndpointMessage's "to"), stripping EndpointMessage payloads. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jicoco-config</artifactId>


### PR DESCRIPTION
## Problem

The `jackson-databind` version is not pinned anywhere — it is left to Maven mediation among transitive providers (`jersey-media-json-jackson`, `jicoco`, `jitsi-utils`, `jackson-module-kotlin`). The winner is decided by declaration order in `jvb/pom.xml`, so it has drifted unintentionally:

- `jersey` 3.0.10 → databind **2.14.1**
- `jersey` bumped to 3.1.11 (#2412) → databind **2.18.0**
- `rtp` got an explicit `jackson-databind ${jackson.version}` (#2418) → databind **2.17.1** (accidental, masked the issue)

`jackson-databind` **2.18.x** has a regression: it silently drops `@JsonAnySetter` properties for types deserialized via a constructor creator, when the any-field appears before the creator property in the JSON. `EndpointMessage` has a creator property (`to`), so on 2.18.x a received `EndpointMessage` like `{"colibriClass":"EndpointMessage","msgPayload":{…},"to":""}` lost its `msgPayload` on forward. `EndpointStats` (no creator) is unaffected, which is why only `EndpointMessage` payloads (e.g. face-box) were stripped.

## Fix

Import `jackson-bom` in `dependencyManagement` and set `jackson.version` to `2.19.4`, so every Jackson artifact resolves to one version regardless of declaration order — no longer dependent on mediation. 2.19.x also fixes the upstream regression and matches what `jicoco`/`jitsi-utils` already expect.

Adds a round-trip test for `EndpointMessage` using the affected field order (any-field before `to`).