### PR TITLE
Update to Kotlin 2.4.20, JUnit 5.14.4, mockk 1.14.11, Jackson 2.21.5

### DIFF
--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/GoogleCcEstimator.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/GoogleCcEstimator.kt
@@ -61,7 +61,7 @@ class GoogleCcEstimator(diagnosticContext: DiagnosticContext, parentLogger: Logg
      * Implements the loss-based part of Google CC.
      */
     private val sendSideBandwidthEstimation =
-        SendSideBandwidthEstimation(diagnosticContext, initBw.bps.toLong(), logger).also {
+        SendSideBandwidthEstimation(diagnosticContext, initBw.bps, logger).also {
             it.setMinMaxBitrate(minBw.bps.toInt(), maxBw.bps.toInt())
         }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcNetworkController.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcNetworkController.kt
@@ -337,9 +337,7 @@ class GoogCcNetworkController(
             if (!feedbackMaxRtts.isEmpty()) {
                 val sumRttMs = feedbackMaxRtts.sum()
                 val meanRttMs = sumRttMs / feedbackMaxRtts.size
-                if (delayBasedBwe != null) {
-                    delayBasedBwe.onRttUpdate(meanRttMs.ms)
-                }
+                delayBasedBwe.onRttUpdate(meanRttMs.ms)
             }
 
             var feedbackMinRtt = MAX_DURATION
@@ -636,7 +634,7 @@ class GoogCcNetworkController(
                 put("loss_ratio", lossRatio)
                 put("send_side_target", sendSideTarget.bps)
                 put("last_loss_based_state", lossBasedState.name)
-                put("data_window", dataWindow?.bytes?.toDouble() ?: Double.NaN)
+                put("data_window", dataWindow?.bytes ?: Double.NaN)
                 put("pushback_target", pushbackTarget.bps)
                 put("in_alr", inAlr)
             }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/ProbeController.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/ProbeController.kt
@@ -559,8 +559,6 @@ class ProbeController(
                     min(maxProbeBitrate, estimatedBitrate * config.lossLimitedProbeScale)
             BandwidthLimitedCause.kDelayBasedLimited ->
                 Unit
-            else ->
-                Unit
         }
 
         /* Skipping use of networkEstimate */

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/srtp/SrtpTransformer.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/srtp/SrtpTransformer.kt
@@ -143,7 +143,7 @@ abstract class SrtpTransformer(
 ) : AbstractSrtpTransformer<SrtpCryptoContext>(contextFactory, logger) {
 
     override fun deriveContext(ssrc: Long, index: Long): SrtpCryptoContext? =
-        contextFactory.deriveContext(ssrc.toInt(), 0) ?: null
+        contextFactory.deriveContext(ssrc.toInt(), 0)
 
     override fun getSsrcAndIndex(packetInfo: PacketInfo): SsrcAndIndex? {
         val rtpPacket: RtpPacket = packetInfo.packet as? RtpPacket ?: run {
@@ -163,7 +163,7 @@ abstract class SrtcpTransformer(
 ) : AbstractSrtpTransformer<SrtcpCryptoContext>(contextFactory, logger) {
 
     override fun deriveContext(ssrc: Long, index: Long): SrtcpCryptoContext? =
-        contextFactory.deriveControlContext(ssrc.toInt()) ?: null
+        contextFactory.deriveControlContext(ssrc.toInt())
 
     override fun getSsrcAndIndex(packetInfo: PacketInfo): SsrcAndIndex? {
         // Contrary to RTP packets, RTCP packets do not get parsed before they are

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
@@ -127,7 +127,7 @@ class EndpointConnectionStats(
         }
     }
 
-    private fun processReportBlock(receivedTime: Instant?, reportBlock: RtcpReportBlock) = synchronized(lock) {
+    private fun processReportBlock(receivedTime: Instant?, reportBlock: RtcpReportBlock): Unit = synchronized(lock) {
         if (reportBlock.lastSrTimestamp == 0L && reportBlock.delaySinceLastSr == 0L) {
             logger.cdebug {
                 "Report block for ssrc ${reportBlock.ssrc} didn't have SR data: " +

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
@@ -73,7 +73,7 @@ class EndpointConnectionStats(
         Collections.synchronizedMap(LRUCache(MAX_SR_TIMESTAMP_HISTORY))
     private val logger = createChildLogger(parentLogger)
 
-    private val lock = Object()
+    private val lock = Any()
 
     /**
      * The calculated RTT, in milliseconds, between the bridge and the endpoint

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RemoteBandwidthEstimator.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RemoteBandwidthEstimator.kt
@@ -139,7 +139,7 @@ class RemoteBandwidthEstimator(
         numRembsCreated++
         return RtcpFbRembPacketBuilder(
             rtcpHeader = RtcpHeaderBuilder(senderSsrc = localSsrc),
-            brBps = currentBw.bps.toLong(),
+            brBps = currentBw.bps,
             ssrcs = ssrcs.toList()
         ).build()
     }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProbingDataSender.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/ProbingDataSender.kt
@@ -170,7 +170,7 @@ class ProbingDataSender(
             val paddingSize = (remainingBytes - RtpHeader.FIXED_HEADER_SIZE_BYTES).coerceAtMost(0xFF)
             val packetLength = RtpHeader.FIXED_HEADER_SIZE_BYTES + paddingSize
 
-            val paddingPacket = PaddingVideoPacket.create(packetLength.toInt())
+            val paddingPacket = PaddingVideoPacket.create(packetLength)
             paddingPacket.payloadType = pt.pt.toPositiveInt()
             paddingPacket.ssrc = senderSsrc
             paddingPacket.timestamp = currDummyTimestamp

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/RemoteBandwidthEstimatorTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/RemoteBandwidthEstimatorTest.kt
@@ -88,7 +88,7 @@ class RemoteBandwidthEstimatorTest : ShouldSpec() {
             sendPackets(targetBitrate)
             context("when receiving a higher bitrate, the estimate should grow") {
                 val rembPacket2 = remoteBandwidthEstimator.createRemb()
-                rembPacket2!!.bitrate shouldBeGreaterThan targetBitrate.bps.toLong()
+                rembPacket2!!.bitrate shouldBeGreaterThan targetBitrate.bps
             }
         }
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -1285,7 +1285,7 @@ class Endpoint @JvmOverloads constructor(
         override fun bandwidthEstimationChanged(newValue: Bandwidth) {
             logger.cdebug { "Estimated bandwidth is now $newValue" }
             latestBandwidth = newValue
-            bitrateController.bandwidthChanged(newValue.bps.toLong())
+            bitrateController.bandwidthChanged(newValue.bps)
             bandwidthProbing.bandwidthEstimationChanged(newValue)
         }
     }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/BandwidthProbing.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/BandwidthProbing.kt
@@ -62,7 +62,7 @@ class BandwidthProbing(
     var diagnosticsContext: DiagnosticContext? = null
 
     override fun bandwidthEstimationChanged(newValue: Bandwidth) {
-        latestBwe = newValue.bps.toLong()
+        latestBwe = newValue.bps
     }
 
     override fun run() {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BitrateController.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BitrateController.kt
@@ -229,8 +229,8 @@ class BitrateController<T : MediaSourceContainer> @JvmOverloads constructor(
         activeSsrcs.removeIf { it < 0 }
 
         return BitrateControllerStatusSnapshot(
-            currentTargetBps = totalTargetBitrate.bps.toLong(),
-            currentIdealBps = totalIdealBitrate.bps.toLong(),
+            currentTargetBps = totalTargetBitrate.bps,
+            currentIdealBps = totalIdealBitrate.bps,
             activeSsrcs = activeSsrcs,
             hasNonIdealLayer = hasNonIdealLayer
         )

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
@@ -230,7 +230,7 @@ internal class SingleSourceAllocation(
      * Gets the target bitrate (in bps) for this endpoint allocation, i.e. the bitrate of the currently chosen layer.
      */
     val targetBitrate: Long
-        get() = targetLayer?.bitrate?.toLong() ?: 0
+        get() = targetLayer?.bitrate ?: 0
 
     private val targetLayer: LayerSnapshot?
         get() = layers.getOrNull(targetIdx)
@@ -240,7 +240,7 @@ internal class SingleSourceAllocation(
      * forward if there were no (bandwidth) constraints.
      */
     val idealBitrate: Long
-        get() = layers.idealLayer?.bitrate?.toLong() ?: 0
+        get() = layers.idealLayer?.bitrate ?: 0
 
     /**
      * Exposed for testing only.

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/metrics/VideobridgePeriodicMetrics.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/metrics/VideobridgePeriodicMetrics.kt
@@ -260,11 +260,11 @@ object VideobridgePeriodicMetrics {
                 val incomingPacketStreamStats = rtpReceiverStats.packetStreamStats
                 bitrateDownloadBps += incomingPacketStreamStats.getBitrateBps()
                 packetRateDownload += incomingPacketStreamStats.packetRate
-                conferenceBitrate = (conferenceBitrate + incomingPacketStreamStats.getBitrateBps()).toLong()
+                conferenceBitrate = conferenceBitrate + incomingPacketStreamStats.getBitrateBps()
                 conferencePacketRate += incomingPacketStreamStats.packetRate
                 bitrateUploadBps += outgoingStats.getBitrateBps()
                 packetRateUpload += outgoingStats.packetRate
-                conferenceBitrate = (conferenceBitrate + outgoingStats.getBitrateBps()).toLong()
+                conferenceBitrate = conferenceBitrate + outgoingStats.getBitrateBps()
                 conferencePacketRate += outgoingStats.packetRate
                 val endpointRtt = endpointConnectionStats.rtt
                 if (endpointRtt > 0) {
@@ -290,11 +290,11 @@ object VideobridgePeriodicMetrics {
             for (relay in conference.relays) {
                 relayBitrateIncomingBps += relay.incomingBitrateBps
                 relayPacketRateIncoming += relay.incomingPacketRate
-                conferenceBitrate = (conferenceBitrate + relay.incomingBitrateBps).toLong()
+                conferenceBitrate = conferenceBitrate + relay.incomingBitrateBps
                 conferencePacketRate += relay.incomingPacketRate
                 relayBitrateOutgoingBps += relay.outgoingBitrateBps
                 relayPacketRateOutgoing += relay.outgoingPacketRate
-                conferenceBitrate = (conferenceBitrate + relay.outgoingBitrateBps).toLong()
+                conferenceBitrate = conferenceBitrate + relay.outgoingBitrateBps
                 conferencePacketRate += relay.outgoingPacketRate
 
                 /* TODO: report Relay RTT and loss, like we do for Endpoints? */

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
@@ -155,10 +155,7 @@ class RelayMessageTransport(
      * @return
      */
     override fun addReceiver(message: AddReceiverMessage): BridgeChannelMessage? {
-        val sourceName = message.sourceName ?: run {
-            logger.error("Received AddReceiverMessage for with sourceName = null")
-            return null
-        }
+        val sourceName = message.sourceName
         val ep = relay.conference.findSourceOwner(sourceName) ?: run {
             logger.warn("Received AddReceiverMessage for unknown or non-local: $sourceName")
             return null

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerTest.kt
@@ -1499,7 +1499,7 @@ class BitrateControllerWrapper(initialEndpoints: List<MediaSourceContainer>, val
         set(value) {
             logger.debug("Setting bwe=$value")
             field = value
-            bc.bandwidthChanged(value.bps.toLong())
+            bc.bandwidthChanged(value.bps)
         }
 
     // Save the output.
@@ -1543,7 +1543,7 @@ class BitrateControllerWrapper(initialEndpoints: List<MediaSourceContainer>, val
         DiagnosticContext(),
         logger,
         clock
-    ).apply { bandwidthChanged(bwe.bps.toLong()) } // TODO: handle the -1 bps case better
+    ).apply { bandwidthChanged(bwe.bps) } // TODO: handle the -1 bps case better
 
     fun setEndpointOrdering(vararg endpoints: TestEndpoint) {
         logger.info("Set endpoints ${endpoints.map{ it.id }.joinToString(",")}")

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
         <kotest.version>5.9.1</kotest.version>
         <junit.version>5.14.4</junit.version>
         <junit.platform.version>1.14.4</junit.platform.version>
-        <jitsi.utils.version>1.0-151-g174c4a1</jitsi.utils.version>
-        <jicoco.version>1.1-178-ga09ed33</jicoco.version>
+        <jitsi.utils.version>1.0-153-gd5c0102</jitsi.utils.version>
+        <jicoco.version>1.1-179-g52cf6ef</jicoco.version>
         <mockk.version>1.14.11</mockk.version>
         <ktlint-maven-plugin.version>3.2.0</ktlint-maven-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
@@ -139,17 +139,17 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-metaconfig</artifactId>
-                <version>1.0-11-g8cf950e</version>
+                <version>1.0-18-ge06bc45</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>ice4j</artifactId>
-                <version>3.2-17-geea6cd3</version>
+                <version>3.2-18-g3984f7f</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-xmpp-extensions</artifactId>
-                <version>1.0-119-gc67bc81</version>
+                <version>1.0-124-g024f15d</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -24,13 +24,13 @@
 
     <properties>
         <jetty.version>12.0.35</jetty.version>
-        <kotlin.version>2.2.20</kotlin.version>
+        <kotlin.version>2.4.20</kotlin.version>
         <kotest.version>5.9.1</kotest.version>
-        <junit.version>5.13.4</junit.version>
-        <junit.platform.version>1.13.4</junit.platform.version>
+        <junit.version>5.14.4</junit.version>
+        <junit.platform.version>1.14.4</junit.platform.version>
         <jitsi.utils.version>1.0-151-g174c4a1</jitsi.utils.version>
         <jicoco.version>1.1-178-ga09ed33</jicoco.version>
-        <mockk.version>1.14.5</mockk.version>
+        <mockk.version>1.14.11</mockk.version>
         <ktlint-maven-plugin.version>3.2.0</ktlint-maven-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
@@ -39,7 +39,7 @@
         <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
         <spotbugs.version>4.9.4</spotbugs.version>
         <spotbugs-maven-plugin.version>4.9.4.2</spotbugs-maven-plugin.version>
-        <jackson.version>2.19.4</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
         <jacoco.version>0.8.13</jacoco.version>
         <bouncycastle.version>1.83</bouncycastle.version>
         <jersey.version>3.1.11</jersey.version>

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/Av1DependencyDescriptorHeaderExtension.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/Av1DependencyDescriptorHeaderExtension.kt
@@ -202,7 +202,7 @@ class Av1DependencyDescriptorHeaderExtension(
         writer.writeBit(customChainsFlag)
 
         if (templateDependencyStructurePresent) {
-            newTemplateDependencyStructure!!.write(writer)
+            newTemplateDependencyStructure.write(writer)
         }
 
         if (activeDecodeTargetsPresent) {


### PR DESCRIPTION
Bumps Kotlin to 2.4.20 and the test tooling to current versions. Jackson 2.21.5 matches what jitsi-utils now uses.

Gives processReportBlock an explicit return type, since an expression-bodied function containing return statements becomes an error in Kotlin 2.5 (KTLC-288), and removes the redundancies flagged by the new compiler: redundant numeric conversions, unreachable elvis branches, an always-true null check, a redundant else in an exhaustive when, an unnecessary !!, and Any() in place of java.lang.Object() for a lock.

Note that Kotlin 2.4 makes param-property the default annotation target, so the Jackson annotations on constructor properties in BridgeChannelMessage now also apply to the properties. Jackson already merges annotations across a logical property, and the message serialization tests pass unchanged.

This is one of a set of same-named kotlin-2.4 branches across jitsi-utils, jitsi-metaconfig, jicoco, jitsi-xmpp-extensions, ice4j, jicofo, jitsi-videobridge and jibri. Each PR only bumps the compiler and test/doc tooling; dependency versions between the jitsi repos are unchanged, so the PRs are independently mergeable. A library built with Kotlin 2.4 can only be consumed by Kotlin 2.3 or newer, so the compiler bumps should land everywhere before any repo picks up a 2.4-built release of another.