### PR TITLE
Fix colibri-ws after Jetty update

### DIFF
--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -56,6 +56,11 @@
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>
       <artifactId>jetty-ee10-servlets</artifactId>
       <version>${jetty.version}</version>


### PR DESCRIPTION
After the Jetty 12 update, Colibri WebSocket connections fail with HTTP 500.

The runtime classpath contains mixed Jetty patch versions: most Jetty artifacts are resolved to `12.0.35`, but `jersey-container-jetty-http:3.1.11` pulls `jetty-security:12.0.22` transitively. This causes a binary incompatibility when handling `/colibri-ws/...` requests:

```text
java.lang.NoSuchMethodError:
'org.eclipse.jetty.security.AuthenticationState
org.eclipse.jetty.security.AuthenticationState.getUndeferredAuthenticationState(org.eclipse.jetty.server.Request)'
```

Adding an explicit org.eclipse.jetty:jetty-security:${jetty.version} dependency aligns it with the rest of Jetty and fixes an issue.