### PR TITLE
log: Report per-source detail when sources are suspended for bandwidth

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.kt
@@ -241,12 +241,13 @@ internal class BandwidthAllocator<T : MediaSourceContainer>(
         if (sourceBitrateAllocations.isEmpty()) {
             return BandwidthAllocation(emptySet())
         }
-        var remainingBandwidth = if (allocationSettings.assumedBandwidthBps >= 0) {
+        val initialBandwidth = if (allocationSettings.assumedBandwidthBps >= 0) {
             logger.warn("Allocating with assumed bandwidth ${allocationSettings.assumedBandwidthBps.bps}.")
             allocationSettings.assumedBandwidthBps
         } else {
             availableBandwidth
         }
+        var remainingBandwidth = initialBandwidth
         var oldRemainingBandwidth: Long = -1
         var oversending = false
         while (oldRemainingBandwidth != remainingBandwidth) {
@@ -273,11 +274,23 @@ internal class BandwidthAllocator<T : MediaSourceContainer>(
         }
 
         // The sources which are in lastN, and are sending video, but were suspended due to bwe.
-        val suspendedIds = sourceBitrateAllocations
-            .filter { it.isSuspended }
-            .map { it.mediaSource.sourceName }.toList()
+        val suspendedSources = sourceBitrateAllocations.filter { it.isSuspended }
+        val suspendedIds = suspendedSources.map { it.mediaSource.sourceName }.toList()
         if (suspendedIds.isNotEmpty()) {
-            logger.info("Sources suspended due to insufficient bandwidth (bwe=$availableBandwidth bps): $suspendedIds")
+            logger.info {
+                // The bandwidth we started with is not the BWE if the receiver signaled an assumed bandwidth, so log
+                // it separately when the two differ.
+                val budget = if (initialBandwidth != availableBandwidth) "budget=$initialBandwidth bps, " else ""
+                val maxOversend = BitrateControllerConfig.config.maxOversendBitrate
+                val sources = suspendedSources.mapIndexed { i, source ->
+                    // Only summarize the first few sources in full. They are in order of priority, so these are the
+                    // ones whose suspension is most likely to be of interest. Name the rest without any detail, to
+                    // bound the size of the message when many sources are suspended at once.
+                    if (i < MAX_SOURCES_SUMMARIZED) source.suspendedSummary() else source.mediaSource.sourceName
+                }
+                "Sources suspended due to insufficient bandwidth (bwe=$availableBandwidth bps, $budget" +
+                    "remaining=$remainingBandwidth bps, maxOversend=$maxOversend): " + sources.joinToString()
+            }
         }
         val allocations = mutableSetOf<SingleAllocation>()
         var targetBps: Long = 0
@@ -358,6 +371,9 @@ internal class BandwidthAllocator<T : MediaSourceContainer>(
 
     companion object {
         private val timeSeriesLogger = TimeSeriesLogger.getTimeSeriesLogger(BandwidthAllocator::class.java)
+
+        /** The number of suspended sources for which we log the full details of the failed allocation. */
+        private const val MAX_SOURCES_SUMMARIZED = 3
     }
 
     interface EventHandler {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/Layers.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/Layers.kt
@@ -20,7 +20,35 @@ import org.jitsi.nlj.RtpLayerDesc
 /**
  * Saves the bitrate of a specific [RtpLayerDesc] at a specific point in time.
  */
-data class LayerSnapshot(val layer: RtpLayerDesc, val bitrate: Long)
+data class LayerSnapshot(
+    val layer: RtpLayerDesc,
+    /**
+     * The bitrate (in bps) to use for allocation. Depending on the `use-vla-target-bitrate` config this is either
+     * [measuredBitrate] or [vlaTargetBitrate].
+     */
+    val bitrate: Long,
+    /** The bitrate (in bps) measured for the layer (and its dependencies). */
+    val measuredBitrate: Long = bitrate,
+    /**
+     * The target bitrate (in bps) signaled by the sender in the VLA RTP header extension, or `null` if the sender
+     * doesn't signal VLA.
+     */
+    val vlaTargetBitrate: Long? = null
+) {
+    /**
+     * A short description of the layer and its bitrate, for logging. The bitrate which was not used for allocation is
+     * only mentioned when it differs from the one which was, so in the default configuration (measured bitrates, no
+     * VLA signaled by the sender) this is just the measured bitrate.
+     */
+    fun summary(): String = buildString {
+        append("${layer.indexString()}/${layer.height}p/${layer.frameRate}fps=$bitrate")
+        val other = listOfNotNull(
+            if (measuredBitrate != bitrate) "measured=$measuredBitrate" else null,
+            vlaTargetBitrate?.takeIf { it != bitrate }?.let { "vla=$it" }
+        )
+        if (other.isNotEmpty()) append(other.joinToString(prefix = "(", postfix = ")"))
+    }
+}
 
 /**
  * An immutable representation of the layers to be considered when allocating bandwidth for an endpoint. The order is

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
@@ -62,15 +62,33 @@ internal class SingleSourceAllocation(
      */
     var targetIdx = -1
 
+    /**
+     * The bandwidth (in bps) which was available to this source the last time [improve] was called, or `null` if
+     * [improve] was never called. The latter means the allocation loop never got as far as this source, because a
+     * higher priority source had not reached its preferred layer. Note that this is negative when the allocator has
+     * oversent, so it can not use a negative sentinel for "never called". Only used for logging.
+     */
+    private var lastAvailableBps: Long? = null
+
+    /** Whether oversending was allowed the last time [improve] was called. Only used for logging. */
+    private var lastAllowedOversending = false
+
     init {
         if (timeSeriesLogger.isTraceEnabled) {
             val ratesTimeSeriesPoint = diagnosticContext.makeTimeSeriesPoint("layers_considered")
                 .addField("remote_endpoint_id", endpointId)
-            for ((l, bitrate) in layers.layers) {
-                ratesTimeSeriesPoint.addField(
-                    "${l.indexString()}_${l.height}p_${l.frameRate}fps_bps",
-                    bitrate
-                )
+            for (layerSnapshot in layers.layers) {
+                val l = layerSnapshot.layer
+                val prefix = "${l.indexString()}_${l.height}p_${l.frameRate}fps"
+                ratesTimeSeriesPoint.addField("${prefix}_bps", layerSnapshot.bitrate)
+                // Which fields are present must not vary with the data, so that the series can be consumed
+                // mechanically. The measured bitrate is the only exception: with useVlaTargetBitrate disabled it is
+                // by configuration always equal to the bitrate above, so it is never added.
+                if (config.useVlaTargetBitrate) {
+                    ratesTimeSeriesPoint.addField("${prefix}_measured_bps", layerSnapshot.measuredBitrate)
+                }
+                // -1 means the sender does not signal a target bitrate for the layer in the VLA extension.
+                ratesTimeSeriesPoint.addField("${prefix}_vla_bps", layerSnapshot.vlaTargetBitrate ?: -1)
             }
             timeSeriesLogger.trace(ratesTimeSeriesPoint)
         }
@@ -92,6 +110,8 @@ internal class SingleSourceAllocation(
     fun improve(remainingBps: Long, allowOversending: Boolean): Long {
         val initialTargetBitrate = targetBitrate
         val maxBps = remainingBps + initialTargetBitrate
+        lastAvailableBps = maxBps
+        lastAllowedOversending = allowOversending
         if (layers.isEmpty()) {
             return 0
         }
@@ -148,6 +168,65 @@ internal class SingleSourceAllocation(
      */
     val isSuspended: Boolean
         get() = targetIdx == -1 && layers.isNotEmpty() && layers[0].bitrate > 0
+
+    /**
+     * The layer which had to fit in the available bandwidth in order for this source not to be suspended: the first
+     * layer, which is the one [improve] tries while the source has no target layer.
+     */
+    private val requiredLayer: LayerSnapshot?
+        get() = layers.firstOrNull()
+
+    /**
+     * The cheapest of the layers which could have kept this source from being suspended, i.e. of [rescuingLayers].
+     * This is normally [requiredLayer], but the layers are not guaranteed to be ordered by bitrate (notably with VP9),
+     * and when oversending it is the cheapest layer which decides whether the source can be rescued.
+     */
+    private val cheapestLayer: LayerSnapshot?
+        get() = rescuingLayers.minByOrNull { it.bitrate }
+
+    /**
+     * The layers which the last [improve] call could have selected while the source had no target layer. That is just
+     * the first one, unless oversending was allowed, in which case the oversend loop scans everything up to and
+     * including [Layers.oversendIndex] (but no further).
+     */
+    private val rescuingLayers: List<LayerSnapshot>
+        get() = layers.take(
+            if (lastAllowedOversending && layers.oversendIndex >= 0) layers.oversendIndex + 1 else 1
+        )
+
+    /**
+     * A summary of why this source ended up suspended, for logging. Only meaningful once the allocation algorithm has
+     * completed, and only for a source which is actually suspended (i.e. [isSuspended] is true) -- for any other source
+     * the fields describe an allocation which did succeed. All bitrates are in bps:
+     *
+     * "required" is the layer which had to fit in the available bandwidth, i.e. what the allocator thought the source
+     * needed; "cheapest" is only present when a different layer could have rescued the source more cheaply; "ideal" is
+     * the bitrate of the layer we'd have forwarded with unlimited bandwidth, and is omitted when that is the required
+     * layer; "oversend" describes the layer we'd have used when oversending (capped by
+     * videobridge.cc.max-oversend-bitrate) -- its bitrate, or "required" when it is the required layer, or "notAllowed"
+     * when this source was not the one source which is allowed to oversend -- and is absent when the source has no
+     * oversend layer at all; "available" is the bandwidth which was left for the source when it was last considered,
+     * and is negative if the allocator had already oversent. The bitrates of the layers which are not called out here
+     * are only available in the "layers_considered" time series.
+     */
+    fun suspendedSummary(): String = buildString {
+        append(mediaSource.sourceName)
+        append("[type=${mediaSource.videoType}")
+        append(" onStage=$onStage")
+        append(" required=${requiredLayer?.summary()}")
+        cheapestLayer?.let { if (it !== requiredLayer) append(" cheapest=${it.summary()}") }
+        if (idealBitrate != requiredLayer?.bitrate) append(" ideal=$idealBitrate")
+        layers.oversendLayer?.let {
+            val oversend = when {
+                !lastAllowedOversending -> "notAllowed"
+                it === requiredLayer -> "required"
+                else -> it.bitrate.toString()
+            }
+            append(" oversend=$oversend")
+        }
+        append(" available=${lastAvailableBps ?: "none(never considered)"}")
+        append(" constraints=$constraints]")
+    }
 
     /**
      * Gets the target bitrate (in bps) for this endpoint allocation, i.e. the bitrate of the currently chosen layer.
@@ -268,13 +347,17 @@ internal class SingleSourceAllocation(
             return Layers.noLayers
         }
         val layers = source.rtpLayers.map {
+            val measuredBitrate = it.getBitrate(nowMs).bps
+            val vlaTargetBitrate = it.targetBitrate?.bps
             LayerSnapshot(
                 it,
                 if (config.useVlaTargetBitrate) {
-                    it.targetBitrate?.bps ?: it.getBitrate(nowMs).bps
+                    vlaTargetBitrate ?: measuredBitrate
                 } else {
-                    it.getBitrate(nowMs).bps
-                }
+                    measuredBitrate
+                },
+                measuredBitrate,
+                vlaTargetBitrate
             )
         }
 


### PR DESCRIPTION
## Problem

`BandwidthAllocator.allocate` logs

```
Sources suspended due to insufficient bandwidth (bwe=761548 bps): [a9b3bd3b-v1]
```

which says nothing about *why* the allocator gave up on a source: how much it thought the source needed, how much was actually left for it by the time it was considered, or whether oversending was even on the table.  That makes reports like [this one](https://community.jitsi.org/t/screen-sharing-turned-off-due-to-insufficient-bandwidth/142455) hard to act on, and screenshare is the case where it matters most — with the default 5 fps capture, lib-jitsi-meet activates only the full resolution encoding (`TPCUtils.calculateEncodingsActiveState`, capped at `ssHigh` = 2.5 Mbps), so the bridge often sees a single expensive layer with nothing cheaper to fall back to.

## Change

For the first few suspended sources — they are in priority order, so these are the ones most likely to be of interest — the message now reports the layer which had to fit, the bandwidth which was actually left for the source, whether oversending applied, and the receiver's constraints:

```
Sources suspended due to insufficient bandwidth (bwe=761548 bps, remaining=-38000 bps, maxOversend=500 kbps):
a9b3bd3b-v1[type=DESKTOP onStage=true required=E0S0T0/1080p/5.0fps=1850000 ideal=2400000 oversend=required
available=-38000 constraints=VideoConstraints[maxHeight=2160,maxFrameRate=-1.0]], 89691993-v0, c4af29ee-v0
```

Notable points:

* `available=none(never considered)` distinguishes a source the allocation loop never reached (a higher priority on-stage source had not reached its preferred layer, so the loop broke) from one that was considered and did not fit.  A negative `available` means the allocator had already oversent, so this cannot use a negative sentinel.
* `oversend` reports `notAllowed` when the source has an oversend layer but was not the one source `allocate` passes `allowOversending = (i == 0)` to.
* Only the first layer can keep a source from being suspended (the "jump over" block is gated on `targetIdx > -1`), except when oversending, where the loop scans up to `oversendIndex`.  `cheapest` is therefore printed only when a *different* layer in that range would have been cheaper, which can happen since the layers are not guaranteed to be ordered by bitrate.
* Redundant fields are omitted: `ideal` when it is the required layer, and the measured/VLA annotations when they equal the bitrate used for allocation.
* Only `bwe` was logged before, even though the budget comes from `assumedBandwidthBps` when the receiver signals it; `budget=` is now logged when the two differ.

`LayerSnapshot` additionally keeps the measured and the VLA-signaled bitrate separately, so the two can be compared regardless of which one `use-vla-target-bitrate` selects, and `layers_considered` gains a `_vla_bps` field per layer (`-1` when the sender does not signal one).  Which fields that series carries depends only on configuration, never on the data, so it stays mechanically consumable.

## Notes

* No behavioral change other than logging, with one caveat: `selectLayers` now reads `getBitrate()` unconditionally, where previously it was skipped if `use-vla-target-bitrate` was enabled and the sender signaled a VLA target.  That read advances the rate tracker's window, but it is exactly the call the default configuration already makes on every allocation pass.
* Adding fields to the `LayerSnapshot` data class widens its generated `equals`, which `selectLayersForScreensharing` relies on via `indexOf`.  The relation is unchanged: the new fields are derived from the same `RtpLayerDesc`, and neither it nor its subclasses override `equals`.

## Testing

`mvn install` and `mvn ktlint:check` clean; the jvb suite passes (378 tests).  The message format itself is not covered by tests.