### PR TITLE
feat: Export sender-reported audio level and VAD in mediajson media events

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
@@ -154,6 +154,19 @@ open class PacketInfo @JvmOverloads constructor(
     var payloadType: PayloadType? = null
 
     /**
+     * The RFC 6464 audio level (0-127, i.e. -dBov: 0 is loudest, 127 is silence) reported by the sender in the
+     * ssrc-audio-level RTP header extension, or null if the packet had no such extension. Populated on the incoming
+     * path by [org.jitsi.nlj.transform.node.incoming.AudioLevelReader].
+     */
+    var audioLevel: Int? = null
+
+    /**
+     * The RFC 6464 Voice Activity Detection flag reported by the sender in the ssrc-audio-level RTP header extension,
+     * or null if the packet had no such extension. Populated alongside [audioLevel].
+     */
+    var vad: Boolean? = null
+
+    /**
      * The payload verification string for the packet, or 'null' if payload verification is disabled. Calculating the
      * it is expensive, thus we only do it when the flag is enabled.
      */
@@ -198,6 +211,8 @@ open class PacketInfo @JvmOverloads constructor(
         clone.shouldDiscard = shouldDiscard
         clone.endpointId = endpointId
         clone.payloadType = payloadType
+        clone.audioLevel = audioLevel
+        clone.vad = vad
         clone.layeringChanged = layeringChanged
         clone.payloadVerification = payloadVerification
         clone.probingInfo = probingInfo

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/AudioLevelReader.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/AudioLevelReader.kt
@@ -70,9 +70,16 @@ class AudioLevelReader(
                     stats.audioLevel()
 
                     val level = AudioLevelHeaderExtension.getAudioLevel(ext)
+                    val vad = AudioLevelHeaderExtension.getVad(ext)
                     val silence = level == MUTED_LEVEL
 
-                    if (!silence) stats.nonSilence(AudioLevelHeaderExtension.getVad(ext))
+                    // Preserve the sender-reported level and VAD flag on the PacketInfo so downstream consumers (e.g.
+                    // the mediajson Exporter) can forward them without re-parsing the header extension (they don't have
+                    // the extension ID mapping).
+                    packetInfo.audioLevel = level
+                    packetInfo.vad = vad
+
+                    if (!silence) stats.nonSilence(vad)
                     if (silence && discardSilence && forwardedSilencePackets > forwardedSilencePacketsLimit) {
                         packetInfo.shouldDiscard = true
                         stats.discardedSilence()

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/MediaJsonSerializer.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/MediaJsonSerializer.kt
@@ -89,7 +89,7 @@ class MediaJsonSerializer(
             handleEvent(createStart(state.tag, epId, payloadType))
         }
 
-        handleEvent(encodeMedia(p, state))
+        handleEvent(encodeMedia(p, state, packetInfo.audioLevel, packetInfo.vad))
     }
 
     private fun createSsrcState(initialRtpTimestamp: Long, payloadType: PayloadType, tag: String): SsrcState {
@@ -117,7 +117,7 @@ class MediaJsonSerializer(
     )
 
     @OptIn(ExperimentalEncodingApi::class)
-    private fun encodeMedia(p: AudioRtpPacket, state: SsrcState): Event {
+    private fun encodeMedia(p: AudioRtpPacket, state: SsrcState, audioLevel: Int?, vad: Boolean?): Event {
         ++seq
         return MediaEvent(
             seq,
@@ -125,7 +125,9 @@ class MediaJsonSerializer(
                 state.tag,
                 state.getSequenceNumber(p.sequenceNumber),
                 state.getTimestamp(p.timestamp),
-                Base64.encode(p.buffer, p.payloadOffset, p.payloadOffset + p.payloadLength)
+                Base64.encode(p.buffer, p.payloadOffset, p.payloadOffset + p.payloadLength),
+                audioLevel,
+                vad
             )
         )
     }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <junit.version>5.13.4</junit.version>
         <junit.platform.version>1.13.4</junit.platform.version>
         <jitsi.utils.version>1.0-150-g4ab9a3b</jitsi.utils.version>
-        <jicoco.version>1.1-173-g1e2216b</jicoco.version>
+        <jicoco.version>1.1-174-g4b9e48e</jicoco.version>
         <mockk.version>1.14.5</mockk.version>
         <ktlint-maven-plugin.version>3.2.0</ktlint-maven-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>


### PR DESCRIPTION
Forwards each audio frame's sender-reported RFC 6464 audio level and VAD flag to the transcription/translation peer (opus-transcriber-proxy) in the mediajson `media` events.

- `AudioLevelReader` already parses the ssrc-audio-level header extension on the incoming path (it has the extension-ID mapping); it now stores the level and VAD flag on the `PacketInfo` (preserved across clones), next to `endpointId`/`payloadType`.
- `MediaJsonSerializer` reads them off the `PacketInfo` and includes them in the outgoing `media` events. It does not re-parse the header extension itself (it's conference-wide and has no per-endpoint extension-ID mapping).
- Populated only for packets that carried the extension; otherwise the fields are null and omitted from the wire.

Motivation: lets the proxy gate on speech and avoid sending silence to paid STT backends, and lets us measure how reliable the sender's VAD flag actually is.

Depends on the new `Media` fields in jitsi/jicoco#237 (same branch name, built together by CI). Merge jicoco first, then bump the released `jicoco.version` here.