### PR TITLE
ref: Take an ExporterEventHandler interface instead of a series of closures

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -280,20 +280,38 @@ public class Conference
         logger = new LoggerImpl(Conference.class.getName(), new LogContext(context));
         exporter = new ExporterWrapper(
             logger,
-            j -> {
-                handleTranscriptionMessage(j);
-                return Unit.INSTANCE;
-            },
-            m -> {
-                handleMediaMessage(m);
-                return Unit.INSTANCE;
-            },
-            (sourceName, sending, timestamp) -> {
-                handleSyntheticSourceSendingChange(sourceName, sending, timestamp);
-                return Unit.INSTANCE;
-            },
-            ssrc -> getAudioSourceName(ssrc),
-            ssrc -> getDiarize(ssrc));
+            new ExporterEventHandler()
+            {
+                @Override
+                public void handleTranscriptionResult(TranscriptionResultEvent event)
+                {
+                    handleTranscriptionMessage(event);
+                }
+
+                @Override
+                public void handleMediaEvent(MediaEvent event)
+                {
+                    handleMediaMessage(event);
+                }
+
+                @Override
+                public void handleSendingChange(String sourceName, boolean sending, long timestamp)
+                {
+                    handleSyntheticSourceSendingChange(sourceName, sending, timestamp);
+                }
+
+                @Override
+                public String getAudioSourceName(long ssrc)
+                {
+                    return Conference.this.getAudioSourceName(ssrc);
+                }
+
+                @Override
+                public boolean getDiarize(long ssrc)
+                {
+                    return Conference.this.getDiarize(ssrc);
+                }
+            });
         this.id = Objects.requireNonNull(id, "id");
         this.conferenceName = conferenceName;
         this.colibri2Handler = new Colibri2ConferenceHandler(this, logger);

--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -278,40 +278,7 @@ public class Conference
         }
 
         logger = new LoggerImpl(Conference.class.getName(), new LogContext(context));
-        exporter = new ExporterWrapper(
-            logger,
-            new ExporterEventHandler()
-            {
-                @Override
-                public void handleTranscriptionResult(TranscriptionResultEvent event)
-                {
-                    handleTranscriptionMessage(event);
-                }
-
-                @Override
-                public void handleMediaEvent(MediaEvent event)
-                {
-                    handleMediaMessage(event);
-                }
-
-                @Override
-                public void handleSendingChange(String sourceName, boolean sending, long timestamp)
-                {
-                    handleSyntheticSourceSendingChange(sourceName, sending, timestamp);
-                }
-
-                @Override
-                public String getAudioSourceName(long ssrc)
-                {
-                    return Conference.this.getAudioSourceName(ssrc);
-                }
-
-                @Override
-                public boolean getDiarize(long ssrc)
-                {
-                    return Conference.this.getDiarize(ssrc);
-                }
-            });
+        exporter = new ExporterWrapper(logger, new ExporterEventHandlerImpl());
         this.id = Objects.requireNonNull(id, "id");
         this.conferenceName = conferenceName;
         this.colibri2Handler = new Colibri2ConferenceHandler(this, logger);
@@ -1130,33 +1097,6 @@ public class Conference
     }
 
     /**
-     * Resolves an audio SSRC to the name of the source it belongs to, or {@code null} if it is not known. Used by the
-     * exporter to filter outbound audio by a connect's exported source names.
-     */
-    @Nullable
-    private String getAudioSourceName(long ssrc)
-    {
-        AbstractEndpoint endpoint = getEndpointBySsrc(ssrc);
-        if (endpoint == null)
-        {
-            return null;
-        }
-        AudioSourceDesc source = endpoint.getAudioSource(ssrc);
-        return source != null ? source.getSourceName() : null;
-    }
-
-    /**
-     * Resolves an audio SSRC to whether diarization is requested for its owning endpoint (the colibri2 {@code diarize}
-     * attribute), defaulting to {@code false} if the SSRC's endpoint is not known. Used by the exporter to set the
-     * {@code diarize} flag on the transcriber start event per source.
-     */
-    private boolean getDiarize(long ssrc)
-    {
-        AbstractEndpoint endpoint = getEndpointBySsrc(ssrc);
-        return endpoint != null && endpoint.getDiarize();
-    }
-
-    /**
      * Whether the packet belongs to a synthetic source (bridge-generated audio, e.g. translated audio). Such packets
      * are exempt from echo-suppression in {@link #sendOut}: a synthetic source is delivered purely by audio
      * subscription, including to its owner endpoint, on every bridge.
@@ -1587,145 +1527,187 @@ public class Conference
     }
 
     /**
-     * Handles transcription messages received from the websocket.
-     *
-     * @param transcriptionMessage the transcription message as JsonNode
+     * The conference's implementation of the {@link ExporterEventHandler} callbacks the {@link ExporterWrapper}
+     * invokes: sinks for the events a peer sends back over an export websocket, plus the SSRC lookups used to
+     * filter and annotate exported audio. A non-static inner class, so the callbacks reach the conference's state
+     * directly.
      */
-    private void handleTranscriptionMessage(TranscriptionResultEvent transcriptionMessage)
+    private class ExporterEventHandlerImpl implements ExporterEventHandler
     {
-        try
+        /**
+         * Handles a transcription result received from the websocket.
+         *
+         * @param event the transcription result
+         */
+        @Override
+        public void handleTranscriptionResult(TranscriptionResultEvent event)
         {
-            EndpointMessage endpointMessage = new EndpointMessage("");
-            endpointMessage.put("msgPayload", transcriptionMessage);
-            endpointMessage.put("from", "transcriber");
-
-            broadcastMessage(endpointMessage, true);
-        }
-        catch (Exception e)
-        {
-            logger.warn("Failed to broadcast transcription message", e);
-        }
-    }
-
-    /**
-     * Handles a translated-audio "media" event received from a translator over the export websocket. The event's
-     * tag names the synthetic source the translated audio belongs to; we build an Opus RTP packet on that source's
-     * SSRC and inject it into the conference, where the synthetic-source routing delivers it (only to endpoints that
-     * explicitly subscribed to that source, and on to relays).
-     */
-    private void handleMediaMessage(MediaEvent mediaEvent)
-    {
-        org.jitsi.mediajson.Media media = mediaEvent.getMedia();
-        String sourceName = media.getTag();
-
-        AudioSourceDesc source = findSyntheticAudioSource(sourceName);
-        if (source == null)
-        {
-            if (removedSyntheticSources.contains(sourceName))
+            try
             {
-                // Expected transient: the translator sent this before it saw our unsubscribe of the source.
-                logger.debug(() -> "Dropping translated media for removed synthetic source: " + sourceName);
+                EndpointMessage endpointMessage = new EndpointMessage("");
+                endpointMessage.put("msgPayload", event);
+                endpointMessage.put("from", "transcriber");
+
+                broadcastMessage(endpointMessage, true);
             }
-            else if (loggedUnknownMediaTags.add(sourceName))
+            catch (Exception e)
             {
-                logger.warn("Received translated media for unknown synthetic source: " + sourceName);
+                logger.warn("Failed to broadcast transcription message", e);
             }
-            return;
         }
 
-        PayloadType opusPayloadType = getOpusPayloadType();
-        if (opusPayloadType == null)
+        /**
+         * Handles a translated-audio "media" event received from a translator over the export websocket. The event's
+         * tag names the synthetic source the translated audio belongs to; we build an Opus RTP packet on that
+         * source's SSRC and inject it into the conference, where the synthetic-source routing delivers it (only to
+         * endpoints that explicitly subscribed to that source, and on to relays).
+         */
+        @Override
+        public void handleMediaEvent(MediaEvent mediaEvent)
         {
-            if (loggedNoOpusPayloadType.compareAndSet(false, true))
+            org.jitsi.mediajson.Media media = mediaEvent.getMedia();
+            String sourceName = media.getTag();
+
+            AudioSourceDesc source = findSyntheticAudioSource(sourceName);
+            if (source == null)
             {
-                logger.warn("Received translated media but no Opus payload type is negotiated; dropping.");
+                if (removedSyntheticSources.contains(sourceName))
+                {
+                    // Expected transient: the translator sent this before it saw our unsubscribe of the source.
+                    logger.debug(() -> "Dropping translated media for removed synthetic source: " + sourceName);
+                }
+                else if (loggedUnknownMediaTags.add(sourceName))
+                {
+                    logger.warn("Received translated media for unknown synthetic source: " + sourceName);
+                }
+                return;
             }
-            return;
-        }
 
-        if (loggedInjectedSources.add(sourceName))
-        {
-            logger.info("Creating injected synthetic source " + sourceName + " (ssrc " + source.getSsrc() + ")");
-        }
-
-        try
-        {
-            byte[] payload = java.util.Base64.getDecoder().decode(media.getPayload());
-            int headerSize = RtpHeader.FIXED_HEADER_SIZE_BYTES;
-            int offset = RtpPacket.BYTES_TO_LEAVE_AT_START_OF_PACKET;
-            // Use a pooled buffer with the standard head and tail room, like other packet-construction sites, so
-            // downstream stages (header extensions, the SRTP auth tag) don't need to reallocate and the buffer
-            // round-trips through the pool.
-            byte[] buffer = ByteBufferPool.getBuffer(
-                offset + headerSize + payload.length + Packet.BYTES_TO_LEAVE_AT_END_OF_PACKET);
-            // The pooled buffer isn't zeroed, and the setters below don't cover every header field (e.g. the
-            // padding/extension/CSRC-count and marker bits), so clear the header region first.
-            Arrays.fill(buffer, offset, offset + headerSize, (byte) 0);
-            System.arraycopy(payload, 0, buffer, offset + headerSize, payload.length);
-
-            AudioRtpPacket rtpPacket = new AudioRtpPacket(buffer, offset, headerSize + payload.length);
-            rtpPacket.setVersion(2);
-            rtpPacket.setPayloadType(opusPayloadType.getPt());
-            rtpPacket.setSequenceNumber(media.getChunk());
-            // The translator sends a monotonic, unwrapped timestamp, but the RTP timestamp is a 32-bit wrapping
-            // field. setTimestamp() truncates to 32 bits on the wire, but caches the raw Long, so mask here to keep
-            // the packet's cached timestamp consistent with its bytes (and with the sending-change notification).
-            rtpPacket.setTimestamp(media.getTimestamp() & 0xFFFFFFFFL);
-            rtpPacket.setSsrc(source.getSsrc());
-
-            PacketInfo packetInfo = new PacketInfo(rtpPacket);
-            packetInfo.setPayloadType(opusPayloadType);
-            // Deliberately leave the endpoint ID unset: this is bridge-generated audio, not an endpoint's own live
-            // audio, so there is no self-echo to suppress. Delivery (including to the source's owner) is governed
-            // entirely by the audio subscriptions, so an endpoint can subscribe to a synthetic source of its own.
-
-            handleIncomingPacket(packetInfo);
-        }
-        catch (Exception e)
-        {
-            logger.warn("Failed to handle translated media for source " + sourceName, e);
-        }
-    }
-
-    /**
-     * Handles a synthetic source's sending-state change, derived from the {@code start}/{@code stop} mediajson events
-     * a translator sends to bracket a "talk" of translated audio. Resolves the named synthetic source (dropping the
-     * change if it isn't a known synthetic source, like {@link #handleMediaMessage}) and broadcasts a
-     * {@link SyntheticSourceSendingChangeEvent} to the conference's clients (and relays).
-     *
-     * @param sourceName the synthetic source whose sending state changed
-     * @param sending    true if the source started sending, false if it stopped
-     * @param timestamp  the RTP timestamp (media clock) at which the change takes effect, on the same timeline as the
-     *                   source's media; the low 32 bits are used (RTP timestamps are 32-bit and wrap)
-     */
-    private void handleSyntheticSourceSendingChange(String sourceName, boolean sending, long timestamp)
-    {
-        AudioSourceDesc source = findSyntheticAudioSource(sourceName);
-        if (source == null)
-        {
-            if (removedSyntheticSources.contains(sourceName))
+            PayloadType opusPayloadType = getOpusPayloadType();
+            if (opusPayloadType == null)
             {
-                // Expected transient: the translator sent this before it saw our unsubscribe of the source.
-                logger.debug(() -> "Dropping sending-change for removed synthetic source: " + sourceName);
+                if (loggedNoOpusPayloadType.compareAndSet(false, true))
+                {
+                    logger.warn("Received translated media but no Opus payload type is negotiated; dropping.");
+                }
+                return;
             }
-            else if (loggedUnknownMediaTags.add(sourceName))
+
+            if (loggedInjectedSources.add(sourceName))
             {
-                logger.warn("Received sending-change for unknown synthetic source: " + sourceName);
+                logger.info("Creating injected synthetic source " + sourceName + " (ssrc " + source.getSsrc() + ")");
             }
-            return;
+
+            try
+            {
+                byte[] payload = java.util.Base64.getDecoder().decode(media.getPayload());
+                int headerSize = RtpHeader.FIXED_HEADER_SIZE_BYTES;
+                int offset = RtpPacket.BYTES_TO_LEAVE_AT_START_OF_PACKET;
+                // Use a pooled buffer with the standard head and tail room, like other packet-construction sites, so
+                // downstream stages (header extensions, the SRTP auth tag) don't need to reallocate and the buffer
+                // round-trips through the pool.
+                byte[] buffer = ByteBufferPool.getBuffer(
+                    offset + headerSize + payload.length + Packet.BYTES_TO_LEAVE_AT_END_OF_PACKET);
+                // The pooled buffer isn't zeroed, and the setters below don't cover every header field (e.g. the
+                // padding/extension/CSRC-count and marker bits), so clear the header region first.
+                Arrays.fill(buffer, offset, offset + headerSize, (byte) 0);
+                System.arraycopy(payload, 0, buffer, offset + headerSize, payload.length);
+
+                AudioRtpPacket rtpPacket = new AudioRtpPacket(buffer, offset, headerSize + payload.length);
+                rtpPacket.setVersion(2);
+                rtpPacket.setPayloadType(opusPayloadType.getPt());
+                rtpPacket.setSequenceNumber(media.getChunk());
+                // The translator sends a monotonic, unwrapped timestamp, but the RTP timestamp is a 32-bit wrapping
+                // field. setTimestamp() truncates to 32 bits on the wire, but caches the raw Long, so mask here to
+                // keep the packet's cached timestamp consistent with its bytes (and the sending-change notification).
+                rtpPacket.setTimestamp(media.getTimestamp() & 0xFFFFFFFFL);
+                rtpPacket.setSsrc(source.getSsrc());
+
+                PacketInfo packetInfo = new PacketInfo(rtpPacket);
+                packetInfo.setPayloadType(opusPayloadType);
+                // Deliberately leave the endpoint ID unset: this is bridge-generated audio, not an endpoint's own
+                // live audio, so there is no self-echo to suppress. Delivery (including to the source's owner) is
+                // governed entirely by the audio subscriptions, so an endpoint can subscribe to its own synthetic
+                // source.
+
+                handleIncomingPacket(packetInfo);
+            }
+            catch (Exception e)
+            {
+                logger.warn("Failed to handle translated media for source " + sourceName, e);
+            }
         }
 
-        try
+        /**
+         * Handles a synthetic source's sending-state change, derived from the {@code start}/{@code stop} mediajson
+         * events a translator sends to bracket a "talk" of translated audio. Resolves the named synthetic source
+         * (dropping the change if it isn't a known synthetic source, like {@link #handleMediaEvent}) and broadcasts
+         * a {@link SyntheticSourceSendingChangeEvent} to the conference's clients (and relays).
+         *
+         * @param sourceName the synthetic source whose sending state changed
+         * @param sending    true if the source started sending, false if it stopped
+         * @param timestamp  the RTP timestamp (media clock) at which the change takes effect, on the same timeline as
+         *                   the source's media; the low 32 bits are used (RTP timestamps are 32-bit and wrap)
+         */
+        @Override
+        public void handleSendingChange(String sourceName, boolean sending, long timestamp)
         {
-            // The translator sends a monotonic, unwrapped timestamp; the RTP timestamp is 32-bit and wraps, and the
-            // client (lib-jitsi-meet) validates 0..0xFFFFFFFF, so send the low 32 bits. This also matches the
-            // wrapped timestamp the client sees on this source's injected media.
-            long rtpTimestamp = timestamp & 0xFFFFFFFFL;
-            broadcastMessage(new SyntheticSourceSendingChangeEvent(sourceName, sending, rtpTimestamp), true);
+            AudioSourceDesc source = findSyntheticAudioSource(sourceName);
+            if (source == null)
+            {
+                if (removedSyntheticSources.contains(sourceName))
+                {
+                    // Expected transient: the translator sent this before it saw our unsubscribe of the source.
+                    logger.debug(() -> "Dropping sending-change for removed synthetic source: " + sourceName);
+                }
+                else if (loggedUnknownMediaTags.add(sourceName))
+                {
+                    logger.warn("Received sending-change for unknown synthetic source: " + sourceName);
+                }
+                return;
+            }
+
+            try
+            {
+                // The translator sends a monotonic, unwrapped timestamp; the RTP timestamp is 32-bit and wraps, and
+                // the client (lib-jitsi-meet) validates 0..0xFFFFFFFF, so send the low 32 bits. This also matches the
+                // wrapped timestamp the client sees on this source's injected media.
+                long rtpTimestamp = timestamp & 0xFFFFFFFFL;
+                broadcastMessage(new SyntheticSourceSendingChangeEvent(sourceName, sending, rtpTimestamp), true);
+            }
+            catch (Exception e)
+            {
+                logger.warn("Failed to broadcast synthetic source sending change for " + sourceName, e);
+            }
         }
-        catch (Exception e)
+
+        /**
+         * Resolves an audio SSRC to the name of the source it belongs to, or {@code null} if it is not known. Used to
+         * filter outbound audio by a connect's exported source names.
+         */
+        @Override
+        @Nullable
+        public String getAudioSourceName(long ssrc)
         {
-            logger.warn("Failed to broadcast synthetic source sending change for " + sourceName, e);
+            AbstractEndpoint endpoint = getEndpointBySsrc(ssrc);
+            if (endpoint == null)
+            {
+                return null;
+            }
+            AudioSourceDesc source = endpoint.getAudioSource(ssrc);
+            return source != null ? source.getSourceName() : null;
+        }
+
+        /**
+         * Resolves an audio SSRC to whether diarization is requested for its owning endpoint (the colibri2
+         * {@code diarize} attribute), defaulting to {@code false} if the SSRC's endpoint is not known. Used to set
+         * the {@code diarize} flag on the transcriber start event per source.
+         */
+        @Override
+        public boolean getDiarize(long ssrc)
+        {
+            AbstractEndpoint endpoint = getEndpointBySsrc(ssrc);
+            return endpoint != null && endpoint.getDiarize();
         }
     }
 

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
@@ -60,18 +60,8 @@ internal class Exporter(
     private val url: URI,
     private val httpHeaders: Map<String, String>,
     val logger: Logger,
-    private val handleTranscriptionResult: ((TranscriptionResultEvent) -> Unit),
-    /** Handles a translated-audio media event received back from the peer. */
-    private val handleMediaEvent: ((MediaEvent) -> Unit),
-    /**
-     * Handles a synthetic source's sending-state change, derived from the `start`/`stop` mediajson events the peer
-     * sends to bracket a "talk": (sourceName, sending, RTP timestamp).
-     */
-    private val handleSendingChange: ((String, Boolean, Long) -> Unit),
-    /** Resolves an audio SSRC to its source name, used to filter outbound audio by this connect's exports. */
-    private val getAudioSourceName: (Long) -> String?,
-    /** Resolves an audio SSRC to whether diarization is requested for its endpoint (colibri2 `diarize` attribute). */
-    private val getDiarize: (Long) -> Boolean,
+    /** The conference-side sinks and SSRC lookups this exporter calls back into. */
+    private val eventHandler: ExporterEventHandler,
     private val pingEnabled: Boolean = false,
     private val pingIntervalMs: Int = 0,
     private val pingTimeoutMs: Int = 0,
@@ -175,7 +165,7 @@ internal class Exporter(
 
     private var serializer: MediaJsonSerializer? = null
 
-    private fun initSerializer() = MediaJsonSerializer(getAudioSourceName, getDiarize) {
+    private fun initSerializer() = MediaJsonSerializer(eventHandler::getAudioSourceName, eventHandler::getDiarize) {
         val session = recorderWebSocket.session
         if (session != null) {
             session.sendText(it.toJson(), Callback.NOOP)
@@ -195,7 +185,7 @@ internal class Exporter(
     override fun wants(packet: PacketInfo): Boolean {
         if (!isConnected()) return false
         val audioPacket = packet.packet as? AudioRtpPacket ?: return false
-        val sourceName = getAudioSourceName(audioPacket.ssrc) ?: return false
+        val sourceName = eventHandler.getAudioSourceName(audioPacket.ssrc) ?: return false
         return exports.isEmpty() || sourceName in exports
     }
 
@@ -228,7 +218,7 @@ internal class Exporter(
                 is TranscriptionResultEvent -> {
                     transcriptsReceivedCount.inc()
                     instanceTranscriptsReceived.incrementAndGet()
-                    handleTranscriptionResult(event)
+                    eventHandler.handleTranscriptionResult(event)
                 }
                 is PongEvent -> {
                     val expectedId = lastPingSentId.get()
@@ -245,7 +235,7 @@ internal class Exporter(
                 is MediaEvent -> {
                     mediaEventsReceivedCount.inc()
                     instanceMediaEventsReceived.incrementAndGet()
-                    handleMediaEvent(event)
+                    eventHandler.handleMediaEvent(event)
                 }
                 is StartEvent -> {
                     // A `start` with a talk timestamp brackets the beginning of a "talk" (translated audio); one
@@ -255,7 +245,7 @@ internal class Exporter(
                     if (timestamp != null) {
                         sendingChangesReceivedCount.inc()
                         instanceSendingChangesReceived.incrementAndGet()
-                        handleSendingChange(event.start.tag, true, timestamp)
+                        eventHandler.handleSendingChange(event.start.tag, true, timestamp)
                     } else {
                         otherMessagesReceivedCount.inc()
                         instanceOtherMessagesReceived.incrementAndGet()
@@ -268,7 +258,7 @@ internal class Exporter(
                     if (timestamp != null) {
                         sendingChangesReceivedCount.inc()
                         instanceSendingChangesReceived.incrementAndGet()
-                        handleSendingChange(event.stop.tag, false, timestamp)
+                        eventHandler.handleSendingChange(event.stop.tag, false, timestamp)
                     } else {
                         otherMessagesReceivedCount.inc()
                         instanceOtherMessagesReceived.incrementAndGet()

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/ExporterEventHandler.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/ExporterEventHandler.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright @ 2024 - Present, 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.videobridge.export
+
+import org.jitsi.mediajson.MediaEvent
+import org.jitsi.mediajson.TranscriptionResultEvent
+
+/**
+ * The conference-side operations an [Exporter] (and the [ExporterWrapper] that owns it) depends on: sinks for the
+ * events a peer sends back, plus lookups resolving an audio SSRC to conference state. Implemented by the conference
+ * and passed in, so the exporter subsystem doesn't depend on the conference directly and can be driven by a fake in
+ * tests.
+ */
+interface ExporterEventHandler {
+    /** Handles a transcription result received back from a peer. */
+    fun handleTranscriptionResult(event: TranscriptionResultEvent)
+
+    /** Handles a translated-audio media event received back from a peer. */
+    fun handleMediaEvent(event: MediaEvent)
+
+    /**
+     * Handles a synthetic source's sending-state change, derived from the `start`/`stop` mediajson events a peer sends
+     * to bracket a "talk".
+     *
+     * @param sourceName the synthetic source whose sending state changed.
+     * @param sending true at the start of a talk, false at its end.
+     * @param timestamp the talk boundary's RTP timestamp (48 kHz); for a stop, one past the end of the run.
+     */
+    fun handleSendingChange(sourceName: String, sending: Boolean, timestamp: Long)
+
+    /** Resolves an audio SSRC to its source name, used to filter outbound audio by a connect's exports. */
+    fun getAudioSourceName(ssrc: Long): String?
+
+    /** Resolves an audio SSRC to whether diarization is requested for its endpoint (colibri2 `diarize` attribute). */
+    fun getDiarize(ssrc: Long): Boolean
+}

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/ExporterWrapper.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/ExporterWrapper.kt
@@ -17,8 +17,6 @@ package org.jitsi.videobridge.export
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import org.jitsi.mediajson.MediaEvent
-import org.jitsi.mediajson.TranscriptionResultEvent
 import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.videobridge.PotentialPacketHandler
@@ -31,35 +29,17 @@ import java.util.concurrent.ConcurrentHashMap
 
 class ExporterWrapper internal constructor(
     parentLogger: Logger,
-    private val handleTranscriptionResult: ((TranscriptionResultEvent) -> Unit),
-    /** Handles a translated-audio media event received back from a peer. */
-    private val handleMediaEvent: ((MediaEvent) -> Unit),
-    /**
-     * Handles a synthetic source's sending-state change, derived from the `start`/`stop` mediajson events a peer
-     * sends to bracket a "talk": (sourceName, sending, RTP timestamp).
-     */
-    private val handleSendingChange: ((String, Boolean, Long) -> Unit),
-    /** Resolves an audio SSRC to its source name, used to filter outbound audio by a connect's exports. */
-    private val getAudioSourceName: (Long) -> String?,
-    /** Resolves an audio SSRC to whether diarization is requested for its endpoint (colibri2 `diarize` attribute). */
-    private val getDiarize: (Long) -> Boolean,
+    /** The conference-side sinks and SSRC lookups each [Exporter] calls back into. */
+    private val eventHandler: ExporterEventHandler,
     /** Creates (and starts) the [Exporter] for a connect. Overridable for testing; defaults to the real one. */
     exporterFactory: ((Connect) -> Exporter)?
 ) {
     constructor(
         parentLogger: Logger,
-        handleTranscriptionResult: ((TranscriptionResultEvent) -> Unit),
-        handleMediaEvent: ((MediaEvent) -> Unit),
-        handleSendingChange: ((String, Boolean, Long) -> Unit),
-        getAudioSourceName: (Long) -> String?,
-        getDiarize: (Long) -> Boolean
+        eventHandler: ExporterEventHandler
     ) : this(
         parentLogger,
-        handleTranscriptionResult,
-        handleMediaEvent,
-        handleSendingChange,
-        getAudioSourceName,
-        getDiarize,
+        eventHandler,
         null
     )
 
@@ -234,11 +214,7 @@ class ExporterWrapper internal constructor(
             connect.url,
             httpHeaders,
             logger,
-            handleTranscriptionResult,
-            handleMediaEvent,
-            handleSendingChange,
-            getAudioSourceName,
-            getDiarize,
+            eventHandler,
             pingEnabled,
             pingIntervalMs,
             pingTimeoutMs,

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/export/ExporterTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/export/ExporterTest.kt
@@ -17,6 +17,8 @@ package org.jitsi.videobridge.export
 
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
+import org.jitsi.mediajson.MediaEvent
+import org.jitsi.mediajson.TranscriptionResultEvent
 import org.jitsi.utils.logging2.LoggerImpl
 import java.net.URI
 
@@ -35,11 +37,15 @@ class ExporterTest : ShouldSpec() {
             URI("ws://localhost:1/"),
             emptyMap(),
             LoggerImpl(javaClass.name),
-            { }, // handleTranscriptionResult
-            { }, // handleMediaEvent
-            { name, sending, timestamp -> changes.add(Change(name, sending, timestamp)) },
-            { null }, // getAudioSourceName
-            { false } // getDiarize
+            object : ExporterEventHandler {
+                override fun handleTranscriptionResult(event: TranscriptionResultEvent) {}
+                override fun handleMediaEvent(event: MediaEvent) {}
+                override fun handleSendingChange(sourceName: String, sending: Boolean, timestamp: Long) {
+                    changes.add(Change(sourceName, sending, timestamp))
+                }
+                override fun getAudioSourceName(ssrc: Long): String? = null
+                override fun getDiarize(ssrc: Long): Boolean = false
+            }
         )
         return exporter to changes
     }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/export/ExporterWrapperTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/export/ExporterWrapperTest.kt
@@ -22,6 +22,8 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.jitsi.mediajson.MediaEvent
+import org.jitsi.mediajson.TranscriptionResultEvent
 import org.jitsi.utils.logging2.LoggerImpl
 import org.jitsi.videobridge.colibri2.FeatureNotImplementedException
 import org.jitsi.videobridge.colibri2.IqProcessingException
@@ -31,10 +33,19 @@ import java.net.URI
 class ExporterWrapperTest : ShouldSpec() {
     private val logger = LoggerImpl(javaClass.name)
 
+    /** A no-op event handler; these tests exercise connect bookkeeping, not the exporter's callbacks. */
+    private val eventHandler = object : ExporterEventHandler {
+        override fun handleTranscriptionResult(event: TranscriptionResultEvent) {}
+        override fun handleMediaEvent(event: MediaEvent) {}
+        override fun handleSendingChange(sourceName: String, sending: Boolean, timestamp: Long) {}
+        override fun getAudioSourceName(ssrc: Long): String? = null
+        override fun getDiarize(ssrc: Long): Boolean = false
+    }
+
     /** Records the mock [Exporter] created for each connect id, so tests can verify calls against them. */
     private inner class Fixture {
         val exporters = mutableMapOf<String, Exporter>()
-        val wrapper = ExporterWrapper(logger, { }, { }, { _, _, _ -> }, { null }, { false }) { connect ->
+        val wrapper = ExporterWrapper(logger, eventHandler) { connect ->
             mockk<Exporter>(relaxed = true).also { exporters[connect.id] = it }
         }
         operator fun get(id: String): Exporter = exporters.getValue(id)


### PR DESCRIPTION
## Summary

Replaces `ExporterWrapper`/`Exporter`'s long positional list of closures with a single `ExporterEventHandler` interface, then moves the conference's implementation of those callbacks into a private inner class. Two commits:

### 1. Take an `ExporterEventHandler` interface instead of a series of closures

`ExporterWrapper` and `Exporter` each took **five** separate function-type parameters — `handleTranscriptionResult`, `handleMediaEvent`, `handleSendingChange`, `getAudioSourceName`, `getDiarize`. They collapse into one interface:

```kotlin
interface ExporterEventHandler {
    fun handleTranscriptionResult(event: TranscriptionResultEvent)
    fun handleMediaEvent(event: MediaEvent)
    fun handleSendingChange(sourceName: String, sending: Boolean, timestamp: Long)
    fun getAudioSourceName(ssrc: Long): String?
    fun getDiarize(ssrc: Long): Boolean
}
```

Both constructors shrink from six params to two; call sites read `eventHandler.handleMediaEvent(...)` instead of relying on positional closure order, the callback surface is documented in one place, and `Conference` no longer needs the `Unit.INSTANCE` boilerplate the Kotlin function types forced on the Java caller.

`ExporterWrapper`'s `exporterFactory` stays a separate optional closure — it overrides how an `Exporter` is *constructed* (a test seam), not one of the conference callbacks.

### 2. Move the conference's exporter callbacks into a private inner class

Rather than have the handler relay to five separate private `Conference` methods, the implementations themselves move into a private (non-static) inner class `ExporterEventHandlerImpl`. It reaches the conference's state and helpers (`broadcastMessage`, `findSyntheticAudioSource`, `getEndpointBySsrc`, `handleIncomingPacket`, the `logged*` sets, …) directly through the enclosing instance, so the bodies move in unchanged; the three handlers also take the interface's names (dropping the older `Message`/`Change` naming). These five methods were only ever called from the exporter callback site, so nothing else changes.

Behavior is unchanged throughout — both commits are pure refactors.

## Testing

`mvn checkstyle:check ktlint:check compile test` — 0 checkstyle violations, ktlint clean, compiles; the `export` package tests pass (`ExporterTest`, `ExporterWrapperTest`, `MediaJsonSerializerTest` — 29 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
