### PR TITLE
feat: expose unmatched transport-cc feedback in statistics

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/TransportCcEngine.kt
@@ -69,6 +69,12 @@ abstract class TransportCcEngine : RtcpListener {
 
     abstract class StatisticsSnapshot {
         abstract fun toJson(): ObjectNode
+
+        /** Cumulative count of transport-cc feedback reports that could not be matched against
+         *  the send-time history.  A sustained flood of these means the estimator has lost both
+         *  its loss and delay signals (unmatched reports are dropped entirely) and is the
+         *  earliest observable marker of a feedback-starvation saturation lock. */
+        open val unmatchedFeedback: Long get() = 0
     }
 
     interface BandwidthListener {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcTransportCcEngine.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcTransportCcEngine.kt
@@ -357,6 +357,8 @@ class GoogCcTransportCcEngine(
         val transportAdapterState: TransportFeedbackAdapter.StatisticsSnapshot,
         val networkControllerState: GoogCcNetworkController.StatisticsSnapshot
     ) : TransportCcEngine.StatisticsSnapshot() {
+        override val unmatchedFeedback: Long get() = transportAdapterState.totalUnmatchedReports
+
         override fun toJson(): ObjectNode {
             return JsonNodeFactory.instance.objectNode().apply {
                 put("name", GoogCcTransportCcEngine::class.java.simpleName)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/TransportFeedbackAdapter.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/TransportFeedbackAdapter.kt
@@ -165,6 +165,11 @@ class TransportFeedbackAdapter(
         return null
     }
 
+    /** Cumulative count of feedback reports that could not be matched against the send-time
+     *  history (see [TransportCcEngine.StatisticsSnapshot.unmatchedFeedback]). */
+    var totalUnmatchedReports: Long = 0
+        private set
+
     fun processTransportFeedback(feedback: RtcpFbTccPacket, feedbackReceiveTime: Instant): TransportPacketsFeedback? {
         if (feedback.GetPacketStatusCount() == 0) {
             logger.info { "Empty transport feedback packet received" }
@@ -225,6 +230,7 @@ class TransportFeedbackAdapter(
             packetResultVector.add(result)
         }
 
+        totalUnmatchedReports += failedLookups
         if (failedLookups > 0) {
             logger.info(
                 "Failed to lookup send time for $failedLookups packet${if (failedLookups > 1) "s" else ""}. " +
@@ -287,6 +293,7 @@ class TransportFeedbackAdapter(
             packetResultVector.add(result)
         }
 
+        totalUnmatchedReports += failedLookups
         if (failedLookups > 0) {
             logger.warn {
                 "Failed to lookup send time for $failedLookups packets. " +
@@ -410,6 +417,7 @@ class TransportFeedbackAdapter(
             history.size,
             currentOffset,
             lastTransportFeedbackBaseTime,
+            totalUnmatchedReports,
         )
     }
 
@@ -421,7 +429,8 @@ class TransportFeedbackAdapter(
         val lastAckSeqNum: Long,
         val historySize: Int,
         val currentOffset: Instant,
-        val lastTransportFeedbackBaseTime: Instant
+        val lastTransportFeedbackBaseTime: Instant,
+        val totalUnmatchedReports: Long
     ) {
         fun toJson(): ObjectNode {
             return JsonNodeFactory.instance.objectNode().apply {
@@ -433,6 +442,7 @@ class TransportFeedbackAdapter(
                 put("history_size", historySize)
                 put("current_offset", currentOffset.toEpochMilliOrInf().toString())
                 put("last_transport_feedback_base_time", lastTransportFeedbackBaseTime.toEpochMilliOrInf().toString())
+                put("total_unmatched_reports", totalUnmatchedReports)
             }
         }
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/metrics/VideobridgePeriodicMetrics.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/metrics/VideobridgePeriodicMetrics.kt
@@ -84,6 +84,11 @@ object VideobridgePeriodicMetrics {
         "current_endpoints",
         "Number of current endpoints (local and relayed)."
     )
+    val tccUnmatchedFeedback = metricsContainer.registerLongGauge(
+        "tcc_unmatched_feedback",
+        "Total transport-cc feedback reports that could not be matched to the send-time history. " +
+            "A sustained flood of these is the marker of a feedback-starvation saturation lock."
+    )
     val endpointsWithHighOutgoingLoss = metricsContainer.registerLongGauge(
         "endpoints_with_high_outgoing_loss",
         "Number of endpoints that have high outgoing loss (>10%)."
@@ -194,6 +199,7 @@ object VideobridgePeriodicMetrics {
         // enableOnstageVideoSuspend is false)
         var numOversending = 0L
         var endpointsWithHighOutgoingLoss = 0L
+        var tccUnmatchedFeedback = 0L
         var numLocalActiveEndpoints = 0L
         var endpointsWithSuspendedSources = 0L
 
@@ -247,8 +253,9 @@ object VideobridgePeriodicMetrics {
                 if (endpoint.hasSuspendedSources()) {
                     endpointsWithSuspendedSources++
                 }
-                val (endpointConnectionStats, rtpReceiverStats, _, outgoingStats) =
+                val (endpointConnectionStats, rtpReceiverStats, _, outgoingStats, tccEngineStats) =
                     endpoint.transceiver.getTransceiverStats()
+                tccUnmatchedFeedback += tccEngineStats.unmatchedFeedback
                 val incomingStats = rtpReceiverStats.incomingStats
                 val incomingPacketStreamStats = rtpReceiverStats.packetStreamStats
                 bitrateDownloadBps += incomingPacketStreamStats.getBitrateBps()
@@ -327,6 +334,7 @@ object VideobridgePeriodicMetrics {
         VideobridgePeriodicMetrics.loss.set(overallLoss)
         VideobridgePeriodicMetrics.endpoints.set(endpoints)
         VideobridgePeriodicMetrics.endpointsWithHighOutgoingLoss.set(endpointsWithHighOutgoingLoss)
+        VideobridgePeriodicMetrics.tccUnmatchedFeedback.set(tccUnmatchedFeedback)
         VideobridgePeriodicMetrics.endpointsWithSpuriousRemb.set(endpointsWithSpuriousRemb().toLong())
         VideobridgePeriodicMetrics.activeEndpoints.set(numLocalActiveEndpoints)
         VideobridgePeriodicMetrics.incomingBitrate.set(bitrateDownloadBps.toLong())

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/stats/VideobridgeStatisticsShim.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/stats/VideobridgeStatisticsShim.kt
@@ -139,6 +139,7 @@ object VideobridgeStatisticsShim {
             put("outgoing_loss", VideobridgePeriodicMetrics.outgoingLoss.get())
             put("overall_loss", VideobridgePeriodicMetrics.loss.get())
             put("endpoints_with_high_outgoing_loss", VideobridgePeriodicMetrics.endpointsWithHighOutgoingLoss.get())
+            put("tcc_unmatched_feedback", VideobridgePeriodicMetrics.tccUnmatchedFeedback.get())
             put("local_active_endpoints", VideobridgePeriodicMetrics.activeEndpoints.get())
             put(BITRATE_DOWNLOAD, VideobridgePeriodicMetrics.incomingBitrate.get() / 1000)
             put(BITRATE_UPLOAD, VideobridgePeriodicMetrics.outgoingBitrate.get() / 1000)


### PR DESCRIPTION
We are investigating egress traffic storms on our videobridge deployment: bridges serving 15–18 participant conferences would suddenly send 2–4 Gbit/s for minutes at a time, with outgoing loss of 60%+ and no corresponding increase on ingress, then recover on their own.

The mechanism we reproduced locally: once the egress path saturates, a growing share of transport-cc feedback reports fails to match the send-time history and is silently discarded (the "Received feedback before packet" path in TransportFeedbackAdapter). The estimator then loses both its loss and delay signals at exactly the moment they matter, so the estimate freezes above the real path capacity and the saturation sustains itself.

The unmatched-report counter added here turned out to be the single most indicative signal of this state -- near zero in healthy operation, in the hundreds of thousands during a storm window -- so we use it for detection
and alerting. We also have an experimental pacer (placed upstream of transport-cc tagging, following libwebrtc's RtpSenderEgress ordering) that eliminates the problem in our reproduction. We plan to propose it separately once it has soaked in production. The metric is useful on it own regardless of that outcome.