### PR TITLE
ref: Bound per-SSRC tracking maps with an LRU

### DIFF
--- a/jitsi-media-transform/spotbugs-exclude.xml
+++ b/jitsi-media-transform/spotbugs-exclude.xml
@@ -42,6 +42,9 @@
     <Bug pattern="BC_IMPOSSIBLE_INSTANCEOF"/>
     <!-- False positives with Kotlin inlines -->
     <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    <!-- False positives for the synthetic bridge methods Kotlin generates on anonymous
+         subclasses of generic collections (e.g. an anonymous LRUCache overriding removeEldestEntry). -->
+    <Bug pattern="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"/>
 
     <!-- False positives for an unknown reason -->
     <Bug pattern="BC_BAD_CAST_TO_ABSTRACT_COLLECTION"/>

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/RetransmissionRequester.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/RetransmissionRequester.kt
@@ -22,6 +22,7 @@ import org.jitsi.rtp.util.RtpUtils
 import org.jitsi.rtp.util.isNextAfter
 import org.jitsi.rtp.util.isOlderThan
 import org.jitsi.rtp.util.numPacketsTo
+import org.jitsi.utils.LRUCache
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.cdebug
 import org.jitsi.utils.logging2.createChildLogger
@@ -42,7 +43,16 @@ class RetransmissionRequester(
     private val clock: Clock = Clock.systemUTC()
 ) {
     private val logger = createChildLogger(parentLogger)
-    private val streamPacketRequesters: MutableMap<Long, StreamPacketRequester> = HashMap()
+
+    /**
+     * Per-SSRC requesters, keyed on the RTP SSRC. Bounded with an LRU to limit the number of SSRCs tracked; evicted
+     * requesters are stopped to cancel their scheduled tasks. Access is synchronized on the map.
+     */
+    private val streamPacketRequesters: MutableMap<Long, StreamPacketRequester> =
+        object : LRUCache<Long, StreamPacketRequester>(MAX_SSRCS, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Long, StreamPacketRequester>): Boolean =
+                super.removeEldestEntry(eldest).also { if (it) eldest.value.stop() }
+        }
 
     fun packetReceived(ssrc: Long, seqNum: Int) {
         val streamPacketRequester = synchronized(streamPacketRequesters) {
@@ -238,5 +248,8 @@ class RetransmissionRequester(
     companion object {
         private const val MAX_REQUESTS = 10
         private val REQUEST_INTERVAL = Duration.ofMillis(150)
+
+        /** The maximum number of SSRCs to track retransmission requesters for. */
+        const val MAX_SSRCS = 64
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/RetransmissionRequester.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/RetransmissionRequester.kt
@@ -250,6 +250,6 @@ class RetransmissionRequester(
         private val REQUEST_INTERVAL = Duration.ofMillis(150)
 
         /** The maximum number of SSRCs to track retransmission requesters for. */
-        const val MAX_SSRCS = 64
+        const val MAX_SSRCS = 1024
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpRrGenerator.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpRrGenerator.kt
@@ -23,13 +23,14 @@ import org.jitsi.rtp.rtcp.RtcpPacket
 import org.jitsi.rtp.rtcp.RtcpReportBlock
 import org.jitsi.rtp.rtcp.RtcpRrPacketBuilder
 import org.jitsi.rtp.rtcp.RtcpSrPacket
+import org.jitsi.utils.LRUCache
 import org.jitsi.utils.MediaType
 import org.jitsi.utils.ms
 import org.jitsi.utils.times
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
-import java.util.concurrent.ConcurrentHashMap
+import java.util.Collections
 import java.util.concurrent.ScheduledExecutorService
 
 /**
@@ -71,7 +72,11 @@ class RtcpRrGenerator(
 ) : RtcpListener {
     var running: Boolean = true
 
-    private val senderInfos: MutableMap<Long, SenderInfo> = ConcurrentHashMap()
+    /**
+     * Per-SSRC sender info, keyed on the RTCP sender SSRC. Bounded with an LRU to limit the number of SSRCs tracked.
+     */
+    private val senderInfos: MutableMap<Long, SenderInfo> =
+        Collections.synchronizedMap(LRUCache(MAX_SSRCS, true))
 
     init {
         doWork()
@@ -140,5 +145,8 @@ class RtcpRrGenerator(
          * The interval at which RRs and REMBs will be sent.
          */
         val reportingInterval = 500.ms
+
+        /** The maximum number of SSRCs to track sender info for. */
+        const val MAX_SSRCS = 64
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpRrGenerator.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpRrGenerator.kt
@@ -147,6 +147,6 @@ class RtcpRrGenerator(
         val reportingInterval = 500.ms
 
         /** The maximum number of SSRCs to track sender info for. */
-        const val MAX_SSRCS = 64
+        const val MAX_SSRCS = 1024
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/AudioRedHandler.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/AudioRedHandler.kt
@@ -34,6 +34,7 @@ import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.rtp.rtp.header_extensions.AudioLevelHeaderExtension
 import org.jitsi.rtp.util.RtpUtils.Companion.applySequenceNumberDelta
 import org.jitsi.rtp.util.RtpUtils.Companion.getTimestampDiffAsInt
+import org.jitsi.utils.LRUCache
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 
@@ -48,7 +49,15 @@ class AudioRedHandler(
     var audioLevelExtId: Int? = null
     var redPayloadType: Int? = null
 
-    private val ssrcRedHandlers: MutableMap<Long, SsrcRedHandler> = HashMap()
+    /**
+     * Per-SSRC RED handlers, keyed on the RTP SSRC. Bounded with an LRU to limit the number of SSRCs tracked; evicted
+     * handlers are stopped to release their cached buffers.
+     */
+    private val ssrcRedHandlers: MutableMap<Long, SsrcRedHandler> =
+        object : LRUCache<Long, SsrcRedHandler>(MAX_SSRCS, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Long, SsrcRedHandler>): Boolean =
+                super.removeEldestEntry(eldest).also { if (it) eldest.value.stop() }
+        }
 
     init {
         streamInformationStore.onRtpPayloadTypesChanged { payloadTypes ->
@@ -286,6 +295,9 @@ class AudioRedHandler(
 
     companion object {
         val config = Config()
+
+        /** The maximum number of SSRCs to track RED handlers for. */
+        const val MAX_SSRCS = 64
     }
 }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/AudioRedHandler.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/AudioRedHandler.kt
@@ -297,7 +297,7 @@ class AudioRedHandler(
         val config = Config()
 
         /** The maximum number of SSRCs to track RED handlers for. */
-        const val MAX_SSRCS = 64
+        const val MAX_SSRCS = 1024
     }
 }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/DiscardableDiscarder.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/DiscardableDiscarder.kt
@@ -49,6 +49,6 @@ class DiscardableDiscarder(name: String, val keepHistory: Boolean) : Transformer
 
     companion object {
         /** The maximum number of SSRCs to track rewriters for. */
-        const val MAX_SSRCS = 64
+        const val MAX_SSRCS = 1024
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/DiscardableDiscarder.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/DiscardableDiscarder.kt
@@ -19,14 +19,19 @@ import org.jitsi.nlj.PacketInfo
 import org.jitsi.nlj.rtp.ResumableStreamRewriter
 import org.jitsi.nlj.transform.node.TransformerNode
 import org.jitsi.rtp.rtp.RtpPacket
-import java.util.concurrent.ConcurrentHashMap
+import org.jitsi.utils.LRUCache
+import java.util.Collections
 
 /**
  * Discards RTP packets which have shouldDiscard set to true, masking their loss
  * in the RTP sequence numbers of RTP packets.
  */
 class DiscardableDiscarder(name: String, val keepHistory: Boolean) : TransformerNode(name) {
-    val rewriters: MutableMap<Long, ResumableStreamRewriter> = ConcurrentHashMap()
+    /**
+     * Per-SSRC rewriters, keyed on the RTP SSRC. Bounded with an LRU to limit the number of SSRCs tracked.
+     */
+    val rewriters: MutableMap<Long, ResumableStreamRewriter> =
+        Collections.synchronizedMap(LRUCache(MAX_SSRCS, true))
 
     override fun transform(packetInfo: PacketInfo): PacketInfo? {
         val packet = packetInfo.packet as? RtpPacket ?: return packetInfo
@@ -41,4 +46,9 @@ class DiscardableDiscarder(name: String, val keepHistory: Boolean) : Transformer
     }
 
     override fun trace(f: () -> Unit) = f.invoke()
+
+    companion object {
+        /** The maximum number of SSRCs to track rewriters for. */
+        const val MAX_SSRCS = 64
+    }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/DuplicateTermination.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/DuplicateTermination.kt
@@ -20,7 +20,6 @@ import org.jitsi.nlj.stats.NodeStatsBlock
 import org.jitsi.nlj.transform.node.TransformerNode
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.utils.LRUCache
-import java.util.TreeMap
 
 /**
  * A node which drops packets with SSRC and sequence number pairs identical to ones
@@ -30,7 +29,10 @@ import java.util.TreeMap
  * will occur is after the [RtxHandler], since duplicate packets are sent over RTX for probing.)
  */
 class DuplicateTermination() : TransformerNode("Duplicate termination") {
-    private val replayContexts: MutableMap<Long, MutableSet<Int>> = TreeMap()
+    /**
+     * Per-SSRC replay context, keyed on the RTP SSRC. Bounded with an LRU to limit the number of SSRCs tracked.
+     */
+    private val replayContexts: MutableMap<Long, MutableSet<Int>> = LRUCache(MAX_SSRCS, true)
     private var numDuplicatePacketsDropped = 0
 
     override fun transform(packetInfo: PacketInfo): PacketInfo? {
@@ -56,4 +58,9 @@ class DuplicateTermination() : TransformerNode("Duplicate termination") {
     }
 
     override fun trace(f: () -> Unit) = f.invoke()
+
+    companion object {
+        /** The maximum number of SSRCs to track replay contexts for. */
+        const val MAX_SSRCS = 64
+    }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/DuplicateTermination.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/DuplicateTermination.kt
@@ -61,6 +61,6 @@ class DuplicateTermination() : TransformerNode("Duplicate termination") {
 
     companion object {
         /** The maximum number of SSRCs to track replay contexts for. */
-        const val MAX_SSRCS = 64
+        const val MAX_SSRCS = 1024
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
@@ -104,7 +104,7 @@ class IncomingStatisticsTracker(
 
     companion object {
         /** The maximum number of SSRCs to track stats for. */
-        const val MAX_SSRCS = 64
+        const val MAX_SSRCS = 1024
     }
 }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
@@ -29,10 +29,11 @@ import org.jitsi.rtp.util.isNewerThan
 import org.jitsi.rtp.util.isNextAfter
 import org.jitsi.rtp.util.numPacketsTo
 import org.jitsi.rtp.util.rolledOverTo
+import org.jitsi.utils.LRUCache
 import org.jitsi.utils.MediaType
 import java.time.Duration
 import java.time.Instant
-import java.util.concurrent.ConcurrentHashMap
+import java.util.Collections
 
 /**
  * Track various statistics about received RTP streams to be used in SR/RR report blocks
@@ -40,7 +41,12 @@ import java.util.concurrent.ConcurrentHashMap
 class IncomingStatisticsTracker(
     private val streamInformationStore: ReadOnlyStreamInformationStore
 ) : ObserverNode("Incoming statistics tracker") {
-    private val ssrcStats: MutableMap<Long, IncomingSsrcStats> = ConcurrentHashMap()
+    /**
+     * Per-SSRC stats, keyed on the RTP SSRC. Bounded with an LRU to limit the number of SSRCs tracked for a single
+     * stream.
+     */
+    private val ssrcStats: MutableMap<Long, IncomingSsrcStats> =
+        Collections.synchronizedMap(LRUCache(MAX_SSRCS, true))
 
     override fun observe(packetInfo: PacketInfo) {
         val rtpPacket = packetInfo.packetAs<RtpPacket>()
@@ -83,14 +89,23 @@ class IncomingStatisticsTracker(
      * generation. Other code should use [getSnapshot].
      */
     fun getSnapshotOfActiveSsrcs() = IncomingStatisticsSnapshot(
-        ssrcStats.mapNotNull { (ssrc, stats) ->
-            stats.getSnapshotIfActive()?.let { Pair(ssrc, it) }
-        }.toMap()
+        synchronized(ssrcStats) {
+            ssrcStats.mapNotNull { (ssrc, stats) ->
+                stats.getSnapshotIfActive()?.let { Pair(ssrc, it) }
+            }.toMap()
+        }
     )
 
     fun getSnapshot() = IncomingStatisticsSnapshot(
-        ssrcStats.map { (ssrc, stats) -> Pair(ssrc, stats.getSnapshot()) }.toMap()
+        synchronized(ssrcStats) {
+            ssrcStats.map { (ssrc, stats) -> Pair(ssrc, stats.getSnapshot()) }.toMap()
+        }
     )
+
+    companion object {
+        /** The maximum number of SSRCs to track stats for. */
+        const val MAX_SSRCS = 64
+    }
 }
 
 class IncomingStatisticsSnapshot(

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/PerSsrcMapCapTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/PerSsrcMapCapTest.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright @ 2024 - Present, 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.nlj
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.jitsi.nlj.format.Vp8PayloadType
+import org.jitsi.nlj.resources.logging.StdoutLogger
+import org.jitsi.nlj.rtcp.RetransmissionRequester
+import org.jitsi.nlj.rtcp.RtcpRrGenerator
+import org.jitsi.nlj.rtp.AudioRtpPacket
+import org.jitsi.nlj.transform.node.AudioRedHandler
+import org.jitsi.nlj.transform.node.incoming.DiscardableDiscarder
+import org.jitsi.nlj.transform.node.incoming.DuplicateTermination
+import org.jitsi.nlj.transform.node.incoming.IncomingStatisticsTracker
+import org.jitsi.nlj.util.StreamInformationStoreImpl
+import org.jitsi.rtp.rtcp.RtcpHeaderBuilder
+import org.jitsi.rtp.rtcp.RtcpSrPacketBuilder
+import org.jitsi.rtp.rtcp.SenderInfoBuilder
+import org.jitsi.rtp.rtp.RtpPacket
+import org.jitsi.utils.concurrent.FakeScheduledExecutorService
+import java.time.Instant
+
+/**
+ * Verifies that the per-SSRC tracking structures are bounded, i.e. that the number of distinct SSRCs tracked for a
+ * single stream is limited regardless of how many distinct SSRCs are received.
+ */
+class PerSsrcMapCapTest : ShouldSpec() {
+    init {
+        val n = 1000
+
+        context("IncomingStatisticsTracker") {
+            val store = StreamInformationStoreImpl().apply {
+                addRtpPayloadType(Vp8PayloadType(100, emptyMap(), emptySet()))
+            }
+            val tracker = IncomingStatisticsTracker(store)
+            repeat(n) { i ->
+                tracker.processPacket(PacketInfo(rtpPacket(i.toLong())).apply { receivedTime = Instant.EPOCH })
+            }
+            should("bound the number of tracked SSRCs") {
+                tracker.getSnapshot().ssrcStats.size shouldBe IncomingStatisticsTracker.MAX_SSRCS
+            }
+        }
+
+        context("DuplicateTermination") {
+            val node = DuplicateTermination()
+            repeat(n) { i -> node.processPacket(PacketInfo(rtpPacket(i.toLong()))) }
+            should("bound the number of tracked replay contexts") {
+                node.mapField("replayContexts").size shouldBe DuplicateTermination.MAX_SSRCS
+            }
+        }
+
+        context("DiscardableDiscarder") {
+            val node = DiscardableDiscarder("test", keepHistory = false)
+            repeat(n) { i -> node.processPacket(PacketInfo(rtpPacket(i.toLong()))) }
+            should("bound the number of tracked rewriters") {
+                node.rewriters.size shouldBe DiscardableDiscarder.MAX_SSRCS
+            }
+        }
+
+        context("AudioRedHandler") {
+            val handler = AudioRedHandler(StreamInformationStoreImpl(), StdoutLogger())
+            repeat(n) { i -> handler.processPacket(PacketInfo(audioPacket(i.toLong()))) }
+            should("bound the number of tracked RED handlers") {
+                handler.mapField("ssrcRedHandlers").size shouldBe AudioRedHandler.MAX_SSRCS
+            }
+        }
+
+        context("RetransmissionRequester") {
+            val scheduler = FakeScheduledExecutorService()
+            val requester = RetransmissionRequester({}, scheduler, StdoutLogger(), scheduler.clock)
+            repeat(n) { i -> requester.packetReceived(i.toLong(), 1) }
+            should("bound the number of tracked stream requesters") {
+                requester.mapField("streamPacketRequesters").size shouldBe RetransmissionRequester.MAX_SSRCS
+            }
+        }
+
+        context("RtcpRrGenerator") {
+            val scheduler = FakeScheduledExecutorService()
+            val store = StreamInformationStoreImpl()
+            val generator = RtcpRrGenerator(
+                scheduler,
+                {},
+                IncomingStatisticsTracker(store),
+                scheduler.clock
+            ) { emptyList() }
+            repeat(n) { i ->
+                val sr = RtcpSrPacketBuilder(
+                    RtcpHeaderBuilder(senderSsrc = i.toLong()),
+                    SenderInfoBuilder(rtpTimestamp = 12345L)
+                ).build()
+                generator.rtcpPacketReceived(sr, Instant.EPOCH)
+            }
+            should("bound the number of tracked sender infos") {
+                generator.mapField("senderInfos").size shouldBe RtcpRrGenerator.MAX_SSRCS
+            }
+        }
+    }
+
+    private fun rtpPacket(ssrcVal: Long, seq: Int = 1, pt: Int = 100): RtpPacket =
+        RtpPacket(ByteArray(50), 0, 50).apply {
+            version = 2
+            hasPadding = false
+            hasExtensions = false
+            isMarked = false
+            payloadType = pt
+            sequenceNumber = seq
+            timestamp = 456L
+            ssrc = ssrcVal
+        }
+
+    private fun audioPacket(ssrcVal: Long, seq: Int = 1, pt: Int = 111): AudioRtpPacket =
+        AudioRtpPacket(ByteArray(50), 0, 50).apply {
+            version = 2
+            hasPadding = false
+            hasExtensions = false
+            isMarked = false
+            payloadType = pt
+            sequenceNumber = seq
+            timestamp = 456L
+            ssrc = ssrcVal
+        }
+
+    /** Reads a private (possibly inherited) [Map] field by reflection, for asserting its size. */
+    private fun Any.mapField(name: String): Map<*, *> {
+        var cls: Class<*>? = this::class.java
+        while (cls != null) {
+            try {
+                val f = cls.getDeclaredField(name)
+                f.isAccessible = true
+                return f.get(this) as Map<*, *>
+            } catch (e: NoSuchFieldException) {
+                cls = cls.superclass
+            }
+        }
+        throw NoSuchFieldException(name)
+    }
+}

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/PerSsrcMapCapTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/PerSsrcMapCapTest.kt
@@ -40,7 +40,8 @@ import java.time.Instant
  */
 class PerSsrcMapCapTest : ShouldSpec() {
     init {
-        val n = 1000
+        // More than any of the caps, so the maps are driven to eviction.
+        val n = 2000
 
         context("IncomingStatisticsTracker") {
             val store = StreamInformationStoreImpl().apply {


### PR DESCRIPTION
Several per-SSRC tracking structures on the receive path grew without bound as new SSRCs were seen, with no cap or eviction. This bounds each with an LRU (1024 entries, access-order):

- `IncomingStatisticsTracker.ssrcStats`
- `DuplicateTermination.replayContexts`
- `RetransmissionRequester.streamPacketRequesters` (evicted requesters are stopped to cancel their scheduled tasks)
- `AudioRedHandler.ssrcRedHandlers` (evicted handlers are stopped to release cached buffers)
- `DiscardableDiscarder.rewriters`
- `RtcpRrGenerator.senderInfos`

The 1024 cap is a backstop: legitimate traffic keeps these maps small, so the limit only bounds pathological growth. It is deliberately high — well above the number of SSRCs a receiver tracks even in large or relayed conferences — so active SSRCs are never evicted under normal operation.

Thread-safety is preserved (`synchronizedMap` where the map was previously concurrent; existing external synchronization elsewhere).

Adds `PerSsrcMapCapTest` covering each bounded map.