### PR TITLE
fix: Screenshare bandwidth allocation: starvation, oversend gating, burst-proof measurement

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
@@ -65,6 +65,12 @@ abstract class RtpLayerDesc(
      */
     protected var bitrateTracker = BitrateCalculator.createBitrateTracker()
 
+    /**
+     * A second [BitrateTracker] with a longer window, for sources whose bitrate is bursty. See
+     * [BitrateCalculator.createSmoothedBitrateTracker].
+     */
+    protected var smoothedBitrateTracker = BitrateCalculator.createSmoothedBitrateTracker()
+
     var targetBitrate: Bandwidth? = null
 
     /**
@@ -82,15 +88,16 @@ abstract class RtpLayerDesc(
     /**
      * Inherit a [BitrateTracker] object
      */
-    internal fun inheritStatistics(tracker: BitrateTracker) {
+    internal fun inheritStatistics(tracker: BitrateTracker, smoothedTracker: BitrateTracker) {
         bitrateTracker = tracker
+        smoothedBitrateTracker = smoothedTracker
     }
 
     /**
      * Inherit another layer description's [BitrateTracker] object.
      */
     internal open fun inheritFrom(other: RtpLayerDesc) {
-        inheritStatistics(other.bitrateTracker)
+        inheritStatistics(other.bitrateTracker, other.smoothedBitrateTracker)
         targetBitrate = other.targetBitrate
     }
 
@@ -104,6 +111,7 @@ abstract class RtpLayerDesc(
         val wasInactive = hasZeroBitrate(nowMs)
         // Update rate stats (this should run after padding termination).
         bitrateTracker.update(packetSize, nowMs)
+        smoothedBitrateTracker.update(packetSize, nowMs)
         return wasInactive && packetSize.bits > 0L
     }
 
@@ -114,6 +122,12 @@ abstract class RtpLayerDesc(
      * @return the cumulative bitrate (in bps) of this [RtpLayerDesc] and its dependencies.
      */
     abstract fun getBitrate(nowMs: Long): Bandwidth
+
+    /**
+     * Like [getBitrate], but measured over the longer window of [smoothedBitrateTracker]. Used for sources whose
+     * bitrate is bursty, where the instantaneous rate over-states the bandwidth the source needs.
+     */
+    abstract fun getSmoothedBitrate(nowMs: Long): Bandwidth
 
     /**
      * Recursively checks this layer and its dependencies to see if the bitrate is zero.

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpLayerDesc.kt
@@ -66,10 +66,65 @@ abstract class RtpLayerDesc(
     protected var bitrateTracker = BitrateCalculator.createBitrateTracker()
 
     /**
-     * A second [BitrateTracker] with a longer window, for sources whose bitrate is bursty. See
-     * [BitrateCalculator.createSmoothedBitrateTracker].
+     * A second [BitrateTracker] with a longer window, for sources whose bitrate is bursty. It is only created once
+     * [enableSmoothedBitrate] is called, because it costs memory per layer and an update per packet per layer, and
+     * only screen sharing sources use it. See [BitrateCalculator.createSmoothedBitrateTracker].
+     *
+     * Volatile because it is enabled from the threads which run bandwidth allocation (one per receiver, so possibly
+     * several at once), but read and updated from the thread which reads packets.
      */
-    protected var smoothedBitrateTracker = BitrateCalculator.createSmoothedBitrateTracker()
+    @Volatile
+    private var smoothedBitrateTracker: BitrateTracker? = null
+
+    /**
+     * The [clock] time at which [smoothedBitrateTracker] was created. Only meaningful while the tracker is non-null.
+     * Writes to it are made visible by the subsequent volatile write to [smoothedBitrateTracker].
+     */
+    private var smoothedBitrateTrackerCreatedMs: Long = -1
+
+    /**
+     * Start tracking a smoothed bitrate for this layer. Idempotent. Until the tracker created here has a full window
+     * of history, [getSmoothedBitrate] falls back to [getBitrate], so that a source is not priced at close to zero
+     * while the longer window fills up.
+     */
+    fun enableSmoothedBitrate(nowMs: Long) {
+        if (smoothedBitrateTracker == null) {
+            synchronized(this) {
+                if (smoothedBitrateTracker == null) {
+                    smoothedBitrateTrackerCreatedMs = nowMs
+                    smoothedBitrateTracker = BitrateCalculator.createSmoothedBitrateTracker()
+                }
+            }
+        }
+    }
+
+    /**
+     * Stop tracking a smoothed bitrate for this layer, dropping the tracker and its history. Called when the source
+     * stops being bursty (e.g. a screen share reverting to camera), so that the layer stops paying for the tracker,
+     * and so that a later re-enable does not price the source from the previous mode's traffic.
+     */
+    fun disableSmoothedBitrate() {
+        if (smoothedBitrateTracker != null) {
+            synchronized(this) {
+                smoothedBitrateTracker = null
+            }
+        }
+    }
+
+    /**
+     * The rate of this layer alone, either over the estimator-matched window or over the longer window used for
+     * bursty sources. The smoothed rate falls back to the other one while it is not being tracked, and while its
+     * tracker does not yet have a full window of history (since it always divides by the full window, a young tracker
+     * would under-report the rate, in the extreme pricing the source at zero at the moment it is enabled).
+     */
+    protected fun layerRate(nowMs: Long, smoothed: Boolean): Bandwidth {
+        val smoothedTracker = if (smoothed) smoothedBitrateTracker else null
+        return if (smoothedTracker != null && nowMs - smoothedBitrateTrackerCreatedMs >= smoothedWindowMs) {
+            smoothedTracker.getRateOverFullWindow(nowMs)
+        } else {
+            bitrateTracker.getRate(nowMs)
+        }
+    }
 
     var targetBitrate: Bandwidth? = null
 
@@ -88,16 +143,21 @@ abstract class RtpLayerDesc(
     /**
      * Inherit a [BitrateTracker] object
      */
-    internal fun inheritStatistics(tracker: BitrateTracker, smoothedTracker: BitrateTracker) {
+    internal fun inheritStatistics(tracker: BitrateTracker) {
         bitrateTracker = tracker
-        smoothedBitrateTracker = smoothedTracker
     }
 
     /**
      * Inherit another layer description's [BitrateTracker] object.
      */
     internal open fun inheritFrom(other: RtpLayerDesc) {
-        inheritStatistics(other.bitrateTracker, other.smoothedBitrateTracker)
+        inheritStatistics(other.bitrateTracker)
+        // Only take the other layer's smoothed tracker if it has one: layer arrays are replaced whenever the
+        // scalability structure is re-signaled, and dropping an established tracker would restart its window.
+        other.smoothedBitrateTracker?.let {
+            smoothedBitrateTrackerCreatedMs = other.smoothedBitrateTrackerCreatedMs
+            smoothedBitrateTracker = it
+        }
         targetBitrate = other.targetBitrate
     }
 
@@ -111,7 +171,7 @@ abstract class RtpLayerDesc(
         val wasInactive = hasZeroBitrate(nowMs)
         // Update rate stats (this should run after padding termination).
         bitrateTracker.update(packetSize, nowMs)
-        smoothedBitrateTracker.update(packetSize, nowMs)
+        smoothedBitrateTracker?.update(packetSize, nowMs)
         return wasInactive && packetSize.bits > 0L
     }
 
@@ -141,6 +201,7 @@ abstract class RtpLayerDesc(
         put("height", height)
         put("index", index)
         put("bitrate_bps", getBitrate(System.currentTimeMillis()).bps)
+        put("smoothed_bitrate_bps", getSmoothedBitrate(System.currentTimeMillis()).bps)
         put("target_bitrate", targetBitrate?.bps ?: 0)
         put("indexString", indexString())
     }
@@ -148,6 +209,9 @@ abstract class RtpLayerDesc(
     abstract fun indexString(): String
 
     companion object {
+        /** The length of the smoothed trackers' window, cached (it is fixed by configuration). */
+        private val smoothedWindowMs: Long by lazy { BitrateCalculator.smoothedWindowSize.toMillis() }
+
         /**
          * The index value that is used to represent that forwarding is suspended.
          */

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/VideoType.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/VideoType.kt
@@ -28,4 +28,10 @@ enum class VideoType {
     NONE;
 
     fun isEnabled() = this != NONE && this != DISABLED
+
+    /**
+     * Whether this is a screen sharing type. Note that among other things screen sharing sources have bursty bitrates,
+     * because the encoder may leave long gaps between frames while the content is static.
+     */
+    fun isScreenshare() = this == DESKTOP || this == DESKTOP_HIGH_FPS
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDRtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDRtpLayerDesc.kt
@@ -64,6 +64,8 @@ class Av1DDRtpLayerDesc(
 
     override fun getBitrate(nowMs: Long) = bitrateTracker.getRate(nowMs)
 
+    override fun getSmoothedBitrate(nowMs: Long) = smoothedBitrateTracker.getRate(nowMs)
+
     override fun hasZeroBitrate(nowMs: Long) = bitrateTracker.getAccumulatedSize(nowMs).bits == 0L
 
     /**

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDRtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDRtpLayerDesc.kt
@@ -62,9 +62,9 @@ class Av1DDRtpLayerDesc(
     override val layerId = dt
     override val index = getIndex(eid, dt)
 
-    override fun getBitrate(nowMs: Long) = bitrateTracker.getRate(nowMs)
+    override fun getBitrate(nowMs: Long) = layerRate(nowMs, smoothed = false)
 
-    override fun getSmoothedBitrate(nowMs: Long) = smoothedBitrateTracker.getRateOverFullWindow(nowMs)
+    override fun getSmoothedBitrate(nowMs: Long) = layerRate(nowMs, smoothed = true)
 
     override fun hasZeroBitrate(nowMs: Long) = bitrateTracker.getAccumulatedSize(nowMs).bits == 0L
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDRtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDRtpLayerDesc.kt
@@ -64,7 +64,7 @@ class Av1DDRtpLayerDesc(
 
     override fun getBitrate(nowMs: Long) = bitrateTracker.getRate(nowMs)
 
-    override fun getSmoothedBitrate(nowMs: Long) = smoothedBitrateTracker.getRate(nowMs)
+    override fun getSmoothedBitrate(nowMs: Long) = smoothedBitrateTracker.getRateOverFullWindow(nowMs)
 
     override fun hasZeroBitrate(nowMs: Long) = bitrateTracker.getAccumulatedSize(nowMs).bits == 0L
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vpx/VpxRtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vpx/VpxRtpLayerDesc.kt
@@ -150,11 +150,7 @@ constructor(
         if (rates.containsKey(index)) {
             return rates
         }
-        rates[index] = if (smoothed) {
-            smoothedBitrateTracker.getRateOverFullWindow(nowMs)
-        } else {
-            bitrateTracker.getRate(nowMs)
-        }
+        rates[index] = layerRate(nowMs, smoothed)
 
         dependencyLayers.forEach { it.calcBitrate(nowMs, smoothed, rates) }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vpx/VpxRtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vpx/VpxRtpLayerDesc.kt
@@ -129,7 +129,9 @@ constructor(
      * @param nowMs
      * @return the cumulative bitrate (in bps) of this [RtpLayerDesc] and its dependencies.
      */
-    override fun getBitrate(nowMs: Long): Bandwidth = calcBitrate(nowMs).values.sum()
+    override fun getBitrate(nowMs: Long): Bandwidth = calcBitrate(nowMs, smoothed = false).values.sum()
+
+    override fun getSmoothedBitrate(nowMs: Long): Bandwidth = calcBitrate(nowMs, smoothed = true).values.sum()
 
     /**
      * Recursively adds the bitrate (in bps) of this [RtpLayerDesc] and
@@ -140,16 +142,20 @@ constructor(
      *
      * @param nowMs
      */
-    private fun calcBitrate(nowMs: Long, rates: MutableMap<Int, Bandwidth> = HashMap()): MutableMap<Int, Bandwidth> {
+    private fun calcBitrate(
+        nowMs: Long,
+        smoothed: Boolean,
+        rates: MutableMap<Int, Bandwidth> = HashMap()
+    ): MutableMap<Int, Bandwidth> {
         if (rates.containsKey(index)) {
             return rates
         }
-        rates[index] = bitrateTracker.getRate(nowMs)
+        rates[index] = if (smoothed) smoothedBitrateTracker.getRate(nowMs) else bitrateTracker.getRate(nowMs)
 
-        dependencyLayers.forEach { it.calcBitrate(nowMs, rates) }
+        dependencyLayers.forEach { it.calcBitrate(nowMs, smoothed, rates) }
 
         if (useSoftDependencies) {
-            softDependencyLayers.forEach { it.calcBitrate(nowMs, rates) }
+            softDependencyLayers.forEach { it.calcBitrate(nowMs, smoothed, rates) }
         }
 
         return rates

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vpx/VpxRtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vpx/VpxRtpLayerDesc.kt
@@ -150,7 +150,11 @@ constructor(
         if (rates.containsKey(index)) {
             return rates
         }
-        rates[index] = if (smoothed) smoothedBitrateTracker.getRate(nowMs) else bitrateTracker.getRate(nowMs)
+        rates[index] = if (smoothed) {
+            smoothedBitrateTracker.getRateOverFullWindow(nowMs)
+        } else {
+            bitrateTracker.getRate(nowMs)
+        }
 
         dependencyLayers.forEach { it.calcBitrate(nowMs, smoothed, rates) }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/BitrateCalculator.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/BitrateCalculator.kt
@@ -17,6 +17,8 @@
 package org.jitsi.nlj.transform.node.incoming
 
 import org.jitsi.config.JitsiConfig
+import org.jitsi.metaconfig.config
+import org.jitsi.metaconfig.from
 import org.jitsi.metaconfig.optionalconfig
 import org.jitsi.nlj.Event
 import org.jitsi.nlj.MediaSourceDesc
@@ -178,7 +180,30 @@ open class BitrateCalculator(
         val bucketSize
             get() = _bucketSize ?: defaultBucketSize()
 
+        /**
+         * The size of the window over which to calculate average rates for sources whose bitrate is bursty, i.e.
+         * screen sharing. See [createSmoothedBitrateTracker].
+         */
+        val smoothedWindowSize: Duration by config(
+            "jmt.rtp.bitrate-calculator.smoothed-window-size".from(JitsiConfig.newConfig)
+        )
+
+        /** The size of the buckets to use with [smoothedWindowSize]. This must divide it evenly. */
+        val smoothedBucketSize: Duration by config(
+            "jmt.rtp.bitrate-calculator.smoothed-bucket-size".from(JitsiConfig.newConfig)
+        )
+
         fun createBitrateTracker() = BitrateTracker(windowSize, bucketSize)
+
+        /**
+         * Creates a tracker with a longer window than [createBitrateTracker], for use with sources whose bitrate is
+         * bursty. A screen sharing encoder is allowed to accumulate about a second of its target bitrate while the
+         * screen is static and then spend it on a single frame, and libwebrtc's screen sharing rate control tolerates
+         * intervals of up to 2.75 seconds between frames, so a rate measured over [windowSize] (which matches the
+         * bandwidth estimator's window) is not representative of the bandwidth such a source actually needs.
+         */
+        fun createSmoothedBitrateTracker() = BitrateTracker(smoothedWindowSize, smoothedBucketSize)
+
         fun createRateTracker() = RateTracker(windowSize, bucketSize)
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/BitrateTracker.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/BitrateTracker.kt
@@ -32,6 +32,16 @@ open class BitrateTracker @JvmOverloads constructor(
 
     @JvmOverloads
     open fun getRateBps(nowMs: Long = clock.millis()): Long = tracker.getRate(nowMs)
+
+    /**
+     * The rate over the full window, that is without the ramp-up which [getRate] applies while the window has not yet
+     * filled up. When a stream has had no packets for a whole window the tracker restarts, and [getRate] then divides
+     * by the time since it resumed rather than by the window; for a bursty stream that turns the first frame after an
+     * idle period into a rate many times the one the stream actually sustains. This under-states the rate of a stream
+     * which has genuinely just started, which is the safer direction when deciding whether it can be forwarded.
+     */
+    fun getRateOverFullWindow(nowMs: Long = clock.millis()): Bandwidth = getAccumulatedSize(nowMs).per(windowSize)
+
     val rate: Bandwidth
         get() = getRate()
     fun update(dataSize: DataSize, now: Long = clock.millis()) = tracker.update(dataSize.bits, now)

--- a/jitsi-media-transform/src/main/resources/reference.conf
+++ b/jitsi-media-transform/src/main/resources/reference.conf
@@ -144,6 +144,14 @@ jmt {
       // The bucket size used to calculate average bitrate (smaller bucket size provides more precision, but requires
       // more memory). This must evenly divide [window-size].
       # bucket-size = 100 ms
+
+      // The window used for sources whose bitrate is bursty (screen sharing), for which the window above -- which is
+      // matched to the bandwidth estimator's window -- is too short to be representative. It should exceed both the
+      // rate control credit a screen sharing encoder may accumulate (about 1 second) and the maximum interval it may
+      // leave between frames (2.75 seconds in libwebrtc).
+      smoothed-window-size = 5 seconds
+      // The bucket size used with smoothed-window-size. This must evenly divide it.
+      smoothed-bucket-size = 100 ms
     }
   }
 

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/MediaSourceDescTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/MediaSourceDescTest.kt
@@ -72,7 +72,8 @@ class MediaSourceDescTest : ShouldSpec() {
                         (i == source.rtpEncodings.size - 1 && j == e.layers.size - 1)
                     ) {
                         /* Encode the layer ID into the rate, so it's unambiguous which layers are getting summed. */
-                        l.inheritStatistics(FakeBitrateTracker(1L shl (i * source.rtpEncodings.size + j)))
+                        val tracker = FakeBitrateTracker(1L shl (i * source.rtpEncodings.size + j))
+                        l.inheritStatistics(tracker, tracker)
                     }
                 }
             }

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/MediaSourceDescTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/MediaSourceDescTest.kt
@@ -72,8 +72,7 @@ class MediaSourceDescTest : ShouldSpec() {
                         (i == source.rtpEncodings.size - 1 && j == e.layers.size - 1)
                     ) {
                         /* Encode the layer ID into the rate, so it's unambiguous which layers are getting summed. */
-                        val tracker = FakeBitrateTracker(1L shl (i * source.rtpEncodings.size + j))
-                        l.inheritStatistics(tracker, tracker)
+                        l.inheritStatistics(FakeBitrateTracker(1L shl (i * source.rtpEncodings.size + j)))
                     }
                 }
             }

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/RtpLayerDescTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/RtpLayerDescTest.kt
@@ -16,8 +16,10 @@
 package org.jitsi.nlj
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import org.jitsi.nlj.rtp.codec.vpx.VpxRtpLayerDesc
+import org.jitsi.nlj.util.bytes
 
 class RtpLayerDescTest : FunSpec({
 
@@ -89,5 +91,62 @@ class RtpLayerDescTest : FunSpec({
         vp9Layers[6].layerId shouldBe 16
         vp9Layers[7].layerId shouldBe 17
         vp9Layers[8].layerId shouldBe 18
+    }
+
+    test("Smoothed bitrate is not tracked until enabled") {
+        val layer = VpxRtpLayerDesc(0, 0, -1, 180, 30.0)
+        layer.updateBitrate(1000.bytes, 0)
+
+        // Fall back to the bitrate over the estimator-matched window.
+        layer.getSmoothedBitrate(100) shouldBe layer.getBitrate(100)
+    }
+
+    test("Smoothed bitrate falls back until its tracker has a full window of history") {
+        val layer = VpxRtpLayerDesc(0, 0, -1, 180, 30.0)
+        layer.enableSmoothedBitrate(0)
+        layer.updateBitrate(1000.bytes, 0)
+
+        layer.getSmoothedBitrate(100) shouldBe layer.getBitrate(100)
+    }
+
+    test("Smoothed bitrate is lower than the short-window rate once its window has filled") {
+        val layer = VpxRtpLayerDesc(0, 0, -1, 180, 30.0)
+        layer.enableSmoothedBitrate(0)
+        val nowMs = 6000L // Past the smoothed window (5s by default).
+        layer.updateBitrate(1000.bytes, nowMs)
+
+        layer.getSmoothedBitrate(nowMs + 100) shouldBeLessThan layer.getBitrate(nowMs + 100)
+    }
+
+    test("Enabling the smoothed bitrate twice does not discard the data collected so far") {
+        val layer = VpxRtpLayerDesc(0, 0, -1, 180, 30.0)
+        layer.enableSmoothedBitrate(0)
+        val nowMs = 6000L
+        layer.updateBitrate(1000.bytes, nowMs)
+        val before = layer.getSmoothedBitrate(nowMs + 100)
+
+        layer.enableSmoothedBitrate(nowMs + 100)
+        layer.getSmoothedBitrate(nowMs + 100) shouldBe before
+    }
+
+    test("Disabling the smoothed bitrate reverts to the short-window rate") {
+        val layer = VpxRtpLayerDesc(0, 0, -1, 180, 30.0)
+        layer.enableSmoothedBitrate(0)
+        val nowMs = 6000L
+        layer.updateBitrate(1000.bytes, nowMs)
+
+        layer.disableSmoothedBitrate()
+        layer.getSmoothedBitrate(nowMs + 100) shouldBe layer.getBitrate(nowMs + 100)
+    }
+
+    test("A layer inheriting from another keeps an established smoothed tracker") {
+        val old = VpxRtpLayerDesc(0, 0, -1, 180, 30.0)
+        old.enableSmoothedBitrate(0)
+        val nowMs = 6000L
+        old.updateBitrate(1000.bytes, nowMs)
+
+        val new = VpxRtpLayerDesc(0, 0, -1, 180, 30.0)
+        new.inheritFrom(old)
+        new.getSmoothedBitrate(nowMs + 100) shouldBe old.getSmoothedBitrate(nowMs + 100)
     }
 })

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/util/BitrateTrackerTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/util/BitrateTrackerTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright @ 2026 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.nlj.util
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.jitsi.utils.ms
+import org.jitsi.utils.secs
+import org.jitsi.utils.time.FakeClock
+
+class BitrateTrackerTest : ShouldSpec() {
+    private val clock = FakeClock()
+    private val tracker = BitrateTracker(5.secs, 100.ms, clock)
+
+    init {
+        context("A single burst") {
+            // 500 kbit, which is 100 kbps once spread over the 5 second window.
+            tracker.update(500_000.bits, clock.millis())
+            clock.elapse(100.ms)
+
+            should("read as a high rate while the window has not filled up") {
+                // getRate divides by the time since the stream started, not by the window.
+                tracker.getRate(clock.millis()) shouldBe 5.mbps
+            }
+            should("read as its average over the window with getRateOverFullWindow") {
+                tracker.getRateOverFullWindow(clock.millis()) shouldBe 100.kbps
+            }
+            context("Once the window has filled up") {
+                clock.elapse(4900.ms)
+                should("agree with getRate") {
+                    tracker.getRate(clock.millis()) shouldBe 100.kbps
+                    tracker.getRateOverFullWindow(clock.millis()) shouldBe 100.kbps
+                }
+            }
+            context("Once the burst has aged out of the window") {
+                clock.elapse(10.secs)
+                should("read as zero") {
+                    tracker.getRateOverFullWindow(clock.millis()) shouldBe 0.bps
+                }
+            }
+        }
+    }
+}

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BandwidthAllocator.kt
@@ -248,6 +248,13 @@ internal class BandwidthAllocator<T : MediaSourceContainer>(
             availableBandwidth
         }
         var remainingBandwidth = initialBandwidth
+        // Only one source is allowed to oversend: the first on-stage source which actually has an oversend layer.
+        // We can not use the index in the loop below to identify it, because sources with disabled constraints are
+        // skipped; and we require an oversend layer so that when there is more than one on-stage source (e.g. a
+        // camera and a screenshare) the slot is not wasted on one which can not use it.
+        val oversendingIndex = sourceBitrateAllocations.indexOfFirst {
+            !it.constraints.isDisabled() && it.isOnStage() && it.layers.oversendIndex >= 0
+        }
         var oldRemainingBandwidth: Long = -1
         var oversending = false
         while (oldRemainingBandwidth != remainingBandwidth) {
@@ -259,7 +266,7 @@ internal class BandwidthAllocator<T : MediaSourceContainer>(
                 }
 
                 // In stage view improve greedily until preferred, in tile view go step-by-step.
-                remainingBandwidth -= sourceBitrateAllocation.improve(remainingBandwidth, i == 0)
+                remainingBandwidth -= sourceBitrateAllocation.improve(remainingBandwidth, i == oversendingIndex)
                 if (remainingBandwidth < 0) {
                     oversending = true
                 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BitrateController.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BitrateController.kt
@@ -245,12 +245,16 @@ class BitrateController<T : MediaSourceContainer> @JvmOverloads constructor(
 
         var totalTargetBps = 0.0
         var totalIdealBps = 0.0
+        var totalTargetSmoothedBps = 0.0
+        var totalIdealSmoothedBps = 0.0
         var totalTargetVlaBps = 0.0
         var totalIdealVlaBps = 0.0
 
         allocation.allocations.forEach {
             it.targetLayer?.getBitrate(nowMs)?.let { bitrate -> totalTargetBps += bitrate.bps }
             it.idealLayer?.getBitrate(nowMs)?.let { bitrate -> totalIdealBps += bitrate.bps }
+            it.targetLayer?.getSmoothedBitrate(nowMs)?.let { bitrate -> totalTargetSmoothedBps += bitrate.bps }
+            it.idealLayer?.getSmoothedBitrate(nowMs)?.let { bitrate -> totalIdealSmoothedBps += bitrate.bps }
             it.targetLayer?.targetBitrate?.let { bitrate -> totalTargetVlaBps += bitrate.bps }
             it.idealLayer?.targetBitrate?.let { bitrate -> totalIdealVlaBps += bitrate.bps }
             trace(
@@ -260,8 +264,10 @@ class BitrateController<T : MediaSourceContainer> @JvmOverloads constructor(
                     .addField("target_idx", it.targetLayer?.index ?: -1)
                     .addField("ideal_idx", it.idealLayer?.index ?: -1)
                     .addField("target_bps_measured", it.targetLayer?.getBitrate(nowMs)?.bps ?: -1)
+                    .addField("target_bps_smoothed", it.targetLayer?.getSmoothedBitrate(nowMs)?.bps ?: -1)
                     .addField("target_bps_vla", it.targetLayer?.targetBitrate?.bps ?: -1)
                     .addField("ideal_bps_measured", it.idealLayer?.getBitrate(nowMs)?.bps ?: -1)
+                    .addField("ideal_bps_smoothed", it.idealLayer?.getSmoothedBitrate(nowMs)?.bps ?: -1)
                     .addField("ideal_bps_vla", it.idealLayer?.targetBitrate?.bps ?: -1)
             )
         }
@@ -271,6 +277,8 @@ class BitrateController<T : MediaSourceContainer> @JvmOverloads constructor(
                 .makeTimeSeriesPoint("allocation", nowMs)
                 .addField("total_target_measured_bps", totalTargetBps)
                 .addField("total_ideal_measured_bps", totalIdealBps)
+                .addField("total_target_smoothed_bps", totalTargetSmoothedBps)
+                .addField("total_ideal_smoothed_bps", totalIdealSmoothedBps)
                 .addField("total_target_vla_bps", totalTargetVlaBps)
                 .addField("total_ideal_vla_bps", totalIdealVlaBps)
         )

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/Layers.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/Layers.kt
@@ -23,11 +23,15 @@ import org.jitsi.nlj.RtpLayerDesc
 data class LayerSnapshot(
     val layer: RtpLayerDesc,
     /**
-     * The bitrate (in bps) to use for allocation. Depending on the `use-vla-target-bitrate` config this is either
-     * [measuredBitrate] or [vlaTargetBitrate].
+     * The bitrate (in bps) to use for allocation: [vlaTargetBitrate] when `use-vla-target-bitrate` is enabled and the
+     * sender signals one; otherwise the smoothed measured bitrate for screen sharing (bursty) sources, and
+     * [measuredBitrate] for everything else.
      */
     val bitrate: Long,
-    /** The bitrate (in bps) measured for the layer (and its dependencies). */
+    /**
+     * The bitrate (in bps) measured for the layer (and its dependencies) over the short window, i.e. the one which
+     * matches the bandwidth estimator's. Note that this is not necessarily the bitrate used for allocation.
+     */
     val measuredBitrate: Long = bitrate,
     /**
      * The target bitrate (in bps) signaled by the sender in the VLA RTP header extension, or `null` if the sender

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
@@ -361,24 +361,24 @@ internal class SingleSourceAllocation(
         if (constraints.maxHeight == 0 || !source.hasRtpLayers()) {
             return Layers.noLayers
         }
+        // Screen sharing is bursty: while the screen is static the encoder accumulates rate control credit (about a
+        // second's worth) and then spends it on a single frame, so the bitrate measured over the short window is not
+        // representative of the bandwidth the source needs. Allocate for it using the longer window instead.
+        val isBursty = source.videoType.isScreenshare()
         val layers = source.rtpLayers.map {
             val measuredBitrate = it.getBitrate(nowMs).bps
             val vlaTargetBitrate = it.targetBitrate?.bps
-            LayerSnapshot(
-                it,
-                if (config.useVlaTargetBitrate) {
-                    vlaTargetBitrate ?: measuredBitrate
-                } else {
-                    measuredBitrate
-                },
-                measuredBitrate,
-                vlaTargetBitrate
-            )
+            val allocationBitrate = when {
+                config.useVlaTargetBitrate && vlaTargetBitrate != null -> vlaTargetBitrate
+                isBursty -> it.getSmoothedBitrate(nowMs).bps
+                else -> measuredBitrate
+            }
+            LayerSnapshot(it, allocationBitrate, measuredBitrate, vlaTargetBitrate)
         }
 
-        return when (source.videoType) {
-            VideoType.CAMERA -> selectLayersForCamera(layers, constraints)
-            VideoType.DESKTOP, VideoType.DESKTOP_HIGH_FPS -> selectLayersForScreensharing(
+        return when {
+            source.videoType == VideoType.CAMERA -> selectLayersForCamera(layers, constraints)
+            source.videoType.isScreenshare() -> selectLayersForScreensharing(
                 layers,
                 constraints,
                 onStage,

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
@@ -80,13 +80,11 @@ internal class SingleSourceAllocation(
             for (layerSnapshot in layers.layers) {
                 val l = layerSnapshot.layer
                 val prefix = "${l.indexString()}_${l.height}p_${l.frameRate}fps"
-                ratesTimeSeriesPoint.addField("${prefix}_bps", layerSnapshot.bitrate)
                 // Which fields are present must not vary with the data, so that the series can be consumed
-                // mechanically. The measured bitrate is the only exception: with useVlaTargetBitrate disabled it is
-                // by configuration always equal to the bitrate above, so it is never added.
-                if (config.useVlaTargetBitrate) {
-                    ratesTimeSeriesPoint.addField("${prefix}_measured_bps", layerSnapshot.measuredBitrate)
-                }
+                // mechanically. Note that the bitrate used for allocation is one of the other two, depending on the
+                // configuration and on whether the source is bursty.
+                ratesTimeSeriesPoint.addField("${prefix}_bps", layerSnapshot.bitrate)
+                ratesTimeSeriesPoint.addField("${prefix}_measured_bps", layerSnapshot.measuredBitrate)
                 // -1 means the sender does not signal a target bitrate for the layer in the VLA extension.
                 ratesTimeSeriesPoint.addField("${prefix}_vla_bps", layerSnapshot.vlaTargetBitrate ?: -1)
             }
@@ -366,6 +364,13 @@ internal class SingleSourceAllocation(
         // representative of the bandwidth the source needs. Allocate for it using the longer window instead.
         val isBursty = source.videoType.isScreenshare()
         val layers = source.rtpLayers.map {
+            if (isBursty) {
+                // Only bursty sources need the extra tracker, so it is not created until we ask for it.
+                it.enableSmoothedBitrate(nowMs)
+            } else {
+                // And when a source stops being bursty, drop the tracker so its layers stop paying for it.
+                it.disableSmoothedBitrate()
+            }
             val measuredBitrate = it.getBitrate(nowMs).bps
             val vlaTargetBitrate = it.targetBitrate?.bps
             val allocationBitrate = when {

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerTest.kt
@@ -1636,6 +1636,7 @@ class MockRtpLayerDesc(
     override val index = getIndex(eid, sid, tid)
 
     override fun getBitrate(nowMs: Long): Bandwidth = bitrate
+    override fun getSmoothedBitrate(nowMs: Long): Bandwidth = bitrate
     override fun hasZeroBitrate(nowMs: Long): Boolean = bitrate == 0.bps
     override fun indexString() = indexString(index)
 }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerTest.kt
@@ -158,6 +158,46 @@ class BitrateControllerTest : ShouldSpec() {
                         verifyStageView()
                     }
                 }
+                context("and the on-stage screenshare does not fit in the available bandwidth") {
+                    // A screenshare with a single expensive layer, i.e. with nothing cheaper for the allocator to
+                    // fall back to. This is what low frame rate screensharing looks like, because the sender only
+                    // activates its highest resolution encoding.
+                    val screenshare = TestEndpoint(
+                        "S",
+                        arrayOf(
+                            MediaSourceDesc(
+                                arrayOf(
+                                    RtpEncodingDesc(
+                                        100L,
+                                        arrayOf(
+                                            MockRtpLayerDesc(
+                                                tid = 0,
+                                                eid = 0,
+                                                height = 1080,
+                                                frameRate = 5.0,
+                                                bitrate = 2000.kbps
+                                            )
+                                        )
+                                    )
+                                ),
+                                sourceName = "S-v0",
+                                owner = "S",
+                                videoType = VideoType.DESKTOP
+                            )
+                        )
+                    )
+                    val bc = BitrateControllerWrapper(listOf(screenshare, b, c), clock = clock)
+                    bc.setStageView("S-v0")
+
+                    // Not enough for the screenshare even with the oversend allowance, though plenty for thumbnails.
+                    bc.bwe = 300.kbps
+
+                    // Nothing is forwarded: bandwidth is reserved for the on-stage source until it reaches its
+                    // "preferred" layer, even when it can not be forwarded at all. This is deliberate, to prevent
+                    // flapping while the estimate ramps up (thumbnails would be enabled here only to be disabled
+                    // when the estimate improves enough for the on-stage source to claim the whole budget).
+                    bc.allocationHistory.last().event.forwardedSources shouldBe emptySet()
+                }
                 context("When LastN=0") {
                     // LastN=0 is used when the client goes in "audio-only" mode.
                     bc.setEndpointOrdering(a, b, c, d)


### PR DESCRIPTION
## Problem

Screenshares are suspended for "insufficient bandwidth" in circumstances where that is surprising ([community thread](https://community.jitsi.org/t/screen-sharing-turned-off-due-to-insufficient-bandwidth/142455)). With the per-source detail added in #2439 deployed on beta, a 40-minute conference showed what is happening. For a 1898p AV1 screenshare declaring a steady 1.35 Mbps VLA target:

* The measured bitrate of its base layer ranged from **919 kbps to 3.73 Mbps** — in one event a receiver with **2.78 Mbps** of estimated bandwidth had the screenshare suspended because the measurement caught a burst.
* In all 21 screenshare-suspension events, **nothing at all was allocated** (`remaining == bwe`): the receiver could not afford the screenshare, and the stage view deliberately reserves the bandwidth for the on-stage source (to prevent flapping during ramp-up), so no thumbnails were forwarded either. This PR does **not** change that behavior — the measurement fixes below shrink the population of receivers *spuriously* stuck in that state, and a ramp-up-aware treatment can be considered once there is data on what remains. A new test pins the current behavior as intentional.
* In 148 further events the screenshare was forwarded but other sources were "never considered"; in 74 of those the leftover budget would have covered them (up to ~2 Mbps left idle vs. a 57 kbps thumbnail). This is addressed by the separate preferred-layer PR.

The measurement problem is structural, not noise. The default measurement window matches the BWE window (1 second for GoogleCc2 — deliberately, since a mismatch between the two caused instability), but low-fps screenshare violates a 1 s window's assumptions on the sender side:

* libaom runs CBR with a 1-second rate-control buffer (`rc_buf_sz = 1000`), so the encoder may bank a second of its target while the screen is static and legally spend it on one frame. Measured over 1 s, that frame reads as ~2× target — the observed common value was 2,024,104 bps against the declared 1,350,000, ratio 1.50, max 2.76.
* libwebrtc's screenshare rate control tolerates up to 2.75 s between frames (`ScreenshareLayers::kMaxFrameIntervalMs`), so a 1 s window sees one frame, two, or none.
* When it sees none for a full window, `RateTracker` resets and its ramp-up divides the next burst by the time since it resumed (floor: one bucket) — unbounded inflation.

## Changes

* **fix: Identify the source allowed to oversend by whether it is on-stage.** Oversending was keyed on loop index 0; a constraints-disabled source sorted first silently disabled oversending, and with two on-stage sources only the first could oversend.
* **feat: Measure the bitrate of screen sharing sources over a longer window.** A second per-layer tracker with a 5 s window (`jmt.rtp.bitrate-calculator.smoothed-window-size`), used only to *allocate* for DESKTOP sources. Everything the BWE loop touches — including the target bitrate `BandwidthProbing` derives padding from — keeps the estimator-matched window, so the coupling between the CC and BWE windows is preserved. 5 s exceeds both sender-side bounds above; on the observed data it recovers 6 of the 9 recoverable suspensions (the other 12 of 21 were genuinely unaffordable at any window).
* **fix: Do not price a bursty source from a partially filled measurement window.** The smoothed rate always divides by the full window (`getRateOverFullWindow`), removing the idle-reset ramp-up artifact. This under-prices a source for up to one window after it starts or resumes — the safe direction for a suspend decision, though it does mean brief unbounded-by-`max-oversend-bitrate` overshoot when a share wakes up.
* **ref: Only track a smoothed bitrate for the sources which use it.** The extra tracker is created on demand, so camera sources (the majority) pay neither the memory nor the per-packet update. The smoothed rate is reported in `debugState` and the `allocation`/`allocation_for_source` time series.

A separate PR (#2444) changes the screenshare "preferred" layer policy, which addresses the 148-event thumbnail starvation case.

## Known trade-offs

* The smoothed rate falls back to the estimator-matched rate until its tracker has a full window of history, so the burst-aliasing behavior persists for the first ~5 s after a source becomes a screenshare.
* The full-window divisor under-prices a share for up to one window after it resumes from idle — the safe direction for a suspend decision, but it means brief overshoot (not bounded by `max-oversend-bitrate`) when a share wakes up.
* A receiver which genuinely can not afford the on-stage screenshare still receives nothing at all (no thumbnails). This is the pre-existing anti-flapping design, kept deliberately; whether to special-case a non-ramping "stuck" state is left for a follow-up informed by data gathered with these changes deployed.

## Testing

Full suite passes (rtp 202, jitsi-media-transform 400, jvb 406). New tests: the starvation regression in `BitrateControllerTest`, `BitrateTrackerTest` for the full-window rate, and `RtpLayerDescTest` for the lazy smoothed tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
