### PR TITLE
feat: set per-endpoint diarize on the transcriber start event

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -288,7 +288,8 @@ public class Conference
                 handleMediaMessage(m);
                 return Unit.INSTANCE;
             },
-            ssrc -> getAudioSourceName(ssrc));
+            ssrc -> getAudioSourceName(ssrc),
+            ssrc -> getDiarize(ssrc));
         this.id = Objects.requireNonNull(id, "id");
         this.conferenceName = conferenceName;
         this.colibri2Handler = new Colibri2ConferenceHandler(this, logger);
@@ -763,6 +764,7 @@ public class Conference
      * transport will be initialized to serve as a controlling ICE agent;
      * otherwise, {@code false}
      * @param doSsrcRewriting whether this endpoint signaled SSRC rewriting support.
+     * @param diarize whether diarization is requested for this endpoint's audio (colibri2 {@code diarize} attribute).
      * @return an <tt>Endpoint</tt> participating in this <tt>Conference</tt>
      */
     @NotNull
@@ -772,7 +774,8 @@ public class Conference
             boolean doSsrcRewriting,
             boolean doMidDemux,
             boolean visitor,
-            boolean privateAddresses)
+            boolean privateAddresses,
+            boolean diarize)
     {
         final AbstractEndpoint existingEndpoint = getEndpoint(id);
         if (existingEndpoint != null)
@@ -781,7 +784,7 @@ public class Conference
         }
 
         final Endpoint endpoint = new Endpoint(
-                id, this, logger, iceControlling, doSsrcRewriting, doMidDemux, visitor, privateAddresses);
+                id, this, logger, iceControlling, doSsrcRewriting, doMidDemux, visitor, privateAddresses, diarize);
         videobridge.localEndpointCreated(visitor);
 
         endpoint.addEventHandler(() -> endpointSourcesChanged(endpoint));
@@ -1118,6 +1121,17 @@ public class Conference
         }
         AudioSourceDesc source = endpoint.getAudioSource(ssrc);
         return source != null ? source.getSourceName() : null;
+    }
+
+    /**
+     * Resolves an audio SSRC to whether diarization is requested for its owning endpoint (the colibri2 {@code diarize}
+     * attribute), defaulting to {@code false} if the SSRC's endpoint is not known. Used by the exporter to set the
+     * {@code diarize} flag on the transcriber start event per source.
+     */
+    private boolean getDiarize(long ssrc)
+    {
+        AbstractEndpoint endpoint = getEndpointBySsrc(ssrc);
+        return endpoint != null && endpoint.getDiarize();
     }
 
     /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/AbstractEndpoint.kt
@@ -176,6 +176,14 @@ abstract class AbstractEndpoint protected constructor(
     abstract val visitor: Boolean
 
     /**
+     * Whether diarization is requested for this endpoint's audio, as signaled via the colibri2 `diarize` attribute.
+     * Propagated to the transcriber via the mediajson start event. Defaults to false for endpoint types that don't
+     * signal it (e.g. relayed endpoints).
+     */
+    open val diarize: Boolean
+        get() = false
+
+    /**
      * Gets the description of the video [MediaSourceDesc] that this endpoint has advertised, or `null` if
      * it hasn't advertised any video sources.
      */

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -127,6 +127,10 @@ class Endpoint @JvmOverloads constructor(
      */
     override val visitor: Boolean,
     supportsPrivateAddresses: Boolean,
+    /**
+     * Whether diarization is requested for this endpoint's audio, as signaled via the colibri2 `diarize` attribute.
+     */
+    override val diarize: Boolean,
     private val clock: Clock = Clock.systemUTC()
 ) : AbstractEndpoint(conference, id, parentLogger),
     PotentialPacketHandler,
@@ -1066,6 +1070,7 @@ class Endpoint @JvmOverloads constructor(
         put("accept_audio", acceptAudio)
         put("accept_video", acceptVideo)
         put("visitor", visitor)
+        put("diarize", diarize)
         set<ObjectNode>("message_transport", messageTransport.debugState)
         if (doSsrcRewriting) {
             set<ObjectNode>("audio_ssrcs", audioSsrcs.getDebugState())

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/colibri2/Colibri2ConferenceHandler.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/colibri2/Colibri2ConferenceHandler.kt
@@ -187,7 +187,8 @@ class Colibri2ConferenceHandler(
                 ssrcRewriting,
                 midDemux,
                 c2endpoint.mucRole == MUCRole.visitor,
-                privateAddresses
+                privateAddresses,
+                c2endpoint.diarize == true
             ).apply {
                 c2endpoint.statsId?.let {
                     statsId = it

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
@@ -63,6 +63,8 @@ internal class Exporter(
     private val handleMediaEvent: ((MediaEvent) -> Unit),
     /** Resolves an audio SSRC to its source name, used to filter outbound audio by this connect's exports. */
     private val getAudioSourceName: (Long) -> String?,
+    /** Resolves an audio SSRC to whether diarization is requested for its endpoint (colibri2 `diarize` attribute). */
+    private val getDiarize: (Long) -> Boolean,
     private val pingEnabled: Boolean = false,
     private val pingIntervalMs: Int = 0,
     private val pingTimeoutMs: Int = 0,
@@ -165,7 +167,7 @@ internal class Exporter(
 
     private var serializer: MediaJsonSerializer? = null
 
-    private fun initSerializer() = MediaJsonSerializer(getAudioSourceName) {
+    private fun initSerializer() = MediaJsonSerializer(getAudioSourceName, getDiarize) {
         val session = recorderWebSocket.session
         if (session != null) {
             session.sendText(it.toJson(), Callback.NOOP)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/ExporterWrapper.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/ExporterWrapper.kt
@@ -36,6 +36,8 @@ class ExporterWrapper internal constructor(
     private val handleMediaEvent: ((MediaEvent) -> Unit),
     /** Resolves an audio SSRC to its source name, used to filter outbound audio by a connect's exports. */
     private val getAudioSourceName: (Long) -> String?,
+    /** Resolves an audio SSRC to whether diarization is requested for its endpoint (colibri2 `diarize` attribute). */
+    private val getDiarize: (Long) -> Boolean,
     /** Creates (and starts) the [Exporter] for a connect. Overridable for testing; defaults to the real one. */
     exporterFactory: ((Connect) -> Exporter)?
 ) {
@@ -43,8 +45,9 @@ class ExporterWrapper internal constructor(
         parentLogger: Logger,
         handleTranscriptionResult: ((TranscriptionResultEvent) -> Unit),
         handleMediaEvent: ((MediaEvent) -> Unit),
-        getAudioSourceName: (Long) -> String?
-    ) : this(parentLogger, handleTranscriptionResult, handleMediaEvent, getAudioSourceName, null)
+        getAudioSourceName: (Long) -> String?,
+        getDiarize: (Long) -> Boolean
+    ) : this(parentLogger, handleTranscriptionResult, handleMediaEvent, getAudioSourceName, getDiarize, null)
 
     val logger = createChildLogger(parentLogger)
 
@@ -220,6 +223,7 @@ class ExporterWrapper internal constructor(
             handleTranscriptionResult,
             handleMediaEvent,
             getAudioSourceName,
+            getDiarize,
             pingEnabled,
             pingIntervalMs,
             pingTimeoutMs,

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/MediaJsonSerializer.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/MediaJsonSerializer.kt
@@ -43,6 +43,8 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 class MediaJsonSerializer(
     /** Resolves an audio SSRC to its source name, which is used as the media-json tag. */
     private val getSourceName: (Long) -> String?,
+    /** Resolves an audio SSRC to whether diarization is requested for its endpoint (colibri2 `diarize` attribute). */
+    private val getDiarize: (Long) -> Boolean,
     /** Encoded mediajson events are sent to this function */
     private val handleEvent: (Event) -> Unit
 ) {
@@ -78,7 +80,7 @@ class MediaJsonSerializer(
             state = createSsrcState(p.timestamp, payloadType, tag)
             ssrcsStarted[p.ssrc] = state
             logger.info("Starting SSRC ${p.ssrc} for endpoint $epId ")
-            handleEvent(createStart(tag, epId, payloadType))
+            handleEvent(createStart(tag, epId, payloadType, p.ssrc))
         }
 
         if (payloadType.pt != state.payloadType.pt) {
@@ -86,7 +88,7 @@ class MediaJsonSerializer(
             // An SSRC's source name doesn't change, so the new state (announced by a new start event) keeps the tag.
             state = createSsrcState(p.timestamp, payloadType, state.tag)
             ssrcsStarted[p.ssrc] = state
-            handleEvent(createStart(state.tag, epId, payloadType))
+            handleEvent(createStart(state.tag, epId, payloadType, p.ssrc))
         }
 
         handleEvent(encodeMedia(p, state))
@@ -102,7 +104,7 @@ class MediaJsonSerializer(
         )
     }
 
-    private fun createStart(tag: String, epId: String, payloadType: PayloadType) = StartEvent(
+    private fun createStart(tag: String, epId: String, payloadType: PayloadType, ssrc: Long) = StartEvent(
         ++seq,
         Start(
             tag,
@@ -112,7 +114,10 @@ class MediaJsonSerializer(
                 (payloadType as? AudioPayloadType)?.channels ?: 1,
                 payloadType.parameters
             ),
-            CustomParameters(endpointId = epId)
+            CustomParameters(endpointId = epId),
+            // Only set the flag when diarization is on; when off, leave it null so the field is omitted from the wire
+            // format (jackson drops nulls) and the transcriber proxy falls back to its global config.
+            diarize = if (getDiarize(ssrc)) true else null
         )
     )
 

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/ConferenceTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/ConferenceTest.kt
@@ -36,7 +36,7 @@ class ConferenceTest : ConfigTest() {
             with(Conference(videobridge, "id", name, null, false)) {
                 endpointCount shouldBe 0
                 // TODO cover the case when they're true
-                createLocalEndpoint("abcdabcd", true, false, false, false, false)
+                createLocalEndpoint("abcdabcd", true, false, false, false, false, false)
                 endpointCount shouldBe 1
                 DebugStateMode.entries.forEach { mode ->
                     getDebugState(mode, null).shouldBeValidJsonConf()

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/export/ExporterWrapperTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/export/ExporterWrapperTest.kt
@@ -34,7 +34,7 @@ class ExporterWrapperTest : ShouldSpec() {
     /** Records the mock [Exporter] created for each connect id, so tests can verify calls against them. */
     private inner class Fixture {
         val exporters = mutableMapOf<String, Exporter>()
-        val wrapper = ExporterWrapper(logger, { }, { }, { null }) { connect ->
+        val wrapper = ExporterWrapper(logger, { }, { }, { null }, { false }) { connect ->
             mockk<Exporter>(relaxed = true).also { exporters[connect.id] = it }
         }
         operator fun get(id: String): Exporter = exporters.getValue(id)

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/export/MediaJsonSerializerTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/export/MediaJsonSerializerTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright @ 2024 - Present, 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.export
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.jitsi.mediajson.Event
+import org.jitsi.mediajson.StartEvent
+import org.jitsi.nlj.PacketInfo
+import org.jitsi.nlj.format.OpusPayloadType
+import org.jitsi.nlj.rtp.AudioRtpPacket
+
+class MediaJsonSerializerTest : ShouldSpec() {
+    init {
+        context("The diarize flag on the start event") {
+            should("be set to true when the resolver returns true for the source's SSRC") {
+                val startEvent = capturedEvents(diarize = true).filterIsInstance<StartEvent>().single()
+                startEvent.start.diarize shouldBe true
+                startEvent.toJson().shouldContain("diarize")
+            }
+            should("be omitted (null) when the resolver returns false") {
+                val startEvent = capturedEvents(diarize = false).filterIsInstance<StartEvent>().single()
+                startEvent.start.diarize shouldBe null
+                // With NON_NULL inclusion, a null diarize must not appear on the wire, so the transcriber falls back
+                // to its global config.
+                startEvent.toJson().shouldNotContain("diarize")
+            }
+        }
+    }
+
+    /** Runs a single audio packet through a serializer and returns the events it emitted. */
+    private fun capturedEvents(diarize: Boolean): List<Event> {
+        val events = mutableListOf<Event>()
+        val serializer = MediaJsonSerializer(
+            getSourceName = { "source-1" },
+            getDiarize = { diarize }
+        ) { events.add(it) }
+        serializer.encode(audioPacketInfo(ssrc = 12345L, epId = "endpoint-1"))
+        return events
+    }
+
+    private fun audioPacketInfo(ssrc: Long, epId: String): PacketInfo {
+        val packet = AudioRtpPacket(ByteArray(1500), 0, 100).apply {
+            this.ssrc = ssrc
+            sequenceNumber = 1
+            timestamp = 1000L
+        }
+        return PacketInfo(packet).apply {
+            endpointId = epId
+            payloadType = OpusPayloadType(111)
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <junit.version>5.13.4</junit.version>
         <junit.platform.version>1.13.4</junit.platform.version>
         <jitsi.utils.version>1.0-150-g4ab9a3b</jitsi.utils.version>
-        <jicoco.version>1.1-173-g1e2216b</jicoco.version>
+        <jicoco.version>1.1-175-g8047337</jicoco.version>
         <mockk.version>1.14.5</mockk.version>
         <ktlint-maven-plugin.version>3.2.0</ktlint-maven-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
@@ -144,7 +144,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-xmpp-extensions</artifactId>
-                <version>1.0-115-gd0c3cd0</version>
+                <version>1.0-116-gc47d314</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Reads the per-endpoint `diarize` attribute that jicofo sets on the COLIBRI v2 endpoint and applies it to the transcriber `start` event for that endpoint's audio, so diarization can be enabled per endpoint (multi-speaker endpoints such as room systems and dial-in) instead of only globally.

`Colibri2ConferenceHandler` reads the attribute and stores it on the `Endpoint` (create-time, like `visitor` / `ssrcRewriting`). A `diarize` resolver (ssrc → endpoint) is threaded through `ExporterWrapper` → `Exporter` → `MediaJsonSerializer`, mirroring the existing source-name lambda; `createStart` sets `diarize = true` only when enabled, else null (omitted from the wire, so the proxy falls back to its global config).

Part of a multi-repo change. The four Maven repos share the branch `diarization-endpoint-control` so CI builds them together; no dependency version bumps are included (they follow after jitsi-xmpp-extensions and jicoco are released).

---

**Related PRs** (per-endpoint speaker diarization, multi-repo):
- jitsi-meet: jitsi/jitsi-meet#17614
- jitsi-xmpp-extensions: jitsi/jitsi-xmpp-extensions#145
- jicoco: jitsi/jicoco#238
- jicofo: jitsi/jicofo#1291
- jitsi-videobridge: jitsi/jitsi-videobridge#2431
- opus-transcriber-proxy: jitsi/opus-transcriber-proxy#106
