### PR TITLE
fix: Do not replace the DTLS role when the same role is re-applied

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsStack.kt
@@ -115,7 +115,21 @@ class DtlsStack(
      */
     private val datagramTransport: DatagramTransport = DatagramTransportImpl(logger)
 
-    fun actAsServer() {
+    /**
+     * Set the role to server, unless it already is one.
+     *
+     * The role is re-applied whenever the peer signals its `setup` attribute again, which it does on every
+     * transport update and not only when something about DTLS changed. Building a new [DtlsRole] each time would
+     * replace the one that has already negotiated the connection with one that never will, so repeating the role
+     * we already have is a no-op.
+     *
+     * @return true if the role changed.
+     */
+    fun actAsServer(): Boolean {
+        if (role is DtlsServer) {
+            return false
+        }
+        warnIfRoleChangesAfterStart("server")
         role = DtlsServer(
             datagramTransport,
             certificateInfo,
@@ -126,9 +140,15 @@ class DtlsStack(
             logger
         )
         roleSet.countDown()
+        return true
     }
 
-    fun actAsClient() {
+    /** Set the role to client, unless it already is one. See [actAsServer]. */
+    fun actAsClient(): Boolean {
+        if (role is DtlsClient) {
+            return false
+        }
+        warnIfRoleChangesAfterStart("client")
         role = DtlsClient(
             datagramTransport,
             certificateInfo,
@@ -139,6 +159,18 @@ class DtlsStack(
             logger
         )
         roleSet.countDown()
+        return true
+    }
+
+    /**
+     * The stack has been started with the role it has now, so replacing that role leaves it with one that was
+     * never started while [dtlsTransport] keeps running the old one. Nothing in the stack does this today, and
+     * the peer is not supposed to change its `setup` after the handshake, so log loudly if it happens.
+     */
+    private fun warnIfRoleChangesAfterStart(newRole: String) {
+        if (dtlsTransport != null) {
+            logger.warn("Changing the DTLS role to $newRole after the stack was started with ${role?.javaClass}.")
+        }
     }
 
     /**

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/dtls/DtlsStackRoleTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/dtls/DtlsStackRoleTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright @ 2026 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.nlj.dtls
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.jitsi.nlj.resources.logging.StdoutLogger
+import java.util.logging.Level
+
+/**
+ * The role of a [DtlsStack] is set from the peer's `setup` attribute, which the peer re-signals with transport
+ * updates that have nothing to do with DTLS. Re-applying the role the stack already has must leave it alone:
+ * building a new [DtlsRole] would discard the one that negotiated the connection.
+ */
+class DtlsStackRoleTest : ShouldSpec() {
+    override fun isolationMode(): IsolationMode = IsolationMode.InstancePerLeaf
+
+    private val stack = DtlsStack(StdoutLogger(_level = Level.OFF))
+
+    init {
+        context("Setting the role for the first time") {
+            should("set it to server") {
+                stack.actAsServer() shouldBe true
+                (stack.role is DtlsServer) shouldBe true
+            }
+            should("set it to client") {
+                stack.actAsClient() shouldBe true
+                (stack.role is DtlsClient) shouldBe true
+            }
+        }
+
+        context("Setting the role again") {
+            should("keep the server role that is already set") {
+                stack.actAsServer() shouldBe true
+                val role = stack.role
+
+                stack.actAsServer() shouldBe false
+                (stack.role === role) shouldBe true
+            }
+            should("keep the client role that is already set") {
+                stack.actAsClient() shouldBe true
+                val role = stack.role
+
+                stack.actAsClient() shouldBe false
+                (stack.role === role) shouldBe true
+            }
+        }
+
+        context("Changing the role") {
+            should("replace a server role with a client one") {
+                stack.actAsServer() shouldBe true
+
+                stack.actAsClient() shouldBe true
+                (stack.role is DtlsClient) shouldBe true
+            }
+            should("replace a client role with a server one") {
+                stack.actAsClient() shouldBe true
+
+                stack.actAsServer() shouldBe true
+                (stack.role is DtlsServer) shouldBe true
+            }
+        }
+    }
+}

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/dtls/DtlsTest.kt
@@ -112,5 +112,15 @@ class DtlsTest : ShouldSpec() {
 
         serverReceivedData.get(5, TimeUnit.SECONDS) shouldBe clientToServerMessage
         clientReceivedData.get(5, TimeUnit.SECONDS) shouldBe serverToClientMessage
+
+        // The peer re-signals its setup attribute with transport updates long after the handshake, so the role is
+        // re-applied then. It must not replace the role that negotiated this connection.
+        val serverRole = dtlsServer.role
+        dtlsServer.actAsServer() shouldBe false
+        (dtlsServer.role === serverRole) shouldBe true
+
+        val clientRole = dtlsClient.role
+        dtlsClient.actAsClient() shouldBe false
+        (dtlsClient.role === clientRole) shouldBe true
     }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/dtls/DtlsTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/dtls/DtlsTransport.kt
@@ -142,18 +142,25 @@ class DtlsTransport(parentLogger: Logger, id: String) {
         }
     }
 
+    /**
+     * Applies the peer's `setup` attribute. This is called for every transport update that carries a fingerprint,
+     * including the ones that have nothing to do with DTLS (an ICE restart, a trickled candidate), so re-applying
+     * the role we already have does nothing and is not logged.
+     */
     fun setSetupAttribute(setupAttr: String?) {
         if (setupAttr.isNullOrEmpty()) {
             return
         }
         when (setupAttr.lowercase()) {
             "active" -> {
-                logger.info("The remote side is acting as DTLS client, we'll act as server")
-                dtlsStack.actAsServer()
+                if (dtlsStack.actAsServer()) {
+                    logger.info("The remote side is acting as DTLS client, we'll act as server")
+                }
             }
             "passive" -> {
-                logger.info("The remote side is acting as DTLS server, we'll act as client")
-                dtlsStack.actAsClient()
+                if (dtlsStack.actAsClient()) {
+                    logger.info("The remote side is acting as DTLS server, we'll act as client")
+                }
             }
             else -> {
                 logger.error(


### PR DESCRIPTION
The `setup` attribute is applied on every transport update that carries a fingerprint, not only when something about DTLS changed. An ICE restart is one such update, so a plain ICE restart logs

```
DtlsTransport.setSetupAttribute#151: The remote side is acting as DTLS client, we'll act as server
```

and builds a new `DtlsServer`, replacing the role that had already negotiated the connection with one that was never started.

Nothing reads the role after the handshake (`DtlsStack.start()` is the only user, and it is reachable only from the one-shot `writeable()` event), so this has no effect on the media. The log line is misleading though, and a role that was never started is a trap for anything that starts the stack again.

`actAsServer`/`actAsClient` now no-op when the role is already the one asked for and return whether the role changed, so the log line is only printed on an actual change. A role change after the stack was started is logged as a warning.
