### PR TITLE
Support in-place ICE restart on an established transport

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/ice/IceConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/ice/IceConfig.kt
@@ -70,6 +70,15 @@ class IceConfig private constructor() {
         "videobridge.ice.advertise-private-candidates".from(JitsiConfig.newConfig)
     )
 
+    /**
+     * Whether in-place ICE restarts are enabled: when an endpoint sends new remote ICE credentials for an
+     * already-established transport, apply them to the existing ice4j Agent and re-run connectivity checks,
+     * instead of ignoring the update.
+     */
+    val restartEnabled: Boolean by config(
+        "videobridge.ice.restart.enabled".from(JitsiConfig.newConfig)
+    )
+
     companion object {
         @JvmField
         val config = IceConfig()

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
@@ -167,7 +167,18 @@ class IceTransport @JvmOverloads constructor(
             return
         }
         if (iceAgent.state.isEstablished) {
-            logger.cdebug { "Connection already established" }
+            // If the remote peer rotated its ICE credentials (new remote ufrag) while our Agent is established,
+            // this is a peer-initiated in-place ICE restart. Apply the new remote credentials to the existing
+            // Agent and re-run checks, rather than ignoring the update.
+            val newUfrag = transportPacketExtension.ufrag
+            val newPassword = transportPacketExtension.password
+            if (IceConfig.config.restartEnabled &&
+                newUfrag != null && newPassword != null && newUfrag != iceStream.remoteUfrag
+            ) {
+                restartIce(transportPacketExtension)
+            } else {
+                logger.cdebug { "Connection already established" }
+            }
             return
         }
         logger.cdebug { "Starting ICE connectivity establishment" }
@@ -218,6 +229,32 @@ class IceTransport @JvmOverloads constructor(
         } else {
             logger.cdebug { "Not starting ICE, no ufrag and pwd yet. ${transportPacketExtension.toXML()}" }
         }
+    }
+
+    /**
+     * Performs an in-place ICE restart: the remote peer rotated its ICE credentials while our local credentials
+     * and the ice4j [Agent] stay the same. Apply the new remote ufrag/password (and any signalled candidates —
+     * normally none, as clients rely on peer-reflexive discovery) and ask ice4j to re-run connectivity checks on
+     * the existing Agent. The currently selected pair keeps being used for sending until a new pair is nominated
+     * (make-before-break), so media is not interrupted.
+     */
+    private fun restartIce(transportPacketExtension: IceUdpTransportPacketExtension) {
+        logger.info(
+            "Performing in-place ICE restart, new remote ufrag=${transportPacketExtension.ufrag} " +
+                "(old=${iceStream.remoteUfrag})"
+        )
+
+        iceStream.remoteUfrag = transportPacketExtension.ufrag
+        iceStream.remotePassword = transportPacketExtension.password
+
+        // Add any signalled remote candidates to the (to-be-rebuilt) check list before restarting. Pass
+        // iceAgentIsRunning=false so they are added as fresh remote candidates; restartIce() below rebuilds the
+        // check list and moves the Agent back to RUNNING. New peer-reflexive addresses (e.g. after a real
+        // network change) are discovered from the incoming checks as usual.
+        val remoteCandidates = transportPacketExtension.getChildExtensionsOfType(CandidatePacketExtension::class.java)
+        addRemoteCandidates(remoteCandidates, iceAgentIsRunning = false)
+
+        iceAgent.restartIce()
     }
 
     fun startReadingData() {

--- a/jvb/src/main/resources/reference.conf
+++ b/jvb/src/main/resources/reference.conf
@@ -315,6 +315,13 @@ videobridge {
     # addresses even for endpoints that have not signaled support for private addresses.
     # Note: Jicofo signals support for private addresses for jigasi and jibri.
     advertise-private-candidates = true
+
+    # In-place ICE restarts: when an endpoint sends new remote ICE credentials for an already-established
+    # transport, apply them to the existing ice4j Agent and re-run connectivity checks, keeping our local
+    # credentials and the selected pair (make-before-break) instead of ignoring the update.
+    restart {
+        enabled = true
+    }
   }
 
   transport {


### PR DESCRIPTION
## Summary

When an endpoint's remote ICE credentials change on a transport that is already established, apply them
to the existing ice4j Agent and re-run connectivity checks, instead of ignoring the update.

Local credentials and the ice4j Agent are unchanged; the endpoint does not need a new transport. The
Agent keeps the currently selected pair in use for sending until a new pair is nominated, so media is not
interrupted.

Gated by `videobridge.ice.restart.enabled` (default true).

Depends on ice4j's `Agent.restartIce()` (jitsi/ice4j#310, same branch name `ice-restart`); requires a
matching ice4j release before the `pom.xml` dependency version can be bumped.

Companion client-side change: jitsi/lib-jitsi-meet (same branch name, `ice-restart`).
