### PR TITLE
feat: For screen sharing, prefer full resolution over full frame rate

### DIFF
--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
@@ -280,13 +280,17 @@ internal class SingleSourceAllocation(
     /**
      * Selects from a list of layers the ones which should be considered when allocating bandwidth, as well as the
      * "preferred" and "oversend" layers. Logic specific to screensharing: we prioritize resolution over framerate,
-     * prioritize the highest layer over other endpoints (by setting the highest layer as "preferred"), and allow
-     * oversending up to the highest resolution (with low frame rate).
+     * prioritize the full resolution (at the frame rate which is cheapest to send it at) over other endpoints by
+     * setting it as "preferred", and allow oversending up to the full resolution (with low frame rate). Above the
+     * preferred layer the screenshare's frame rate competes with the other sources, which may reduce (though not
+     * disable) their quality as it improves.
      */
     private fun selectLayersForScreensharing(
         layers: List<LayerSnapshot>,
         constraints: VideoConstraints,
-        onStage: Boolean
+        onStage: Boolean,
+        /** Whether the sender has asked for the share's frame rate to be prioritized. */
+        highFps: Boolean
     ): Layers {
         var activeLayers = layers.filter { it.bitrate > 0 }
         // No active layers usually happens when the source has just been signaled and we haven't received
@@ -313,17 +317,28 @@ internal class SingleSourceAllocation(
             }
         }
 
-        val oversendIdx = if (onStage && config.allowOversendOnStage) {
-            val maxHeight = selectedLayers.maxOfOrNull { it.layer.height } ?: return Layers.noLayers
-            // Of all layers with the highest resolution select the one with lowest bitrate. In case of VP9 the layers
-            // are not necessarily ordered by bitrate.
-            val lowestBitrateLayer = selectedLayers.filter { it.layer.height == maxHeight }.minByOrNull { it.bitrate }
-                ?: return Layers.noLayers
-            selectedLayers.indexOf(lowestBitrateLayer)
+        // A source always has at least one layer here (selectLayers returns early otherwise), and the branches above
+        // never leave selectedLayers empty, so the maxima below exist.
+        val maxHeight = selectedLayers.maxOf { it.layer.height }
+        val maxHeightIndices = selectedLayers.indices.filter { selectedLayers[it].layer.height == maxHeight }
+        // Of all layers with the highest resolution, the one with the lowest bitrate. In case of VP9 the layers are
+        // not necessarily ordered by bitrate.
+        val cheapestMaxHeightIdx = maxHeightIndices.minBy { selectedLayers[it].bitrate }
+        // Since we prioritize resolution over frame rate, "preferred" is the full resolution at the frame rate which
+        // is cheapest to send it at. Anything above that improves frame rate only, and competes with the other
+        // sources on equal terms rather than blocking them entirely. There are two exceptions, for which we keep the
+        // highest layer as "preferred" (as we previously did for all screen sharing):
+        //  - High frame rate screen sharing, where the sender has explicitly asked for frame rate to be prioritized.
+        //  - The structure used with VP9 (multiple encodings with the same resolution and unknown frame rate), where
+        //    the layers above the cheapest one improve quality rather than frame rate, and quality is exactly what
+        //    this policy exists to protect.
+        val preferredIdx = if (highFps || maxHeightIndices.any { selectedLayers[it].layer.frameRate < 0 }) {
+            selectedLayers.size - 1
         } else {
-            -1
+            cheapestMaxHeightIdx
         }
-        return Layers(selectedLayers, selectedLayers.size - 1, oversendIdx)
+        val oversendIdx = if (onStage && config.allowOversendOnStage) cheapestMaxHeightIdx else -1
+        return Layers(selectedLayers, preferredIdx, oversendIdx)
     }
 
     /**
@@ -363,7 +378,12 @@ internal class SingleSourceAllocation(
 
         return when (source.videoType) {
             VideoType.CAMERA -> selectLayersForCamera(layers, constraints)
-            VideoType.DESKTOP, VideoType.DESKTOP_HIGH_FPS -> selectLayersForScreensharing(layers, constraints, onStage)
+            VideoType.DESKTOP, VideoType.DESKTOP_HIGH_FPS -> selectLayersForScreensharing(
+                layers,
+                constraints,
+                onStage,
+                highFps = source.videoType == VideoType.DESKTOP_HIGH_FPS
+            )
             else -> Layers.noLayers
         }
     }

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerTest.kt
@@ -385,8 +385,10 @@ class BitrateControllerTest : ShouldSpec() {
         // TODO: the allocations for bwe=-1 are wrong.
         bc.allocationHistory.removeIf { it.bwe < 0.bps }
 
+        // Note that the thumbnails are enabled once the screenshare has reached full resolution at its cheapest
+        // frame rate (720p/7.5 at 660 kbps; the first thumbnail fits alongside it at bwe=710 kbps), and from then
+        // on the screenshare's frame rate competes with them.
         bc.allocationHistory.shouldMatchInOrder(
-            // We expect to be oversending when screensharing is used.
             Event(
                 0.kbps,
                 BandwidthAllocation(
@@ -419,37 +421,14 @@ class BitrateControllerTest : ShouldSpec() {
                         SingleAllocation(b, targetLayer = noVideo),
                         SingleAllocation(c, targetLayer = noVideo),
                         SingleAllocation(d, targetLayer = noVideo)
-                    ),
-                    oversending = false
-                )
-            ),
-            Event(
-                1320.kbps,
-                BandwidthAllocation(
-                    setOf(
-                        SingleAllocation(a, targetLayer = hd15),
-                        SingleAllocation(b, targetLayer = noVideo),
-                        SingleAllocation(c, targetLayer = noVideo),
-                        SingleAllocation(d, targetLayer = noVideo)
                     )
                 )
             ),
             Event(
-                2000.kbps,
+                710.kbps,
                 BandwidthAllocation(
                     setOf(
-                        SingleAllocation(a, targetLayer = hd30),
-                        SingleAllocation(b, targetLayer = noVideo),
-                        SingleAllocation(c, targetLayer = noVideo),
-                        SingleAllocation(d, targetLayer = noVideo)
-                    )
-                )
-            ),
-            Event(
-                2050.kbps,
-                BandwidthAllocation(
-                    setOf(
-                        SingleAllocation(a, targetLayer = hd30),
+                        SingleAllocation(a, targetLayer = hd7_5),
                         SingleAllocation(b, targetLayer = ld7_5),
                         SingleAllocation(c, targetLayer = noVideo),
                         SingleAllocation(d, targetLayer = noVideo)
@@ -457,10 +436,10 @@ class BitrateControllerTest : ShouldSpec() {
                 )
             ),
             Event(
-                2100.kbps,
+                760.kbps,
                 BandwidthAllocation(
                     setOf(
-                        SingleAllocation(a, targetLayer = hd30),
+                        SingleAllocation(a, targetLayer = hd7_5),
                         SingleAllocation(b, targetLayer = ld7_5),
                         SingleAllocation(c, targetLayer = ld7_5),
                         SingleAllocation(d, targetLayer = noVideo)
@@ -468,10 +447,10 @@ class BitrateControllerTest : ShouldSpec() {
                 )
             ),
             Event(
-                2150.kbps,
+                810.kbps,
                 BandwidthAllocation(
                     setOf(
-                        SingleAllocation(a, targetLayer = hd30),
+                        SingleAllocation(a, targetLayer = hd7_5),
                         SingleAllocation(b, targetLayer = ld7_5),
                         SingleAllocation(c, targetLayer = ld7_5),
                         SingleAllocation(d, targetLayer = ld7_5)
@@ -479,10 +458,10 @@ class BitrateControllerTest : ShouldSpec() {
                 )
             ),
             Event(
-                2200.kbps,
+                860.kbps,
                 BandwidthAllocation(
                     setOf(
-                        SingleAllocation(a, targetLayer = hd30),
+                        SingleAllocation(a, targetLayer = hd7_5),
                         SingleAllocation(b, targetLayer = ld15),
                         SingleAllocation(c, targetLayer = ld7_5),
                         SingleAllocation(d, targetLayer = ld7_5)
@@ -490,13 +469,134 @@ class BitrateControllerTest : ShouldSpec() {
                 )
             ),
             Event(
-                2250.kbps,
+                910.kbps,
                 BandwidthAllocation(
                     setOf(
-                        SingleAllocation(a, targetLayer = hd30),
+                        SingleAllocation(a, targetLayer = hd7_5),
                         SingleAllocation(b, targetLayer = ld15),
                         SingleAllocation(c, targetLayer = ld15),
                         SingleAllocation(d, targetLayer = ld7_5)
+                    )
+                )
+            ),
+            Event(
+                960.kbps,
+                BandwidthAllocation(
+                    setOf(
+                        SingleAllocation(a, targetLayer = hd7_5),
+                        SingleAllocation(b, targetLayer = ld15),
+                        SingleAllocation(c, targetLayer = ld15),
+                        SingleAllocation(d, targetLayer = ld15)
+                    )
+                )
+            ),
+            Event(
+                1010.kbps,
+                BandwidthAllocation(
+                    setOf(
+                        SingleAllocation(a, targetLayer = hd7_5),
+                        SingleAllocation(b, targetLayer = ld30),
+                        SingleAllocation(c, targetLayer = ld15),
+                        SingleAllocation(d, targetLayer = ld15)
+                    )
+                )
+            ),
+            Event(
+                1060.kbps,
+                BandwidthAllocation(
+                    setOf(
+                        SingleAllocation(a, targetLayer = hd7_5),
+                        SingleAllocation(b, targetLayer = ld30),
+                        SingleAllocation(c, targetLayer = ld30),
+                        SingleAllocation(d, targetLayer = ld15)
+                    )
+                )
+            ),
+            Event(
+                1120.kbps,
+                BandwidthAllocation(
+                    setOf(
+                        SingleAllocation(a, targetLayer = hd7_5),
+                        SingleAllocation(b, targetLayer = ld30),
+                        SingleAllocation(c, targetLayer = ld30),
+                        SingleAllocation(d, targetLayer = ld30)
+                    )
+                )
+            ),
+            Event(
+                1470.kbps,
+                BandwidthAllocation(
+                    setOf(
+                        SingleAllocation(a, targetLayer = hd15),
+                        SingleAllocation(b, targetLayer = ld7_5),
+                        SingleAllocation(c, targetLayer = ld7_5),
+                        SingleAllocation(d, targetLayer = ld7_5)
+                    )
+                )
+            ),
+            Event(
+                1520.kbps,
+                BandwidthAllocation(
+                    setOf(
+                        SingleAllocation(a, targetLayer = hd15),
+                        SingleAllocation(b, targetLayer = ld15),
+                        SingleAllocation(c, targetLayer = ld7_5),
+                        SingleAllocation(d, targetLayer = ld7_5)
+                    )
+                )
+            ),
+            Event(
+                1570.kbps,
+                BandwidthAllocation(
+                    setOf(
+                        SingleAllocation(a, targetLayer = hd15),
+                        SingleAllocation(b, targetLayer = ld15),
+                        SingleAllocation(c, targetLayer = ld15),
+                        SingleAllocation(d, targetLayer = ld7_5)
+                    )
+                )
+            ),
+            Event(
+                1620.kbps,
+                BandwidthAllocation(
+                    setOf(
+                        SingleAllocation(a, targetLayer = hd15),
+                        SingleAllocation(b, targetLayer = ld15),
+                        SingleAllocation(c, targetLayer = ld15),
+                        SingleAllocation(d, targetLayer = ld15)
+                    )
+                )
+            ),
+            Event(
+                1670.kbps,
+                BandwidthAllocation(
+                    setOf(
+                        SingleAllocation(a, targetLayer = hd15),
+                        SingleAllocation(b, targetLayer = ld30),
+                        SingleAllocation(c, targetLayer = ld15),
+                        SingleAllocation(d, targetLayer = ld15)
+                    )
+                )
+            ),
+            Event(
+                1720.kbps,
+                BandwidthAllocation(
+                    setOf(
+                        SingleAllocation(a, targetLayer = hd15),
+                        SingleAllocation(b, targetLayer = ld30),
+                        SingleAllocation(c, targetLayer = ld30),
+                        SingleAllocation(d, targetLayer = ld15)
+                    )
+                )
+            ),
+            Event(
+                1780.kbps,
+                BandwidthAllocation(
+                    setOf(
+                        SingleAllocation(a, targetLayer = hd15),
+                        SingleAllocation(b, targetLayer = ld30),
+                        SingleAllocation(c, targetLayer = ld30),
+                        SingleAllocation(d, targetLayer = ld30)
                     )
                 )
             ),

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocationTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocationTest.kt
@@ -204,9 +204,9 @@ class SingleSourceAllocationTest : ShouldSpec() {
                             clock
                         )
 
-                    // For screensharing the "preferred" layer should be the highest -- always prioritized over other
-                    // endpoints.
-                    allocation.preferredLayer shouldBe hd30
+                    // For screensharing the "preferred" layer is the full resolution at its cheapest frame rate: the
+                    // resolution is prioritized over other sources, but additional frame rate is not.
+                    allocation.preferredLayer shouldBe hd7point5
                     allocation.oversendLayer shouldBe hd7point5
                     allocation.layers.map { it.layer } shouldBe
                         listOf(ld7point5, ld15, ld30, sd7point5, sd15, sd30, hd7point5, hd15, hd30)
@@ -222,10 +222,39 @@ class SingleSourceAllocationTest : ShouldSpec() {
                             clock
                         )
 
-                    allocation.preferredLayer shouldBe sd30
+                    allocation.preferredLayer shouldBe sd7point5
                     allocation.oversendLayer shouldBe sd7point5
                     allocation.layers.map { it.layer } shouldBe listOf(ld7point5, ld15, ld30, sd7point5, sd15, sd30)
                 }
+            }
+            context("High fps screensharing") {
+                // The sender explicitly asked for frame rate to be prioritized, so the highest layer stays
+                // "preferred" (while oversend still uses the cheapest layer at the full resolution).
+                val mediaSource = MediaSourceDesc(
+                    arrayOf(
+                        RtpEncodingDesc(1L, arrayOf(ld7point5, ld15, ld30)),
+                        RtpEncodingDesc(1L, arrayOf(sd7point5, sd15, sd30)),
+                        RtpEncodingDesc(1L, arrayOf(hd7point5, hd15, hd30))
+                    ),
+                    sourceName = SOURCE_NAME,
+                    owner = OWNER,
+                    videoType = VideoType.DESKTOP_HIGH_FPS
+                )
+
+                val allocation =
+                    SingleSourceAllocation(
+                        "A",
+                        mediaSource,
+                        VideoConstraints(720),
+                        true,
+                        diagnosticContext,
+                        clock
+                    )
+
+                allocation.preferredLayer shouldBe hd30
+                allocation.oversendLayer shouldBe hd7point5
+                allocation.layers.map { it.layer } shouldBe
+                    listOf(ld7point5, ld15, ld30, sd7point5, sd15, sd30, hd7point5, hd15, hd30)
             }
             context("The high layers are inactive (send-side bwe restrictions)") {
                 // Override layers with bitrate=0. Simulate only up to 360p/30 being active.
@@ -253,9 +282,9 @@ class SingleSourceAllocationTest : ShouldSpec() {
                         clock
                     )
 
-                // For screensharing the "preferred" layer should be the highest -- always prioritized over other
-                // endpoints.
-                allocation.preferredLayer shouldBe sd30
+                // For screensharing the "preferred" layer is the full resolution at its cheapest frame rate: the
+                // resolution is prioritized over other sources, but additional frame rate is not.
+                allocation.preferredLayer shouldBe sd7point5
                 allocation.oversendLayer shouldBe sd7point5
                 allocation.layers.map { it.layer } shouldBe listOf(ld7point5, ld15, ld30, sd7point5, sd15, sd30)
             }
@@ -289,9 +318,9 @@ class SingleSourceAllocationTest : ShouldSpec() {
                             clock
                         )
 
-                    // For screensharing the "preferred" layer should be the highest -- always prioritized over other
-                    // endpoints.
-                    allocation.preferredLayer shouldBe hd30
+                    // For screensharing the "preferred" layer is the full resolution at its cheapest frame rate: the
+                    // resolution is prioritized over other sources, but additional frame rate is not.
+                    allocation.preferredLayer shouldBe hd7point5
                     allocation.oversendLayer shouldBe hd7point5
                     allocation.layers.map { it.layer } shouldBe listOf(hd7point5, hd15, hd30)
                 }
@@ -306,10 +335,10 @@ class SingleSourceAllocationTest : ShouldSpec() {
                             clock
                         )
 
-                    // For screensharing the "preferred" layer should be the highest -- always prioritized over other
-                    // endpoints. Since no layers satisfy the resolution constraints, we consider layers from the
-                    // lowest available resolution (which is high).
-                    allocation.preferredLayer shouldBe hd30
+                    // Since no layers satisfy the resolution constraints, we consider layers from the lowest
+                    // available resolution (which is high). The "preferred" layer is that resolution at its cheapest
+                    // frame rate.
+                    allocation.preferredLayer shouldBe hd7point5
                     allocation.oversendLayer shouldBe hd7point5
                     allocation.layers.map { it.layer } shouldBe listOf(hd7point5, hd15, hd30)
                 }
@@ -341,14 +370,15 @@ class SingleSourceAllocationTest : ShouldSpec() {
                             clock
                         )
 
+                    // With VP9's multiple-encodings structure the layers above the cheapest improve quality (not
+                    // frame rate), so the highest stays "preferred". Oversend still uses the cheapest.
                     allocation.preferredLayer shouldBe l3
                     allocation.oversendLayer shouldBe l1
                     allocation.layers.map { it.layer } shouldBe listOf(l1, l2, l3)
                 }
                 context("With 180p constraints") {
-                    // For screensharing the "preferred" layer should be the highest -- always prioritized over other
-                    // endpoints. Since no layers satisfy the resolution constraints, we consider layers from the
-                    // lowest available resolution (which is high). If we are off-stage we only consider the first of
+                    // Since no layers satisfy the resolution constraints, we consider layers from the lowest
+                    // available resolution (which is high). If we are off-stage we only consider the first of
                     // these layers.
                     context("On stage") {
                         val allocation = SingleSourceAllocation(
@@ -360,6 +390,8 @@ class SingleSourceAllocationTest : ShouldSpec() {
                             clock
                         )
 
+                        // With VP9's multiple-encodings structure the layers above the cheapest improve quality
+                        // (not frame rate), so the highest stays "preferred". Oversend still uses the cheapest.
                         allocation.preferredLayer shouldBe l3
                         allocation.oversendLayer shouldBe l1
                         allocation.layers.map { it.layer } shouldBe listOf(l1, l2, l3)


### PR DESCRIPTION
## Problem

For screensharing, `selectLayersForScreensharing` sets the "preferred" layer — the point up to which the allocator improves a source before considering anyone else — to the *highest* layer, i.e. full resolution at full frame rate. Its own docstring says the policy is to prioritize resolution over frame rate; setting preferred to the top layer prioritizes frame rate too.

Combined with the stage-view rule that nothing else is allocated until the on-stage source reaches preferred, this starves thumbnails whenever the screenshare can afford full resolution but not full frame rate. On beta (with the logging from #2439), a 40-minute conference showed 148 allocation events where the screenshare was forwarded but other sources were never considered; in 74 of them the leftover budget would have covered the skipped source — up to ~2 Mbps left idle while a 57 kbps camera thumbnail was never examined.

## Change

Make the preferred layer the full resolution at whichever frame rate is cheapest to send it at — the same layer the oversend logic already selects, now computed once and used for both. Above that point the screenshare's frame rate competes with other sources on equal terms instead of pre-empting them.

In the updated `BitrateControllerTest` expectations, thumbnails now appear at 710 kbps instead of 2050 kbps in the screensharing stage-view scenario.

## Exceptions

Two cases keep the highest layer as "preferred", i.e. the previous behavior:

* **High-fps screenshare** (`DESKTOP_HIGH_FPS`): the sender explicitly asked for frame rate to be prioritized, so demoting its frame rate would contradict the signal. This also gives senders a per-share opt-out of the new policy.
* **VP9's multiple-encodings structure** (same resolution, unknown frame rate): the layers above the cheapest improve *quality*, not frame rate, so "resolution over frame rate" must not demote them. Oversend still uses the cheapest full-resolution layer.

## Trade-off

This is a deliberate policy change: under contention, a thumbnail may now be *reduced in quality* (not disabled) as the screenshare's frame rate improves — visible in the new test expectations around 1.47 Mbps. The original motivation for holding thumbnails back was to avoid enabling them only to disable them again; with this change they can flap between temporal layers, but not off.

For low-fps screenshare where the temporal ladder carries little (T0 within 1–2% of the total, common with static content), preferred is effectively unchanged and this makes no difference; the effect is confined to content where the frame-rate layers are genuinely expensive.

The policy is not operator-configurable; if a knob is wanted (the camera equivalents `onstage-preferred-height-px`/`onstage-preferred-framerate` are configurable), it can be added — though the `DESKTOP_HIGH_FPS` exception already gives senders a per-share escape hatch.

## Testing

Full jvb suite passes (406 tests). The screensharing stage-view expectations were regenerated from actual allocator output and reviewed for sensibility: screenshare to full resolution first, then thumbnails, then frame rate competing fairly. New coverage pins the VP9 and high-fps exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
