### PR TITLE
ref: Only cache an SRTP/SRTCP decryption context after it authenticates

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/srtp/SrtpTransformer.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/srtp/SrtpTransformer.kt
@@ -45,6 +45,12 @@ abstract class AbstractSrtpTransformer<CryptoContextType : BaseSrtpCryptoContext
      */
     private val contexts: MutableMap<Long, CryptoContextType> = ConcurrentHashMap()
 
+    /**
+     * The number of SSRCs for which a crypto context is currently cached.
+     */
+    val numCachedContexts: Int
+        get() = synchronized(contexts) { contexts.size }
+
     fun close() {
         synchronized(contexts) {
             contextFactory.close()
@@ -52,20 +58,11 @@ abstract class AbstractSrtpTransformer<CryptoContextType : BaseSrtpCryptoContext
     }
 
     /**
-     * Gets the context for a specific SSRC and index.
+     * Whether a context that is derived on demand (because none was cached for the SSRC yet) should only be added to
+     * [contexts] after the first transform operation using it succeeds. This is used for decryption, so that we do not
+     * retain a context for an SSRC whose packets never successfully authenticate.
      */
-    protected fun getContext(ssrc: Long, index: Long): CryptoContextType? {
-        synchronized(contexts) {
-            contexts[ssrc]?.let { return it }
-
-            val derivedContext = deriveContext(ssrc, index) ?: run {
-                logger.warn("Failed to derive context for $ssrc $index")
-                return null
-            }
-            contexts[ssrc] = derivedContext
-            return derivedContext
-        }
-    }
+    protected open val cacheContextOnlyOnSuccessfulTransform: Boolean = false
 
     /**
      * Derives a new context for a specific SSRC and index.
@@ -73,23 +70,59 @@ abstract class AbstractSrtpTransformer<CryptoContextType : BaseSrtpCryptoContext
     protected abstract fun deriveContext(ssrc: Long, index: Long): CryptoContextType?
 
     /**
-     * Gets the context to use for a specific packet.
+     * Gets the SSRC and index (sequence number) to use for a specific packet, or null if it can not be handled.
      */
-    protected abstract fun getContext(packetInfo: PacketInfo): CryptoContextType?
+    protected abstract fun getSsrcAndIndex(packetInfo: PacketInfo): SsrcAndIndex?
 
     /**
-     * Does the actual transformation of a packet, with a specific context.
+     * Does the actual transformation of a packet, with a specific context. [isNewContext] indicates that the context was
+     * just derived and is not (yet) cached, which a transformer may use to force a full transform (e.g. to bypass the
+     * "skip decryption" optimization) so that the returned status reliably reflects whether the context is valid.
      */
-    protected abstract fun transform(packetInfo: PacketInfo, context: CryptoContextType): SrtpErrorStatus
+    protected abstract fun transform(
+        packetInfo: PacketInfo,
+        context: CryptoContextType,
+        isNewContext: Boolean
+    ): SrtpErrorStatus
 
     /**
      * Transforms a packet, returns [SrtpErrorStatus.OK] on success or another [SrtpErrorStatus] on failure.
      */
     fun transform(packetInfo: PacketInfo): SrtpErrorStatus {
-        val context = getContext(packetInfo) ?: return SrtpErrorStatus.FAIL
+        val ssrcAndIndex = getSsrcAndIndex(packetInfo) ?: return SrtpErrorStatus.FAIL
+        val ssrc = ssrcAndIndex.ssrc
 
-        return transform(packetInfo, context)
+        // Look up (or derive) the context under the lock. We must synchronize even the lookup because the map is not
+        // necessarily thread-safe (and an access-order map is structurally modified on read). The lock is only held
+        // for the lookup/derivation, not for the transform itself.
+        var isNewContext = false
+        val context = synchronized(contexts) {
+            contexts[ssrc] ?: run {
+                val derivedContext = deriveContext(ssrc, ssrcAndIndex.index) ?: run {
+                    logger.warn("Failed to derive context for $ssrc ${ssrcAndIndex.index}")
+                    return SrtpErrorStatus.FAIL
+                }
+                isNewContext = true
+                if (!cacheContextOnlyOnSuccessfulTransform) {
+                    contexts[ssrc] = derivedContext
+                }
+                derivedContext
+            }
+        }
+
+        val status = transform(packetInfo, context, isNewContext)
+        if (isNewContext && cacheContextOnlyOnSuccessfulTransform && status == SrtpErrorStatus.OK) {
+            synchronized(contexts) {
+                contexts.putIfAbsent(ssrc, context)
+            }
+        }
+        return status
     }
+
+    /**
+     * The SSRC and index (sequence number) identifying the context to use for a packet.
+     */
+    protected data class SsrcAndIndex(val ssrc: Long, val index: Long)
 }
 
 /**
@@ -103,12 +136,12 @@ abstract class SrtpTransformer(
     override fun deriveContext(ssrc: Long, index: Long): SrtpCryptoContext? =
         contextFactory.deriveContext(ssrc.toInt(), 0) ?: null
 
-    override fun getContext(packetInfo: PacketInfo): SrtpCryptoContext? {
+    override fun getSsrcAndIndex(packetInfo: PacketInfo): SsrcAndIndex? {
         val rtpPacket: RtpPacket = packetInfo.packet as? RtpPacket ?: run {
             logger.cwarn { "Can not handle non-RTP packet: ${packetInfo.packet.javaClass}" }
             return null
         }
-        return getContext(rtpPacket.ssrc, rtpPacket.sequenceNumber.toLong())
+        return SsrcAndIndex(rtpPacket.ssrc, rtpPacket.sequenceNumber.toLong())
     }
 }
 
@@ -123,12 +156,12 @@ abstract class SrtcpTransformer(
     override fun deriveContext(ssrc: Long, index: Long): SrtcpCryptoContext? =
         contextFactory.deriveControlContext(ssrc.toInt()) ?: null
 
-    override fun getContext(packetInfo: PacketInfo): SrtcpCryptoContext? {
+    override fun getSsrcAndIndex(packetInfo: PacketInfo): SsrcAndIndex? {
         // Contrary to RTP packets, RTCP packets do not get parsed before they are
         // decrypted. So (if this is a decrypting transformer) we are working with
         // an UnparsedPacket here and need to read the SSRC manually.
         val senderSsrc = RtcpHeader.getSenderSsrc(packetInfo.packet.getBuffer(), packetInfo.packet.getOffset())
-        return getContext(senderSsrc, 0)
+        return SsrcAndIndex(senderSsrc, 0)
     }
 }
 
@@ -140,7 +173,14 @@ class SrtcpDecryptTransformer(
     parentLogger: Logger
 ) : SrtcpTransformer(contextFactory, parentLogger) {
 
-    override fun transform(packetInfo: PacketInfo, context: SrtcpCryptoContext): SrtpErrorStatus {
+    // Only cache a derived context once it has successfully authenticated a packet.
+    override val cacheContextOnlyOnSuccessfulTransform = true
+
+    override fun transform(
+        packetInfo: PacketInfo,
+        context: SrtcpCryptoContext,
+        isNewContext: Boolean
+    ): SrtpErrorStatus {
         return context.reverseTransformPacket(packetInfo.packet).apply {
             packetInfo.resetPayloadVerification()
         }
@@ -156,7 +196,11 @@ class SrtcpEncryptTransformer(
     parentLogger: Logger
 ) : SrtcpTransformer(contextFactory, parentLogger) {
 
-    override fun transform(packetInfo: PacketInfo, context: SrtcpCryptoContext): SrtpErrorStatus {
+    override fun transform(
+        packetInfo: PacketInfo,
+        context: SrtcpCryptoContext,
+        isNewContext: Boolean
+    ): SrtpErrorStatus {
         return context.transformPacket(packetInfo.packet).apply {
             // We convert the encrypted RTCP packet to an UnparsedPacket because
             // we don't want any of the RTCP fields trying to parse the data
@@ -181,13 +225,18 @@ class SrtpDecryptTransformer(
     var earlyDiscardedPacketsSinceLastSuccess = 0
     private val alwaysProcess = maxConsecutivePacketsDiscardedEarly <= 0
 
-    override fun transform(packetInfo: PacketInfo, context: SrtpCryptoContext): SrtpErrorStatus {
+    // Only cache a derived context once it has successfully authenticated a packet.
+    override val cacheContextOnlyOnSuccessfulTransform = true
+
+    override fun transform(packetInfo: PacketInfo, context: SrtpCryptoContext, isNewContext: Boolean): SrtpErrorStatus {
         // We want to avoid authenticating and decrypting packets that we are going to discarded (e.g. silence). We
         // can not just discard them without passing them to the SRTP stack, because this will eventually break the ROC.
         // Here we bypass the SRTP stack for packets marked to be discarded, but make sure that we haven't dropped too
-        // many consecutive packets.
+        // many consecutive packets. We never bypass for a newly-derived context: it must actually decrypt (and thus
+        // authenticate) a packet before it is cached, so the returned status must reflect whether the context is valid.
         if (packetInfo.shouldDiscard) {
-            return if (alwaysProcess ||
+            return if (isNewContext ||
+                alwaysProcess ||
                 earlyDiscardedPacketsSinceLastSuccess++ > maxConsecutivePacketsDiscardedEarly
             ) {
                 doTransform(packetInfo, context)
@@ -217,7 +266,7 @@ class SrtpEncryptTransformer(
     parentLogger: Logger
 ) : SrtpTransformer(contextFactory, parentLogger) {
 
-    override fun transform(packetInfo: PacketInfo, context: SrtpCryptoContext): SrtpErrorStatus {
+    override fun transform(packetInfo: PacketInfo, context: SrtpCryptoContext, isNewContext: Boolean): SrtpErrorStatus {
         return context.transformPacket(packetInfo.packetAs()).apply {
             packetInfo.packet = packetInfo.packet.toOtherType(::UnparsedPacket)
             packetInfo.resetPayloadVerification()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/srtp/SrtpTransformer.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/srtp/SrtpTransformer.kt
@@ -26,10 +26,10 @@ import org.jitsi.srtp.SrtcpCryptoContext
 import org.jitsi.srtp.SrtpContextFactory
 import org.jitsi.srtp.SrtpCryptoContext
 import org.jitsi.srtp.SrtpErrorStatus
+import org.jitsi.utils.LRUCache
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.utils.logging2.cwarn
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Implements the methods common to all 4 transformer implementation (encrypt/decrypt for SRTP/SRTCP)
@@ -41,9 +41,13 @@ abstract class AbstractSrtpTransformer<CryptoContextType : BaseSrtpCryptoContext
     protected val logger = createChildLogger(parentLogger)
 
     /**
-     * All the known SSRC's corresponding SrtpCryptoContexts
+     * All the known SSRC's corresponding SrtpCryptoContexts. Bounded with an LRU to limit the number of SSRCs tracked;
+     * evicted contexts are simply dropped (their native cipher resources are freed by a [java.lang.ref.Cleaner], and
+     * the contexts hold no other state that needs explicit cleanup). All access is guarded by synchronizing on the map.
+     * Note that eviction resets the ROC and replay state for an SSRC, so the cap must be high enough that
+     * legitimately-active SSRCs are never evicted.
      */
-    private val contexts: MutableMap<Long, CryptoContextType> = ConcurrentHashMap()
+    private val contexts: MutableMap<Long, CryptoContextType> = LRUCache(MAX_SSRCS, true)
 
     /**
      * The number of SSRCs for which a crypto context is currently cached.
@@ -123,6 +127,11 @@ abstract class AbstractSrtpTransformer<CryptoContextType : BaseSrtpCryptoContext
      * The SSRC and index (sequence number) identifying the context to use for a packet.
      */
     protected data class SsrcAndIndex(val ssrc: Long, val index: Long)
+
+    companion object {
+        /** The maximum number of SSRCs to keep crypto contexts for. */
+        const val MAX_SSRCS = 1024
+    }
 }
 
 /**

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/SrtpTransformerNode.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/SrtpTransformerNode.kt
@@ -136,6 +136,7 @@ abstract class SrtpTransformerNode(name: String) : MultipleOutputTransformerNode
             addNumber("num_srtp_replay_fail", numSrtpReplayFail)
             addNumber("num_srtp_replay_old", numSrtpReplayOld)
             addNumber("num_srtp_invalid_packet", numSrtpInvalidPacket)
+            addNumber("num_cached_contexts", transformer?.numCachedContexts ?: 0)
         }
     }
 
@@ -146,6 +147,7 @@ abstract class SrtpTransformerNode(name: String) : MultipleOutputTransformerNode
         put("num_srtp_replay_fail", numSrtpReplayFail)
         put("num_srtp_replay_old", numSrtpReplayOld)
         put("num_srtp_invalid_packet", numSrtpInvalidPacket)
+        put("num_cached_contexts", transformer?.numCachedContexts ?: 0)
     }
 
     override fun stop() {

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/SrtpDecryptTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/SrtpDecryptTest.kt
@@ -64,6 +64,9 @@ internal class SrtpDecryptTest : ShouldSpec() {
             }
         }
 
+        // Note: we don't test that the context map is bounded by its LRU cap (AbstractSrtpTransformer.MAX_SSRCS),
+        // because contexts are only cached once they authenticate a packet, so driving the map to eviction would
+        // require generating authenticating packets for that many distinct SSRCs, which the single-key sample can't do.
         context("receiving RTP packets that fail to authenticate") {
             val decryptTransformer = srtpTransformers.srtpDecryptTransformer
 

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/SrtpDecryptTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/SrtpDecryptTest.kt
@@ -26,6 +26,7 @@ import org.jitsi.nlj.resources.logging.StdoutLogger
 import org.jitsi.nlj.resources.srtp_samples.SrtpSample
 import org.jitsi.nlj.srtp.SrtpUtil
 import org.jitsi.nlj.test_utils.matchers.ByteArrayBuffer.haveSameContentAs
+import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.srtp.SrtpErrorStatus
 
 internal class SrtpDecryptTest : ShouldSpec() {
@@ -62,5 +63,55 @@ internal class SrtpDecryptTest : ShouldSpec() {
                 decryptedPacket should haveSameContentAs(SrtpSample.expectedDecryptedRtpPacket)
             }
         }
+
+        context("receiving RTP packets that fail to authenticate") {
+            val decryptTransformer = srtpTransformers.srtpDecryptTransformer
+
+            should("not cache a context for an SSRC that never authenticates") {
+                repeat(5) {
+                    val packetInfo = PacketInfo(corruptAuthTag(SrtpSample.incomingEncryptedRtpPacket.clone()))
+                    decryptTransformer.transform(packetInfo) shouldNotBe SrtpErrorStatus.OK
+                }
+                decryptTransformer.numCachedContexts shouldBe 0
+            }
+
+            should("cache a context once a packet authenticates") {
+                // A failed packet leaves no state behind.
+                val failed = PacketInfo(corruptAuthTag(SrtpSample.incomingEncryptedRtpPacket.clone()))
+                decryptTransformer.transform(failed) shouldNotBe SrtpErrorStatus.OK
+                decryptTransformer.numCachedContexts shouldBe 0
+
+                // The first successful decryption for the SSRC caches the context.
+                val succeeded = PacketInfo(SrtpSample.incomingEncryptedRtpPacket.clone())
+                decryptTransformer.transform(succeeded) shouldBe SrtpErrorStatus.OK
+                decryptTransformer.numCachedContexts shouldBe 1
+            }
+        }
+
+        context("receiving SRTCP packets that fail to authenticate") {
+            val decryptTransformer = srtpTransformers.srtcpDecryptTransformer
+
+            should("not cache a context for an SSRC that never authenticates") {
+                repeat(5) {
+                    val packet = SrtpSample.incomingEncryptedRtcpPacket.clone()
+                    packet.buffer[packet.offset + packet.length - 1]++
+                    decryptTransformer.transform(PacketInfo(packet)) shouldNotBe SrtpErrorStatus.OK
+                }
+                decryptTransformer.numCachedContexts shouldBe 0
+            }
+
+            should("cache a context once a packet authenticates") {
+                decryptTransformer.transform(PacketInfo(SrtpSample.incomingEncryptedRtcpPacket.clone())) shouldBe
+                    SrtpErrorStatus.OK
+                decryptTransformer.numCachedContexts shouldBe 1
+            }
+        }
+    }
+
+    /**
+     * Corrupts the authentication tag (the last byte) of an encrypted RTP packet so that it will fail to authenticate.
+     */
+    private fun corruptAuthTag(packet: RtpPacket): RtpPacket = packet.apply {
+        buffer[offset + length - 1]++
     }
 }


### PR DESCRIPTION
## Problem

An SRTP/SRTCP crypto context was derived and added to the per-SSRC context map on the *first packet* seen for an SSRC, before any packet had authenticated. For the decryption transformers this meant a context was retained for an SSRC whose packets never successfully authenticate.

## Change

`AbstractSrtpTransformer` now commits a newly-derived context to the map only after the first transform using it succeeds. This is gated by a new `cacheContextOnlyOnSuccessfulTransform` flag, which the two decryption transformers (`SrtpDecryptTransformer`, `SrtcpDecryptTransformer`) enable; the encryption transformers keep caching on derivation as before.

Details:
- The context lookup/derivation and the deferred `putIfAbsent` are both done under `synchronized(contexts)`; the transform itself still runs outside the lock.
- A newly-derived decryption context always performs a full decrypt/authenticate instead of taking the `shouldDiscard` "skip decryption" bypass, so the returned status reliably reflects whether the context is valid — otherwise a discardable packet could report `OK` without authenticating and cause an unvalidated context to be cached. This is folded into the existing bypass condition via an `isNewContext` flag threaded through `transform()`.

## Bounding the context map

The context map is also capped at `MAX_SSRCS` (1024) with an access-order LRU, so the number of SSRCs tracked for a stream stays limited. Evicted contexts are dropped; their native cipher resources are freed by a `Cleaner`, and they hold no other state needing explicit cleanup. All context-map access is synchronized on the map (which the non-thread-safe `LRUCache` requires). This was previously part of #2428 and moved here since it overlaps with the deferred-caching change to the same map.

## Observability

Adds `numCachedContexts` to the transformer, reported as `num_cached_contexts` in `SrtpTransformerNode`'s node stats and `statsJson`.

## Tests

Adds cases to `SrtpDecryptTest` (for both SRTP and SRTCP decrypt) asserting that packets which fail to authenticate leave no cached context, and that the first packet that authenticates results in exactly one cached context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
