### PR TITLE
Update ice4j: keep-alive pair maintenance (dedup, pruning, re-checking, cap).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>ice4j</artifactId>
-                <version>3.2-16-gb3a1a87</version>
+                <version>3.2-17-geea6cd3</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Picks up jitsi/ice4j#312 (ice4j `3.2-17-geea6cd3`), the follow-ups to #311 aimed at the `all_succeeded` keep-alive strategy:

- Keep-alive pairs are deduplicated by local socket and remote address. With single-port harvesting, the host pair and the mapped pair to the same remote address were both kept alive; now one is.
- A non-selected keep-alive pair which stays FAILED for 30 s (`ice4j.keep-alive.failed-pair-timeout`) is removed instead of being probed indefinitely. The selected pair is never removed.
- After termination, a check on a pair we do not keep alive gets an error response for all strategies, and a known pair the remote side checks again is re-checked and re-added if it succeeds.
- The keep-alive set is capped at `ice4j.keep-alive.max-pairs` (default 10).
- A keep-alive timeout on an already-failed pair logs at DEBUG rather than INFO.

Both new settings have defaults in ice4j's reference.conf; no JVB config change is needed.

Verified on a stage bridge running this ice4j for about a day with `all_succeeded` and `send-to-last-received-from-address=true`: dedup confirmed by packet capture (one keep-alive per remote address per cycle), pruning confirmed both organically and in a controlled VPN-drop test (pair removed 32 s after failing, probing stopped), no ICE failures or ice4j warnings.

Compiles and `IceTransportRestartTest` passes against the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
