### PR TITLE
Run ktlint 1.8.0 directly via exec-maven-plugin and reformat

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,6 @@
 [*.{kt,kts}]
+# Keep constructor parameters wrapped one per line, and kotest specs unindented.
+ktlint_standard_class-signature = disabled
 max_line_length=120
 ktlint_code_style = intellij_idea
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,11 +42,12 @@ mvn install
 # Run checkstyle (Java formatting)
 mvn checkstyle:check
 
-# Run ktlint (Kotlin formatting, must be run inside a submodule directory, e.g. ./jvb/)
-mvn ktlint:check
+# Run ktlint (Kotlin formatting, must be run inside a submodule directory, e.g. ./jvb/; sibling modules must be
+# resolvable, so run "mvn install -DskipTests" from the root first if they are not)
+mvn exec:exec@ktlint-check
 
 # Auto-format Kotlin code (must be run inside a submodule directory, e.g. ./jvb/)
-mvn ktlint:format
+mvn exec:exec@ktlint-format
 ```
 
 ## Project Structure
@@ -113,7 +114,7 @@ Uses Typesafe Config (HOCON format):
 ### Kotlin Code
 - Follows ktlint conventions (standard Kotlin style)
 - **Line Length**: Maximum 120 characters
-- Use ktlint Maven plugin for linting and formatting
+- ktlint runs from Maven via exec-maven-plugin (version pinned by `ktlint.version` in the root pom); `mvn verify` runs the check
 
 ### Testing
 - Uses JUnit 5 for new tests (JUnit 4 vintage engine for legacy tests)

--- a/jitsi-media-transform/README.md
+++ b/jitsi-media-transform/README.md
@@ -2,29 +2,20 @@
 Jitsi Media Transform contains classes for processing and transforming RTP and RTCP packets
 
 # Code style
-We use ktlint for linting and autoformatting. The ktlint command-line utility
-can be installed by running:
+We use [ktlint](https://pinterest.github.io/ktlint/) for linting and autoformatting. It runs as part of
+`mvn verify` (the build fails on style violations), and the version used is pinned by `ktlint.version` in the
+root `pom.xml`, so no separate installation is needed.
+
+To run only the check, or to autoformat, run these in this module's directory:
 ```
-curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.39.0/ktlint && chmod a+x ktlint && sudo mv ktlint /usr/local/bin/
+mvn exec:exec@ktlint-check
+mvn exec:exec@ktlint-format
 ```
 
-Or, on macOS with Homebrew:
+If you also want the `ktlint` command-line tool (for editor integration or a git hook), install a version matching
+`ktlint.version`, e.g. on macOS with Homebrew:
 ```
 brew install ktlint
 ```
-
-To perform the checks simply run `ktlint`.
-
-You can install a pre-commit or pre-push git hook by running this in the git
-repository directory:
-```
-ktlint --install-git-pre-commit-hook
-```
-
-You can automatically update Intellij IDEA's formatting rules to to be
-compatible with ktlint:
-```
-ktlint --apply-to-idea-project
-```
-
-Autoformatting can be run by calling `ktlint -F`.
+It can then be run directly with `ktlint` (or `ktlint -F` to autoformat), install a pre-commit hook with
+`ktlint installGitPreCommitHook`, and configure IntelliJ IDEA with `ktlint applyToIDEAProject`.

--- a/jitsi-media-transform/pom.xml
+++ b/jitsi-media-transform/pom.xml
@@ -251,24 +251,61 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <!-- ktlint: check runs in the verify phase; auto-format with "mvn exec:exec@ktlint-format" -->
             <plugin>
-                <groupId>com.github.gantsign.maven</groupId>
-                <artifactId>ktlint-maven-plugin</artifactId>
-                <version>${ktlint-maven-plugin.version}</version>
-                <configuration>
-                    <sourceRoots>
-                       <sourceRoot>${project.basedir}/src/main/kotlin</sourceRoot>
-                    </sourceRoots>
-                    <testSourceRoots>
-                        <testSourceRoot>${project.basedir}/src/test/kotlin</testSourceRoot>
-                    </testSourceRoots>
-                </configuration>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.6.3</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.pinterest.ktlint</groupId>
+                        <artifactId>ktlint-cli</artifactId>
+                        <version>${ktlint.version}</version>
+                        <classifier>all</classifier>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
-                      <id>check</id>
-                      <goals>
-                          <goal>check</goal>
-                      </goals>
+                        <id>ktlint-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <includePluginDependencies>true</includePluginDependencies>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath>
+                                    <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                                </classpath>
+                                <argument>com.pinterest.ktlint.Main</argument>
+                                <argument>--relative</argument>
+                                <argument>src/main/kotlin/**/*.kt</argument>
+                                <argument>src/test/kotlin/**/*.kt</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>ktlint-format</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <includePluginDependencies>true</includePluginDependencies>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath>
+                                    <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                                </classpath>
+                                <argument>com.pinterest.ktlint.Main</argument>
+                                <argument>--format</argument>
+                                <argument>--relative</argument>
+                                <argument>src/main/kotlin/**/*.kt</argument>
+                                <argument>src/test/kotlin/**/*.kt</argument>
+                            </arguments>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/MediaSourceDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/MediaSourceDesc.kt
@@ -202,17 +202,13 @@ class MediaSourceDesc
  */
 fun Array<MediaSourceDesc>.copy() = Array(this.size) { i -> this[i].copy() }
 
-fun Array<MediaSourceDesc>.findRtpLayerDescs(packet: VideoRtpPacket): Collection<RtpLayerDesc> {
-    return this.flatMap { it.findRtpLayerDescs(packet) }
+fun Array<MediaSourceDesc>.findRtpLayerDescs(packet: VideoRtpPacket): Collection<RtpLayerDesc> = this.flatMap {
+    it.findRtpLayerDescs(packet)
 }
 
-fun Array<MediaSourceDesc>.findRtpSourceByPrimary(ssrc: Long): MediaSourceDesc? {
-    return this.find { it.matches(ssrc) }
-}
+fun Array<MediaSourceDesc>.findRtpSourceByPrimary(ssrc: Long): MediaSourceDesc? = this.find { it.matches(ssrc) }
 
-fun Array<MediaSourceDesc>.findRtpSource(ssrc: Long): MediaSourceDesc? {
-    return this.find { it.hasSsrc(ssrc) }
-}
+fun Array<MediaSourceDesc>.findRtpSource(ssrc: Long): MediaSourceDesc? = this.find { it.hasSsrc(ssrc) }
 
 fun Array<MediaSourceDesc>.findRtpSource(packet: RtpPacket): MediaSourceDesc? = findRtpSource(packet.ssrc)
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/PacketInfo.kt
@@ -76,18 +76,16 @@ class EventTimeline(
         } ?: Duration.ofMillis(-1)
     }
 
-    override fun toString(): String {
-        return with(StringBuffer()) {
-            referenceTime?.let {
-                append("Reference time: $referenceTime; ")
-                synchronized(timeline) {
-                    append(timeline.joinToString(separator = "; "))
-                }
-            } ?: run {
-                append("[No timeline]")
+    override fun toString(): String = with(StringBuffer()) {
+        referenceTime?.let {
+            append("Reference time: $referenceTime; ")
+            synchronized(timeline) {
+                append(timeline.joinToString(separator = "; "))
             }
-            toString()
+        } ?: run {
+            append("[No timeline]")
         }
+        toString()
     }
 }
 
@@ -196,9 +194,7 @@ open class PacketInfo @JvmOverloads constructor(
      * Get the contained packet cast to [ExpectedPacketType]
      */
     @Suppress("UNCHECKED_CAST")
-    fun <ExpectedPacketType : Packet> packetAs(): ExpectedPacketType {
-        return packet as ExpectedPacketType
-    }
+    fun <ExpectedPacketType : Packet> packetAs(): ExpectedPacketType = packet as ExpectedPacketType
 
     /**
      * Create a deep clone of this PacketInfo (both the contained packet and the metadata map

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpEncodingDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpEncodingDesc.kt
@@ -150,10 +150,8 @@ constructor(
     /**
      * {@inheritDoc}
      */
-    override fun toString(): String {
-        return "primary_ssrc=$primarySSRC,secondary_ssrcs=$secondarySsrcs," +
-            "layers=\n    ${layers.joinToString(separator = "\n    ")}"
-    }
+    override fun toString(): String = "primary_ssrc=$primarySSRC,secondary_ssrcs=$secondarySsrcs," +
+        "layers=\n    ${layers.joinToString(separator = "\n    ")}"
 
     /**
      * Gets a boolean indicating whether the SSRC specified in the
@@ -161,12 +159,10 @@ constructor(
      *
      * @param ssrc the SSRC to match.
      */
-    fun hasSsrc(ssrc: Long): Boolean {
-        return if (primarySSRC == ssrc) {
-            true
-        } else {
-            secondarySsrcs.containsKey(ssrc)
-        }
+    fun hasSsrc(ssrc: Long): Boolean = if (primarySSRC == ssrc) {
+        true
+    } else {
+        secondarySsrcs.containsKey(ssrc)
     }
 
     /**
@@ -187,9 +183,7 @@ constructor(
     }
 }
 
-fun VideoRtpPacket.getEncodingIds(): Collection<Long> {
-    return this.layerIds.map { RtpEncodingDesc.calcEncodingId(ssrc, it) }
-}
+fun VideoRtpPacket.getEncodingIds(): Collection<Long> = this.layerIds.map { RtpEncodingDesc.calcEncodingId(ssrc, it) }
 
 /**
  * Get the "nominal" height of a set of layers - if they all indicate the same spatial layer and same height.

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpReceiverImpl.kt
@@ -272,15 +272,13 @@ class RtpReceiverImpl @JvmOverloads constructor(
         }
     }
 
-    private fun handleIncomingPacket(packet: PacketInfo): Boolean {
-        return if (running) {
-            packet.addEvent(PACKET_QUEUE_EXIT_EVENT)
-            processPacket(packet)
-            true
-        } else {
-            BufferPool.returnBuffer(packet.packet.buffer)
-            false
-        }
+    private fun handleIncomingPacket(packet: PacketInfo): Boolean = if (running) {
+        packet.addEvent(PACKET_QUEUE_EXIT_EVENT)
+        processPacket(packet)
+        true
+    } else {
+        BufferPool.returnBuffer(packet.packet.buffer)
+        false
     }
 
     override fun doProcessPacket(packetInfo: PacketInfo) = inputTreeRoot.processPacket(packetInfo)
@@ -334,10 +332,8 @@ class RtpReceiverImpl @JvmOverloads constructor(
         }
     }
 
-    override fun isFeatureEnabled(feature: Features): Boolean {
-        return when (feature) {
-            Features.TRANSCEIVER_PCAP_DUMP -> toggleablePcapWriter.isEnabled()
-        }
+    override fun isFeatureEnabled(feature: Features): Boolean = when (feature) {
+        Features.TRANSCEIVER_PCAP_DUMP -> toggleablePcapWriter.isEnabled()
     }
 
     override fun stop() {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/RtpSenderImpl.kt
@@ -291,30 +291,26 @@ class RtpSenderImpl(
         }
     }
 
-    override fun isFeatureEnabled(feature: Features): Boolean {
-        return when (feature) {
-            Features.TRANSCEIVER_PCAP_DUMP -> toggleablePcapWriter.isEnabled()
-        }
+    override fun isFeatureEnabled(feature: Features): Boolean = when (feature) {
+        Features.TRANSCEIVER_PCAP_DUMP -> toggleablePcapWriter.isEnabled()
     }
 
     /**
      * Handles packets that have gone through the incoming queue and sends them
      * through the sender pipeline
      */
-    private fun handlePacket(packetInfo: PacketInfo): Boolean {
-        return if (running) {
-            packetInfo.addEvent(PACKET_QUEUE_EXIT_EVENT)
+    private fun handlePacket(packetInfo: PacketInfo): Boolean = if (running) {
+        packetInfo.addEvent(PACKET_QUEUE_EXIT_EVENT)
 
-            val root = when (packetInfo.packet) {
-                is RtcpPacket -> outgoingRtcpRoot
-                else -> outgoingRtpRoot
-            }
-            root.processPacket(packetInfo)
-            true
-        } else {
-            BufferPool.returnBuffer(packetInfo.packet.buffer)
-            false
+        val root = when (packetInfo.packet) {
+            is RtcpPacket -> outgoingRtcpRoot
+            else -> outgoingRtpRoot
         }
+        root.processPacket(packetInfo)
+        true
+    } else {
+        BufferPool.returnBuffer(packetInfo.packet.buffer)
+        false
     }
 
     override fun getStreamStats() = statsTracker.getSnapshot()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/Transceiver.kt
@@ -342,15 +342,13 @@ class Transceiver(
     /**
      * Get various media and network stats
      */
-    fun getTransceiverStats(): TransceiverStats {
-        return TransceiverStats(
-            endpointConnectionStats.getSnapshot(),
-            rtpReceiver.getStats(),
-            rtpSender.getStreamStats(),
-            rtpSender.getPacketStreamStats(),
-            rtpSender.getTransportCcEngineStats()
-        )
-    }
+    fun getTransceiverStats(): TransceiverStats = TransceiverStats(
+        endpointConnectionStats.getSnapshot(),
+        rtpReceiver.getStats(),
+        rtpSender.getStreamStats(),
+        rtpSender.getPacketStreamStats(),
+        rtpSender.getTransportCcEngineStats()
+    )
 
     fun addEndpointConnectionStatsListener(listener: EndpointConnectionStats.EndpointConnectionStatsListener) =
         endpointConnectionStats.addListener(listener)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsUtils.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/DtlsUtils.kt
@@ -82,15 +82,13 @@ class DtlsUtils {
          * A helper which finds an SRTP protection profile present in both
          * [ours] and [theirs].  Throws [DtlsException] if no common profile is found.
          */
-        fun chooseSrtpProtectionProfile(ours: Iterable<Int>, theirs: Iterable<Int>): Int {
-            return try {
-                ours.first(theirs::contains)
-            } catch (e: NoSuchElementException) {
-                throw DtlsException(
-                    "No common SRTP protection profile found.  Ours: ${ours.joinToString()} " +
-                        "Theirs: ${theirs.joinToString()}"
-                )
-            }
+        fun chooseSrtpProtectionProfile(ours: Iterable<Int>, theirs: Iterable<Int>): Int = try {
+            ours.first(theirs::contains)
+        } catch (e: NoSuchElementException) {
+            throw DtlsException(
+                "No common SRTP protection profile found.  Ours: ${ours.joinToString()} " +
+                    "Theirs: ${theirs.joinToString()}"
+            )
         }
 
         /**
@@ -181,7 +179,7 @@ class DtlsUtils {
             certificate: Certificate,
             remoteFingerprints: Map<String, List<String>>
         ) {
-            /** RFC 8122:
+            /* RFC 8122:
              *    An endpoint MUST select the set of fingerprints that use its most
              *    preferred hash function (out of those offered by the peer) and verify
              *    that each certificate used matches one fingerprint out of that set.
@@ -295,6 +293,7 @@ class DtlsUtils {
 inline fun Logger.notifyAlertRaised(alertLevel: Short, alertDescription: Short, message: String?, cause: Throwable?) {
     when (alertDescription) {
         AlertDescription.close_notify -> cdebug { "close_notify raised, connection closing" }
+
         else -> {
             val stack = with(StringBuffer()) {
                 val e = Exception()
@@ -315,6 +314,7 @@ inline fun Logger.notifyAlertRaised(alertLevel: Short, alertDescription: Short, 
 inline fun Logger.notifyAlertReceived(alertLevel: Short, alertDescription: Short) {
     when (alertDescription) {
         AlertDescription.close_notify -> cinfo { "close_notify received, connection closing" }
+
         else -> cerror {
             "Alert received: level=$alertLevel, description=$alertDescription " +
                 "(${AlertDescription.getName(alertDescription)})"

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/TlsServerImpl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/dtls/TlsServerImpl.kt
@@ -96,23 +96,19 @@ class TlsServerImpl(
 
     override fun getCipherSuites() = DtlsConfig.config.cipherSuites.toIntArray()
 
-    override fun getRSAEncryptionCredentials(): TlsCredentialedDecryptor {
-        return BcDefaultTlsCredentialedDecryptor(
-            (context.crypto as BcTlsCrypto),
-            certificateInfo.certificate,
-            PrivateKeyFactory.createKey(certificateInfo.keyPair.private.encoded)
-        )
-    }
+    override fun getRSAEncryptionCredentials(): TlsCredentialedDecryptor = BcDefaultTlsCredentialedDecryptor(
+        (context.crypto as BcTlsCrypto),
+        certificateInfo.certificate,
+        PrivateKeyFactory.createKey(certificateInfo.keyPair.private.encoded)
+    )
 
-    override fun getECDSASignerCredentials(): TlsCredentialedSigner {
-        return BcDefaultTlsCredentialedSigner(
-            TlsCryptoParameters(context),
-            (context.crypto as BcTlsCrypto),
-            PrivateKeyFactory.createKey(certificateInfo.keyPair.private.encoded),
-            certificateInfo.certificate,
-            SignatureAndHashAlgorithm(HashAlgorithm.sha256, SignatureAlgorithm.ecdsa)
-        )
-    }
+    override fun getECDSASignerCredentials(): TlsCredentialedSigner = BcDefaultTlsCredentialedSigner(
+        TlsCryptoParameters(context),
+        (context.crypto as BcTlsCrypto),
+        PrivateKeyFactory.createKey(certificateInfo.keyPair.private.encoded),
+        certificateInfo.certificate,
+        SignatureAndHashAlgorithm(HashAlgorithm.sha256, SignatureAlgorithm.ecdsa)
+    )
 
     override fun getCertificateRequest(): CertificateRequest {
         val signatureAlgorithms = Vector<SignatureAndHashAlgorithm>(1)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/KeyframeRequester.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/KeyframeRequester.kt
@@ -103,6 +103,7 @@ class KeyframeRequester @JvmOverloads constructor(
                 if (forward) numPlisForwarded++
                 if (!canSend) numPlisDropped++
             }
+
             is RtcpFbFirPacket -> {
                 sourceSsrc = pliOrFirPacket.mediaSenderSsrc
                 canSend = canSendKeyframeRequest(packetInfo.endpointId, sourceSsrc, now)
@@ -117,6 +118,7 @@ class KeyframeRequester @JvmOverloads constructor(
                 }
                 if (!canSend) numFirsDropped++
             }
+
             // This is not possible, but the compiler doesn't know it.
             else -> throw IllegalStateException("Packet is neither PLI nor FIR")
         }
@@ -211,6 +213,7 @@ class KeyframeRequester @JvmOverloads constructor(
                 numPlisGenerated++
                 RtcpFbPliPacketBuilder(mediaSourceSsrc = mediaSsrc).build()
             }
+
             streamInformationStore.supportsFir -> {
                 numFirsGenerated++
                 RtcpFbFirPacketBuilder(
@@ -218,6 +221,7 @@ class KeyframeRequester @JvmOverloads constructor(
                     firCommandSeqNum = firCommandSequenceNumber.incrementAndGet()
                 ).build()
             }
+
             else -> {
                 logger.warn("Can not send neither PLI nor FIR")
                 return
@@ -239,20 +243,18 @@ class KeyframeRequester @JvmOverloads constructor(
 
     override fun trace(f: () -> Unit) = f.invoke()
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            addNumber("wait_interval_ms", waitInterval.toMillis())
-            addNumber("num_api_requests", numApiRequests)
-            addNumber("num_api_requests_dropped", numApiRequestsDropped)
-            addNumber("num_firs_dropped", numFirsDropped)
-            addNumber("num_firs_generated", numFirsGenerated)
-            addNumber("num_firs_forwarded", numFirsForwarded)
-            addNumber("num_plis_dropped", numPlisDropped)
-            addNumber("num_plis_generated", numPlisGenerated)
-            addNumber("num_plis_forwarded", numPlisForwarded)
-            addNumber("num_requests_dropped_per_receiver_limit", numRequestsDroppedPerReceiverLimit)
-            addNumber("num_requests_dropped_source_wide_limit", numRequestsDroppedSourceWideLimit)
-        }
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        addNumber("wait_interval_ms", waitInterval.toMillis())
+        addNumber("num_api_requests", numApiRequests)
+        addNumber("num_api_requests_dropped", numApiRequestsDropped)
+        addNumber("num_firs_dropped", numFirsDropped)
+        addNumber("num_firs_generated", numFirsGenerated)
+        addNumber("num_firs_forwarded", numFirsForwarded)
+        addNumber("num_plis_dropped", numPlisDropped)
+        addNumber("num_plis_generated", numPlisGenerated)
+        addNumber("num_plis_forwarded", numPlisForwarded)
+        addNumber("num_requests_dropped_per_receiver_limit", numRequestsDroppedPerReceiverLimit)
+        addNumber("num_requests_dropped_source_wide_limit", numRequestsDroppedSourceWideLimit)
     }
 
     override fun statsJson() = super.statsJson().apply {
@@ -296,13 +298,13 @@ class KeyframeRequester @JvmOverloads constructor(
     }
 }
 
-private fun PacketInfo.getPliOrFirPacket(): RtcpFbPacket? {
-    return when (val pkt = packet) {
-        // We intentionally ignore compound RTCP packets in order to avoid unnecessary parsing. We can do this because:
-        // 1. Compound packets coming from remote endpoint are terminated in RtcpTermination
-        // 2. Whenever a PLI or FIR is generated in our code, it is not part of a compound packet.
-        is RtcpFbFirPacket -> pkt
-        is RtcpFbPliPacket -> pkt
-        else -> null
-    }
+private fun PacketInfo.getPliOrFirPacket(): RtcpFbPacket? = when (val pkt = packet) {
+    // We intentionally ignore compound RTCP packets in order to avoid unnecessary parsing. We can do this because:
+    // 1. Compound packets coming from remote endpoint are terminated in RtcpTermination
+    // 2. Whenever a PLI or FIR is generated in our code, it is not part of a compound packet.
+    is RtcpFbFirPacket -> pkt
+
+    is RtcpFbPliPacket -> pkt
+
+    else -> null
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/RetransmissionRequester.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/RetransmissionRequester.kt
@@ -103,6 +103,7 @@ class RetransmissionRequester(
                         logger.cdebug { "$ssrc packet $seqNum was received, currently missing ${getMissingSeqNums()}" }
                         // By definition we've already received highestReceivedSeqNum, so nothing needs to be done.
                     }
+
                     seqNum isOlderThan highestReceivedSeqNum -> {
                         logger.cdebug { "$ssrc packet $seqNum was received, currently missing ${getMissingSeqNums()}" }
                         // An older packet, possibly already requested
@@ -112,9 +113,11 @@ class RetransmissionRequester(
                             updateWorkDueTime(NO_REQUEST_DUE)
                         }
                     }
+
                     seqNum isNextAfter highestReceivedSeqNum -> {
                         highestReceivedSeqNum = seqNum
                     }
+
                     highestReceivedSeqNum numPacketsTo seqNum < maxMissingSeqNums -> {
                         logger.cdebug {
                             "$ssrc missing packet detected! Just received " +
@@ -127,6 +130,7 @@ class RetransmissionRequester(
                         }
                         highestReceivedSeqNum = seqNum
                     }
+
                     else -> { // diff > maxMissingSeqNums
                         logger.cwarn {
                             "$ssrc large jump in sequence numbers detected (highest received was " +
@@ -164,6 +168,7 @@ class RetransmissionRequester(
                         logger.cdebug { "$ssrc no more work to do, cancelling job handle" }
                         currentTaskHandle?.cancel(false)
                     }
+
                     else -> {
                         // TODO(brian): only re-schedule if the change is larger than X ms?
                         // The work is now due either sooner or later than we previously thought, so

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpRrGenerator.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtcp/RtcpRrGenerator.kt
@@ -46,13 +46,11 @@ private data class SenderInfo(
 ) {
     private fun hasReceivedSr(): Boolean = lastSrReceivedTime != null
 
-    fun getDelaySinceLastSr(now: Instant): Long {
-        return if (hasReceivedSr()) {
-            // This value is in 1/65536 of a second, so multiplying by 65536 gives us the value
-            Duration.between(lastSrReceivedTime, now).times(65536).seconds
-        } else {
-            0
-        }
+    fun getDelaySinceLastSr(now: Instant): Long = if (hasReceivedSr()) {
+        // This value is in 1/65536 of a second, so multiplying by 65536 gives us the value
+        Duration.between(lastSrReceivedTime, now).times(65536).seconds
+    } else {
+        0
     }
 }
 
@@ -131,7 +129,9 @@ class RtcpRrGenerator(
 
             when (packets.size) {
                 0 -> {}
+
                 1 -> rtcpSender(packets.first())
+
                 else -> for (packet in CompoundRtcpPacket.createWithMtu(packets)) {
                     rtcpSender(packet)
                 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/ClassicTransportCcEngine.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/ClassicTransportCcEngine.kt
@@ -140,6 +140,7 @@ class ClassicTransportCcEngine(
                         }
                     }
                 }
+
                 is ReceivedPacketReport -> {
                     currArrivalTimestamp += packetReport.deltaDuration
 
@@ -226,17 +227,15 @@ class ClassicTransportCcEngine(
         }
     }
 
-    override fun getStatistics(): StatisticsSnapshot {
-        return StatisticsSnapshot(
-            numPacketsReported.sum(),
-            numPacketsReportedLost.sum(),
-            numDuplicateReports.sum(),
-            numPacketsReportedAfterLost.sum(),
-            numPacketsUnreported.sum(),
-            numMissingPacketReports.sum(),
-            bandwidthEstimator.getStats()
-        )
-    }
+    override fun getStatistics(): StatisticsSnapshot = StatisticsSnapshot(
+        numPacketsReported.sum(),
+        numPacketsReportedLost.sum(),
+        numDuplicateReports.sum(),
+        numPacketsReportedAfterLost.sum(),
+        numPacketsUnreported.sum(),
+        numMissingPacketReports.sum(),
+        bandwidthEstimator.getStats()
+    )
 
     override fun addBandwidthListener(listener: BandwidthListener) = bandwidthEstimator.addListener(listener)
 
@@ -284,17 +283,15 @@ class ClassicTransportCcEngine(
         val numMissingPacketReports: Long,
         val bandwidthEstimatorStats: BandwidthEstimator.StatisticsSnapshot
     ) : TransportCcEngine.StatisticsSnapshot() {
-        override fun toJson(): ObjectNode {
-            return JsonNodeFactory.instance.objectNode().also {
-                it.put("name", ClassicTransportCcEngine::class.java.simpleName)
-                it.put("numPacketsReported", numPacketsReported)
-                it.put("numPacketsReportedLost", numPacketsReportedLost)
-                it.put("numDuplicateReports", numDuplicateReports)
-                it.put("numPacketsReportedAfterLost", numPacketsReportedAfterLost)
-                it.put("numPacketsUnreported", numPacketsUnreported)
-                it.put("numMissingPacketReports", numMissingPacketReports)
-                it.set<ObjectNode>("bandwidth_estimator_stats", bandwidthEstimatorStats.toJson())
-            }
+        override fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().also {
+            it.put("name", ClassicTransportCcEngine::class.java.simpleName)
+            it.put("numPacketsReported", numPacketsReported)
+            it.put("numPacketsReportedLost", numPacketsReportedLost)
+            it.put("numDuplicateReports", numDuplicateReports)
+            it.put("numPacketsReportedAfterLost", numPacketsReportedAfterLost)
+            it.put("numPacketsUnreported", numPacketsUnreported)
+            it.put("numMissingPacketReports", numMissingPacketReports)
+            it.set<ObjectNode>("bandwidth_estimator_stats", bandwidthEstimatorStats.toJson())
         }
     }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/LossListener.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/LossListener.kt
@@ -38,12 +38,10 @@ class LossTracker : LossListener {
     }
 
     @Synchronized
-    fun getSnapshot(): Snapshot {
-        return Snapshot(
-            lostPackets.getAccumulatedCount(),
-            receivedPackets.getAccumulatedCount()
-        )
-    }
+    fun getSnapshot(): Snapshot = Snapshot(
+        lostPackets.getAccumulatedCount(),
+        receivedPackets.getAccumulatedCount()
+    )
 
     data class Snapshot(
         val packetsLost: Long,

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/VideoRtpPacket.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/VideoRtpPacket.kt
@@ -33,16 +33,12 @@ open class VideoRtpPacket @JvmOverloads constructor(
 
     open val layerIds: Collection<Int> = listOf(0)
 
-    override fun toString(): String {
-        return super.toString() + ", EncID=$encodingId"
-    }
+    override fun toString(): String = super.toString() + ", EncID=$encodingId"
 
-    override fun clone(): VideoRtpPacket {
-        return VideoRtpPacket(
-            cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),
-            BYTES_TO_LEAVE_AT_START_OF_PACKET,
-            length,
-            encodingId = encodingId
-        ).also { postClone(it) }
-    }
+    override fun clone(): VideoRtpPacket = VideoRtpPacket(
+        cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),
+        BYTES_TO_LEAVE_AT_START_OF_PACKET,
+        length,
+        encodingId = encodingId
+    ).also { postClone(it) }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/GoogleCcEstimator.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/GoogleCcEstimator.kt
@@ -37,14 +37,12 @@ class GoogleCcEstimator(diagnosticContext: DiagnosticContext, parentLogger: Logg
     override var initBw: Bandwidth = BandwidthEstimatorConfig.initBw
     /* TODO: observable which sets the components' values if we're in initial state. */
 
-    override var minBw: Bandwidth by Delegates.observable(BandwidthEstimatorConfig.minBw) {
-            _, _, newValue ->
+    override var minBw: Bandwidth by Delegates.observable(BandwidthEstimatorConfig.minBw) { _, _, newValue ->
         bitrateEstimatorAbsSendTime.setMinBitrate(newValue.bps.toInt())
         sendSideBandwidthEstimation.setMinMaxBitrate(newValue.bps.toInt(), maxBw.bps.toInt())
     }
 
-    override var maxBw: Bandwidth by Delegates.observable(BandwidthEstimatorConfig.maxBw) {
-            _, _, newValue ->
+    override var maxBw: Bandwidth by Delegates.observable(BandwidthEstimatorConfig.maxBw) { _, _, newValue ->
         sendSideBandwidthEstimation.setMinMaxBitrate(minBw.bps.toInt(), newValue.bps.toInt())
     }
 
@@ -101,9 +99,7 @@ class GoogleCcEstimator(diagnosticContext: DiagnosticContext, parentLogger: Logg
         sendSideBandwidthEstimation.onRttUpdate(newRtt)
     }
 
-    override fun getCurrentBw(now: Instant): Bandwidth {
-        return sendSideBandwidthEstimation.latestEstimate.bps
-    }
+    override fun getCurrentBw(now: Instant): Bandwidth = sendSideBandwidthEstimation.latestEstimate.bps
 
     override fun getStats(now: Instant): StatisticsSnapshot = StatisticsSnapshot(
         "GoogleCcEstimator",

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/AcknowledgedBitrateEstimator.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/AcknowledgedBitrateEstimator.kt
@@ -57,6 +57,6 @@ class AcknowledgedBitrateEstimator(
     }
 }
 
-private fun List<PacketResult>.isSortedByReceiveTime(): Boolean {
-    return this.asSequence().zipWithNext { a, b -> a.receiveTime <= b.receiveTime }.all { it }
-}
+private fun List<PacketResult>.isSortedByReceiveTime(): Boolean = this.asSequence().zipWithNext { a, b ->
+    a.receiveTime <= b.receiveTime
+}.all { it }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/AimdRateControl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/AimdRateControl.kt
@@ -128,10 +128,8 @@ class AimdRateControl(private val sendSide: Boolean = false) {
         return false
     }
 
-    fun initialTimeToReduceFurther(atTime: Instant): Boolean {
-        return validEstimate() &&
-            timeToReduceFurther(atTime, latestEstimate() / 2 - 1.bps)
-    }
+    fun initialTimeToReduceFurther(atTime: Instant): Boolean = validEstimate() &&
+        timeToReduceFurther(atTime, latestEstimate() / 2 - 1.bps)
 
     fun latestEstimate() = currentBitrate
 
@@ -262,6 +260,7 @@ class AimdRateControl(private val sendSide: Boolean = false) {
                 }
                 timeLastBitrateChange = atTime
             }
+
             RateControlState.kRcDecrease -> {
                 var decreasedBitrate = Bandwidth.INFINITY
 
@@ -338,10 +337,12 @@ class AimdRateControl(private val sendSide: Boolean = false) {
                     timeLastBitrateChange = atTime
                     rateControlState = RateControlState.kRcIncrease
                 }
+
             BandwidthUsage.kBwOverusing ->
                 if (rateControlState != RateControlState.kRcDecrease) {
                     rateControlState = RateControlState.kRcDecrease
                 }
+
             BandwidthUsage.kBwUnderusing ->
                 rateControlState = RateControlState.kRcHold
         }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/BitrateEstimator.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/BitrateEstimator.kt
@@ -135,13 +135,9 @@ open class BitrateEstimator {
         return Pair(bitrateSample, isSmallSample)
     }
 
-    open fun bitrate(): Bandwidth? {
-        return if (bitrateEstimateKbps < 0.0f) null else bitrateEstimateKbps.kbps
-    }
+    open fun bitrate(): Bandwidth? = if (bitrateEstimateKbps < 0.0f) null else bitrateEstimateKbps.kbps
 
-    fun peekRate(): Bandwidth? {
-        return if (currentWindowMs > 0) sum.bytes.per(currentWindowMs.ms) else null
-    }
+    fun peekRate(): Bandwidth? = if (currentWindowMs > 0) sum.bytes.per(currentWindowMs.ms) else null
 
     open fun expectFastRateChange() {
         // By setting the bitrate-estimate variance to a higher value we allow the

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/BitrateProber.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/BitrateProber.kt
@@ -247,6 +247,7 @@ class BitrateProber(
             ProbingState.kDisabled, ProbingState.kActive -> {
                 return false
             }
+
             ProbingState.kInactive -> {
                 if (config.allowStartProbingImmediately) {
                     return true

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/DelayBasedBwe.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/DelayBasedBwe.kt
@@ -228,9 +228,7 @@ class DelayBasedBwe(
         rateControl.setMinBitrate(minBitrate)
     }
 
-    fun getExpectedBwePeriod(): Duration {
-        return rateControl.getExpectedBandwidthPeriod()
-    }
+    fun getExpectedBwePeriod(): Duration = rateControl.getExpectedBandwidthPeriod()
 
     fun lastEstimate(): Bandwidth = prevBitrate
     fun lastState(): BandwidthUsage = prevState

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcNetworkController.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcNetworkController.kt
@@ -61,11 +61,9 @@ class GoogCcNetworkController(
     private val logger = config.parentLogger.createChildLogger(javaClass.name)
     private val diagnosticContext = config.diagnosticContext
 
-    override fun onNetworkAvailability(msg: NetworkAvailability): NetworkControlUpdate {
-        return NetworkControlUpdate(
-            probeClusterConfigs = probeController.onNetworkAvailability(msg)
-        )
-    }
+    override fun onNetworkAvailability(msg: NetworkAvailability): NetworkControlUpdate = NetworkControlUpdate(
+        probeClusterConfigs = probeController.onNetworkAvailability(msg)
+    )
 
     override fun onNetworkRouteChange(msg: NetworkRouteChange): NetworkControlUpdate {
         if (safeResetOnRouteChange) {
@@ -616,28 +614,26 @@ class GoogCcNetworkController(
         /* Additions to the fields from goog_cc_printer */
         val inAlr: Boolean
     ) {
-        fun toJson(): ObjectNode {
-            return JsonNodeFactory.instance.objectNode().apply {
-                put("time", time.toEpochMilli())
-                put("rtt", rtt.toDouble())
-                put("target", target.bps)
-                put("stable_target", stableTarget.bps)
-                put("pacing", pacing?.bps?.toDouble() ?: Double.NaN)
-                put("padding", padding?.bps?.toDouble() ?: Double.NaN)
-                put("window", window.bytes)
-                put("rate_control_state", rateControlState.name)
-                put("stable_estimate", stableEstimate?.bps?.toDouble() ?: Double.NaN)
-                put("trendline", trendline)
-                put("trendline_modified_offset", trendlineModifiedOffset)
-                put("trendline_modified_threshold", trendlineOffsetThreshold)
-                put("acknowledged_rate", acknowledgedRate?.bps?.toDouble() ?: Double.NaN)
-                put("loss_ratio", lossRatio)
-                put("send_side_target", sendSideTarget.bps)
-                put("last_loss_based_state", lossBasedState.name)
-                put("data_window", dataWindow?.bytes ?: Double.NaN)
-                put("pushback_target", pushbackTarget.bps)
-                put("in_alr", inAlr)
-            }
+        fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
+            put("time", time.toEpochMilli())
+            put("rtt", rtt.toDouble())
+            put("target", target.bps)
+            put("stable_target", stableTarget.bps)
+            put("pacing", pacing?.bps?.toDouble() ?: Double.NaN)
+            put("padding", padding?.bps?.toDouble() ?: Double.NaN)
+            put("window", window.bytes)
+            put("rate_control_state", rateControlState.name)
+            put("stable_estimate", stableEstimate?.bps?.toDouble() ?: Double.NaN)
+            put("trendline", trendline)
+            put("trendline_modified_offset", trendlineModifiedOffset)
+            put("trendline_modified_threshold", trendlineOffsetThreshold)
+            put("acknowledged_rate", acknowledgedRate?.bps?.toDouble() ?: Double.NaN)
+            put("loss_ratio", lossRatio)
+            put("send_side_target", sendSideTarget.bps)
+            put("last_loss_based_state", lossBasedState.name)
+            put("data_window", dataWindow?.bytes ?: Double.NaN)
+            put("pushback_target", pushbackTarget.bps)
+            put("in_alr", inAlr)
         }
 
         fun addToTimeSeriesPoint(point: DiagnosticContext.TimeSeriesPoint) {
@@ -784,12 +780,15 @@ class GoogCcNetworkController(
                 LossBasedState.kDecreasing ->
                     // Probes may not be sent in this state.
                     BandwidthLimitedCause.kLossLimitedBwe
+
                 LossBasedState.kIncreaseUsingPadding ->
                     // Probes may not be sent in this state.
                     BandwidthLimitedCause.kLossLimitedBwe
+
                 LossBasedState.kIncreasing ->
                     // Probes may be sent in this state.
                     BandwidthLimitedCause.kLossLimitedBweIncreasing
+
                 LossBasedState.kDelayBasedEstimate ->
                     BandwidthLimitedCause.kDelayBasedLimited
             }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcTransportCcEngine.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcTransportCcEngine.kt
@@ -107,6 +107,7 @@ class GoogCcTransportCcEngine(
                     }
                 }
             }
+
             is RtcpFbRembPacket -> {
                 /* Ignore REMB packets - if we're supposed to be receiving them they'll be handled by [RembHandler],
                  * and if we're not we're getting mysterious spurious REMB messages which we want to ignore.
@@ -119,10 +120,12 @@ class GoogCcTransportCcEngine(
                 processUpdate(update)
                  */
             }
+
             is RtcpSrPacket -> {
                 val time = receivedTime ?: clock.instant()
                 onReport(time, rtcpPacket.reportBlocks)
             }
+
             is RtcpRrPacket -> {
                 val time = receivedTime ?: clock.instant()
                 onReport(time, rtcpPacket.reportBlocks)
@@ -359,12 +362,10 @@ class GoogCcTransportCcEngine(
     ) : TransportCcEngine.StatisticsSnapshot() {
         override val unmatchedFeedback: Long get() = transportAdapterState.totalUnmatchedReports
 
-        override fun toJson(): ObjectNode {
-            return JsonNodeFactory.instance.objectNode().apply {
-                put("name", GoogCcTransportCcEngine::class.java.simpleName)
-                set<ObjectNode>("transport_adapter", transportAdapterState.toJson())
-                set<ObjectNode>("network_controller", networkControllerState.toJson())
-            }
+        override fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
+            put("name", GoogCcTransportCcEngine::class.java.simpleName)
+            set<ObjectNode>("transport_adapter", transportAdapterState.toJson())
+            set<ObjectNode>("network_controller", networkControllerState.toJson())
         }
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/IntervalBudget.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/IntervalBudget.kt
@@ -60,9 +60,7 @@ class IntervalBudget(
         bytesRemaining = max(bytesRemaining - bytes, -maxBytesInBudget)
     }
 
-    fun bytesRemaining(): Long {
-        return max(0, bytesRemaining)
-    }
+    fun bytesRemaining(): Long = max(0, bytesRemaining)
 
     fun budgetRatio(): Double {
         if (maxBytesInBudget == 0L) {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/LinkCapacityEstimator.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/LinkCapacityEstimator.kt
@@ -28,17 +28,13 @@ class LinkCapacityEstimator {
     private var estimateKbps: Double? = null
     private var deviationKbps: Double = 0.4
 
-    fun upperBound(): Bandwidth {
-        return estimateKbps?.let {
-            (it + 3 * deviationEstimateKbps()).kbps
-        } ?: Bandwidth.INFINITY
-    }
+    fun upperBound(): Bandwidth = estimateKbps?.let {
+        (it + 3 * deviationEstimateKbps()).kbps
+    } ?: Bandwidth.INFINITY
 
-    fun lowerBound(): Bandwidth {
-        return estimateKbps?.let {
-            (max(0.0, it - 3 * deviationEstimateKbps())).kbps
-        } ?: Bandwidth.ZERO
-    }
+    fun lowerBound(): Bandwidth = estimateKbps?.let {
+        (max(0.0, it - 3 * deviationEstimateKbps())).kbps
+    } ?: Bandwidth.ZERO
 
     fun reset() {
         estimateKbps = null

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/LossBasedBweV2.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/LossBasedBweV2.kt
@@ -63,9 +63,7 @@ enum class LossBasedState {
 private val kInitHoldDuration = 300.ms
 private val kMaxHoldDuration = 60.secs
 
-private fun isValid(datarate: Bandwidth?): Boolean {
-    return datarate?.isFinite() ?: false
-}
+private fun isValid(datarate: Bandwidth?): Boolean = datarate?.isFinite() ?: false
 
 private fun isValid(timestamp: Instant) = timestamp.isFinite()
 
@@ -139,19 +137,13 @@ class LossBasedBweV2(configIn: Config = defaultConfig) {
     /** Returns true iff a BWE can be calculated, i.e., the estimator has been
      initialized with a BWE and then has received enough `PacketResult`s.
      */
-    fun isReady(): Boolean {
-        return isEnabled() &&
-            isValid(currentBestEstimate.lossLimitedBandwidth) &&
-            numObservations >= config.minNumObservations
-    }
+    fun isReady(): Boolean = isEnabled() &&
+        isValid(currentBestEstimate.lossLimitedBandwidth) &&
+        numObservations >= config.minNumObservations
 
-    fun readyToUseInStartPhase(): Boolean {
-        return isReady() && config.useInStartPhase
-    }
+    fun readyToUseInStartPhase(): Boolean = isReady() && config.useInStartPhase
 
-    fun useInStartPhase(): Boolean {
-        return config.useInStartPhase
-    }
+    fun useInStartPhase(): Boolean = config.useInStartPhase
 
     /** Returns [Bandwidth.INFINITY] if no BWE can be calculated. */
     fun getLossBasedResult(): Result {
@@ -937,12 +929,10 @@ class LossBasedBweV2(configIn: Config = defaultConfig) {
         return derivatives
     }
 
-    private fun getFeasibleInherentLoss(channelParameters: ChannelParameters): Double {
-        return min(
-            max(channelParameters.inherentLoss, config.inherentLossLowerBound),
-            getInherentLossUpperBound(channelParameters.lossLimitedBandwidth)
-        )
-    }
+    private fun getFeasibleInherentLoss(channelParameters: ChannelParameters): Double = min(
+        max(channelParameters.inherentLoss, config.inherentLossLowerBound),
+        getInherentLossUpperBound(channelParameters.lossLimitedBandwidth)
+    )
 
     private fun getInherentLossUpperBound(bandwidth: Bandwidth): Double {
         if (bandwidth == Bandwidth.ZERO) {
@@ -956,14 +946,12 @@ class LossBasedBweV2(configIn: Config = defaultConfig) {
         return min(inherentLossUpperBound, 1.0)
     }
 
-    private fun adjustBiasFactor(lossRate: Double, biasFactor: Double): Double {
-        return biasFactor *
-            (config.lossThresholdOfHighBandwidthPreference - lossRate) /
-            (
-                config.bandwidthPreferenceSmoothingFactor +
-                    abs(config.lossThresholdOfHighBandwidthPreference - lossRate)
-                )
-    }
+    private fun adjustBiasFactor(lossRate: Double, biasFactor: Double): Double = biasFactor *
+        (config.lossThresholdOfHighBandwidthPreference - lossRate) /
+        (
+            config.bandwidthPreferenceSmoothingFactor +
+                abs(config.lossThresholdOfHighBandwidthPreference - lossRate)
+            )
 
     private fun getHighBandwidthBias(bandwidth: Bandwidth): Double {
         if (isValid(bandwidth)) {
@@ -1034,9 +1022,7 @@ class LossBasedBweV2(configIn: Config = defaultConfig) {
             (1.0 - config.sendingRateSmoothingFactor) * instantaneousSendingRate
     }
 
-    private fun getInstantUpperBound(): Bandwidth {
-        return cachedInstantUpperBound ?: maxBitrate
-    }
+    private fun getInstantUpperBound(): Bandwidth = cachedInstantUpperBound ?: maxBitrate
 
     private fun calculateInstantUpperBound() {
         var instantLimit = maxBitrate
@@ -1051,9 +1037,7 @@ class LossBasedBweV2(configIn: Config = defaultConfig) {
         cachedInstantUpperBound = instantLimit
     }
 
-    private fun getInstantLowerBound(): Bandwidth {
-        return cachedInstantLowerBound ?: Bandwidth.ZERO
-    }
+    private fun getInstantLowerBound(): Bandwidth = cachedInstantLowerBound ?: Bandwidth.ZERO
 
     private fun calculateInstantLowerBound() {
         var instanceLowerBound = Bandwidth.ZERO
@@ -1148,23 +1132,19 @@ class LossBasedBweV2(configIn: Config = defaultConfig) {
         return true
     }
 
-    private fun isEstimateIncreasingWhenLossLimited(oldEstimate: Bandwidth, newEstimate: Bandwidth): Boolean {
-        return (
-            oldEstimate < newEstimate ||
-                (
-                    oldEstimate == newEstimate &&
-                        (
-                            lossBasedResult.state == LossBasedState.kIncreasing ||
-                                lossBasedResult.state == LossBasedState.kIncreaseUsingPadding
-                            )
-                    )
-            ) &&
-            isInLossLimitedState()
-    }
+    private fun isEstimateIncreasingWhenLossLimited(oldEstimate: Bandwidth, newEstimate: Bandwidth): Boolean = (
+        oldEstimate < newEstimate ||
+            (
+                oldEstimate == newEstimate &&
+                    (
+                        lossBasedResult.state == LossBasedState.kIncreasing ||
+                            lossBasedResult.state == LossBasedState.kIncreaseUsingPadding
+                        )
+                )
+        ) &&
+        isInLossLimitedState()
 
-    private fun isInLossLimitedState(): Boolean {
-        return lossBasedResult.state != LossBasedState.kDelayBasedEstimate
-    }
+    private fun isInLossLimitedState(): Boolean = lossBasedResult.state != LossBasedState.kDelayBasedEstimate
 
     private fun canKeepIncreasingState(estimate: Bandwidth): Boolean {
         if (config.paddingDuration == Duration.ZERO ||

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/NetworkController.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/NetworkController.kt
@@ -19,7 +19,7 @@ import org.jitsi.utils.logging.DiagnosticContext
 import org.jitsi.utils.logging2.Logger
 import java.time.Duration
 
-/** Base type for network controller,
+/* Base type for network controller,
  * based on WebRTC api/transport/network_control.h in
  * WebRTC tag branch-heads/7204 (Chromium 138).
  */

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/NetworkTypes.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/NetworkTypes.kt
@@ -31,7 +31,7 @@ import org.jitsi.utils.toDoubleMillis
 import java.time.Duration
 import java.time.Instant
 
-/** Common network types used for bandwidth estimation,
+/* Common network types used for bandwidth estimation,
  * based on WebRTC api/transport/network_types.{h,cc} in
  * WebRTC tag branch-heads/7204 (Chromium 138).
  */
@@ -190,21 +190,13 @@ class TransportPacketsFeedback {
     /** Arrival times for messages without send times information */
     val sendlessArrivalTimes = ArrayList<Instant>()
 
-    fun receivedWithSendInfo(): List<PacketResult> {
-        return packetFeedbacks.filter { it.isReceived() }
-    }
+    fun receivedWithSendInfo(): List<PacketResult> = packetFeedbacks.filter { it.isReceived() }
 
-    fun lostWithSendInfo(): List<PacketResult> {
-        return packetFeedbacks.filterNot { it.isReceived() }
-    }
+    fun lostWithSendInfo(): List<PacketResult> = packetFeedbacks.filterNot { it.isReceived() }
 
-    fun packetsWithFeedback(): List<PacketResult> {
-        return packetFeedbacks
-    }
+    fun packetsWithFeedback(): List<PacketResult> = packetFeedbacks
 
-    fun sortedByReceiveTime(): List<PacketResult> {
-        return receivedWithSendInfo().sortedBy { it.receiveTime }
-    }
+    fun sortedByReceiveTime(): List<PacketResult> = receivedWithSendInfo().sortedBy { it.receiveTime }
 }
 
 // Network estimation
@@ -219,10 +211,8 @@ class NetworkEstimate {
     var lossRateRatio = 0.0f
 
     /* Jitsi local */
-    override fun toString(): String {
-        return "atTime $atTime: " +
-            "bandwidth $bandwidth, rtt $roundTripTime, bwePeriod $bwePeriod, lossRateRatio $lossRateRatio"
-    }
+    override fun toString(): String = "atTime $atTime: " +
+        "bandwidth $bandwidth, rtt $roundTripTime, bwePeriod $bwePeriod, lossRateRatio $lossRateRatio"
 }
 
 class PacerConfig {
@@ -239,10 +229,8 @@ class PacerConfig {
     fun padRate() = padWindow.per(timeWindow)
 
     /* Jitsi Local */
-    override fun toString(): String {
-        return "Data rate ${dataRate()} ($dataWindow per $timeWindow), " +
-            "pad rate ${padRate()} ($padWindow per $timeWindow)"
-    }
+    override fun toString(): String = "Data rate ${dataRate()} ($dataWindow per $timeWindow), " +
+        "pad rate ${padRate()} ($padWindow per $timeWindow)"
 }
 
 data class ProbeClusterConfig(
@@ -258,10 +246,8 @@ data class ProbeClusterConfig(
     var id: Int = 0
 ) {
     /* Jitsi local */
-    override fun toString(): String {
-        return "atTime $atTime: ID=$id: DataRate $targetDataRate Duration $targetDuration " +
-            "ProbeDelta $minProbeDelta ProbeCount $targetProbeCount"
-    }
+    override fun toString(): String = "atTime $atTime: ID=$id: DataRate $targetDataRate Duration $targetDuration " +
+        "ProbeDelta $minProbeDelta ProbeCount $targetProbeCount"
 }
 
 class TargetTransferRate {
@@ -274,10 +260,8 @@ class TargetTransferRate {
     var cwndReduceRatio = 0.0
 
     /* Jitsi local */
-    override fun toString(): String {
-        return "atTime $atTime: networkEstimate {$networkEstimate}, " +
-            "targetRate $targetRate, stableTargetRate $stableTargetRate, cwndReduceRatio $cwndReduceRatio"
-    }
+    override fun toString(): String = "atTime $atTime: networkEstimate {$networkEstimate}, " +
+        "targetRate $targetRate, stableTargetRate $stableTargetRate, cwndReduceRatio $cwndReduceRatio"
 }
 
 // Contains updates of network controller comand state. Using nullables to
@@ -290,9 +274,8 @@ open class NetworkControlUpdate(
     open val targetRate: TargetTransferRate? = null
 ) {
     /* Jitsi local */
-    fun isEmpty(): Boolean {
-        return congestionWindow == null && pacerConfig == null && probeClusterConfigs.isEmpty() && targetRate == null
-    }
+    fun isEmpty(): Boolean =
+        congestionWindow == null && pacerConfig == null && probeClusterConfigs.isEmpty() && targetRate == null
 
     fun isNotEmpty() = !isEmpty()
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/ProbeController.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/ProbeController.kt
@@ -288,8 +288,10 @@ class ProbeController(
         when (newState) {
             State.kInit ->
                 state = State.kInit
+
             State.kWaitingForProbingResult ->
                 state = State.kWaitingForProbingResult
+
             State.kProbingComplete -> {
                 state = State.kProbingComplete
                 minBitrateToProbeFurther = Bandwidth.INFINITY
@@ -554,9 +556,11 @@ class ProbeController(
                 logger.info { "Not sending probe in bandwidth limited state. $bandwidthLimitedCause" }
                 return mutableListOf()
             }
+
             BandwidthLimitedCause.kLossLimitedBweIncreasing ->
                 maxProbeBitrate =
                     min(maxProbeBitrate, estimatedBitrate * config.lossLimitedProbeScale)
+
             BandwidthLimitedCause.kDelayBasedLimited ->
                 Unit
         }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/SendSideBandwidthEstimation.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/SendSideBandwidthEstimation.kt
@@ -87,9 +87,7 @@ class LinkCapacityTracker {
         lastLinkCapcityUpdate = atTime
     }
 
-    fun estimate(): Bandwidth {
-        return capacityEstimateBps.bps
-    }
+    fun estimate(): Bandwidth = capacityEstimateBps.bps
 }
 
 class RttBasedBackoff {
@@ -109,9 +107,7 @@ class RttBasedBackoff {
         lastPropagationRtt = propagationRtt
     }
 
-    fun isRttAboveLimit(): Boolean {
-        return correctedRtt() > rttLimit
-    }
+    fun isRttAboveLimit(): Boolean = correctedRtt() > rttLimit
 
     private fun correctedRtt(): Duration {
         // Avoid timeout when no packets are being sent.
@@ -447,9 +443,7 @@ class SendSideBandwidthEstimation(
         lossBasedBandwidthEstimatorV2.setMinMaxBitrate(minBitrateConfigured, maxBitrateConfigured)
     }
 
-    fun getMinBitrate(): Int {
-        return minBitrateConfigured.bps.toInt()
-    }
+    fun getMinBitrate(): Int = minBitrateConfigured.bps.toInt()
 
     fun setAcknowledgedRate(acknowledgedRate: Bandwidth?, atTime: Instant) {
         this.acknowledgedRate = acknowledgedRate
@@ -473,10 +467,8 @@ class SendSideBandwidthEstimation(
         updateEstimate(report.feedbackTime)
     }
 
-    private fun isInStartPhase(atTime: Instant): Boolean {
-        return firstReportTime.isInfinite() ||
-            Duration.between(firstReportTime, atTime) <= kStartPhase
-    }
+    private fun isInStartPhase(atTime: Instant): Boolean = firstReportTime.isInfinite() ||
+        Duration.between(firstReportTime, atTime) <= kStartPhase
 
     private fun updateUmaStatsPacketsLost(atTime: Instant, packetsLost: Int) {
         val bitrateKbps = ((currentTarget.bps + 500) / 1000).kbps

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/TransportFeedbackAdapter.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/TransportFeedbackAdapter.kt
@@ -315,9 +315,8 @@ class TransportFeedbackAdapter(
         val ssrc: Long,
         val rtpSequenceNumber: Int
     ) : Comparable<SsrcAndRtpSequenceNumber> {
-        override fun compareTo(other: SsrcAndRtpSequenceNumber): Int {
-            return compareValuesBy(this, other, { it.ssrc }, { it.rtpSequenceNumber })
-        }
+        override fun compareTo(other: SsrcAndRtpSequenceNumber): Int =
+            compareValuesBy(this, other, { it.ssrc }, { it.rtpSequenceNumber })
     }
 
     private fun toTransportFeedback(
@@ -407,19 +406,17 @@ class TransportFeedbackAdapter(
     private val history = TreeMap<Long, PacketFeedback>()
 
     /** Jitsi local */
-    fun getStatisitics(): StatisticsSnapshot {
-        return StatisticsSnapshot(
-            inFlight.inFlightData,
-            pendingUntrackedSize,
-            lastSendTime,
-            lastUntrackedSendTime,
-            lastAckSeqNum,
-            history.size,
-            currentOffset,
-            lastTransportFeedbackBaseTime,
-            totalUnmatchedReports,
-        )
-    }
+    fun getStatisitics(): StatisticsSnapshot = StatisticsSnapshot(
+        inFlight.inFlightData,
+        pendingUntrackedSize,
+        lastSendTime,
+        lastUntrackedSendTime,
+        lastAckSeqNum,
+        history.size,
+        currentOffset,
+        lastTransportFeedbackBaseTime,
+        totalUnmatchedReports,
+    )
 
     class StatisticsSnapshot(
         val inFlight: DataSize,
@@ -432,30 +429,26 @@ class TransportFeedbackAdapter(
         val lastTransportFeedbackBaseTime: Instant,
         val totalUnmatchedReports: Long
     ) {
-        fun toJson(): ObjectNode {
-            return JsonNodeFactory.instance.objectNode().apply {
-                put("in_flight_bytes", inFlight.bytes)
-                put("pending_untracked_size", pendingUntrackedSize.bytes)
-                put("last_send_time", lastSendTime.toEpochMilliOrInf().toString())
-                put("last_untracked_send_time", lastUntrackedSendTime.toEpochMilliOrInf().toString())
-                put("last_ack_seq_num", lastAckSeqNum)
-                put("history_size", historySize)
-                put("current_offset", currentOffset.toEpochMilliOrInf().toString())
-                put("last_transport_feedback_base_time", lastTransportFeedbackBaseTime.toEpochMilliOrInf().toString())
-                put("total_unmatched_reports", totalUnmatchedReports)
-            }
+        fun toJson(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
+            put("in_flight_bytes", inFlight.bytes)
+            put("pending_untracked_size", pendingUntrackedSize.bytes)
+            put("last_send_time", lastSendTime.toEpochMilliOrInf().toString())
+            put("last_untracked_send_time", lastUntrackedSendTime.toEpochMilliOrInf().toString())
+            put("last_ack_seq_num", lastAckSeqNum)
+            put("history_size", historySize)
+            put("current_offset", currentOffset.toEpochMilliOrInf().toString())
+            put("last_transport_feedback_base_time", lastTransportFeedbackBaseTime.toEpochMilliOrInf().toString())
+            put("total_unmatched_reports", totalUnmatchedReports)
         }
     }
 }
 
-private fun Instant.toEpochMilliOrInf(): Number {
-    return try {
-        this.toEpochMilli()
-    } catch (e: ArithmeticException) {
-        if (this < Instant.EPOCH) {
-            Double.NEGATIVE_INFINITY
-        } else {
-            Double.POSITIVE_INFINITY
-        }
+private fun Instant.toEpochMilliOrInf(): Number = try {
+    this.toEpochMilli()
+} catch (e: ArithmeticException) {
+    if (this < Instant.EPOCH) {
+        Double.NEGATIVE_INFINITY
+    } else {
+        Double.POSITIVE_INFINITY
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDParser.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDParser.kt
@@ -104,7 +104,7 @@ class Av1DDParser(
         val history = ddStateHistory[av1Packet.ssrc]
 
         if (history == null) {
-            /** Probably getting spammed with SSRCs? */
+            /* Probably getting spammed with SSRCs? */
             logger.warn("History for ${av1Packet.ssrc} disappeared between createFrom and parse!")
             return
         }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDRtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/av1/Av1DDRtpLayerDesc.kt
@@ -80,9 +80,7 @@ class Av1DDRtpLayerDesc(
     /**
      * {@inheritDoc}
      */
-    override fun toString(): String {
-        return "subjective_quality=$index,DT=$dt,height=$height,frameRate=$frameRate"
-    }
+    override fun toString(): String = "subjective_quality=$index,DT=$dt,height=$height,frameRate=$frameRate"
 
     companion object {
         /**

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp8/Vp8Packet.kt
@@ -66,12 +66,10 @@ class Vp8Packet private constructor(
 
     /** End of VP8 frame is the marker bit. */
     override val isEndOfFrame: Boolean
-        /** This uses [get] rather than initialization because [isMarked] is a var. */
+        /* This uses [get] rather than initialization because [isMarked] is a var. */
         get() = isMarked
 
-    override fun meetsRoutingNeeds(): Boolean {
-        return hasPictureId && hasTemporalLayerIndex
-    }
+    override fun meetsRoutingNeeds(): Boolean = hasPictureId && hasTemporalLayerIndex
 
     val hasTemporalLayerIndex =
         DePacketizer.VP8PayloadDescriptor.hasTemporalLayerIndex(buffer, payloadOffset, payloadLength)
@@ -151,23 +149,19 @@ class Vp8Packet private constructor(
             return "type=Vp8Packet len=$vp8PayloadLength hashCode=$hashCode"
         }
 
-    override fun toString(): String {
-        return super.toString() + ", TID=$temporalLayerIndex"
-    }
+    override fun toString(): String = super.toString() + ", TID=$temporalLayerIndex"
 
-    override fun clone(): Vp8Packet {
-        return Vp8Packet(
-            cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),
-            BYTES_TO_LEAVE_AT_START_OF_PACKET,
-            length,
-            isKeyframe = isKeyframe,
-            isStartOfFrame = isStartOfFrame,
-            encodingId = encodingId,
-            height = height,
-            pictureId = pictureId,
-            TL0PICIDX = TL0PICIDX
-        ).also { postClone(it) }
-    }
+    override fun clone(): Vp8Packet = Vp8Packet(
+        cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),
+        BYTES_TO_LEAVE_AT_START_OF_PACKET,
+        length,
+        isKeyframe = isKeyframe,
+        isStartOfFrame = isStartOfFrame,
+        encodingId = encodingId,
+        height = height,
+        pictureId = pictureId,
+        TL0PICIDX = TL0PICIDX
+    ).also { postClone(it) }
 
     companion object {
         private val logger = createLogger()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp9/Vp9Packet.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vp9/Vp9Packet.kt
@@ -85,7 +85,7 @@ class Vp9Packet private constructor(
     /** End of VP9 picture is the marker bit. Note frame/picture distinction. */
     /* TODO: not sure this should be the override from [ParsedVideoPacket] */
     val isEndOfPicture: Boolean
-        /** This uses [get] rather than initialization because [isMarked] is a var. */
+        /* This uses [get] rather than initialization because [isMarked] is a var. */
         get() = isMarked
 
     val hasLayerIndices =
@@ -197,23 +197,19 @@ class Vp9Packet private constructor(
             return "type=VP9Packet len=$vp9PayloadLength hashCode=$hashCode"
         }
 
-    override fun toString(): String {
-        return super.toString() + ", SID=$spatialLayerIndex, TID=$temporalLayerIndex"
-    }
+    override fun toString(): String = super.toString() + ", SID=$spatialLayerIndex, TID=$temporalLayerIndex"
 
-    override fun clone(): Vp9Packet {
-        return Vp9Packet(
-            cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),
-            BYTES_TO_LEAVE_AT_START_OF_PACKET,
-            length,
-            isKeyframe = isKeyframe,
-            isStartOfFrame = isStartOfFrame,
-            isEndOfFrame = isEndOfFrame,
-            encodingId = encodingId,
-            pictureId = pictureId,
-            TL0PICIDX = TL0PICIDX
-        ).also { postClone(it) }
-    }
+    override fun clone(): Vp9Packet = Vp9Packet(
+        cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),
+        BYTES_TO_LEAVE_AT_START_OF_PACKET,
+        length,
+        isKeyframe = isKeyframe,
+        isStartOfFrame = isStartOfFrame,
+        isEndOfFrame = isEndOfFrame,
+        encodingId = encodingId,
+        pictureId = pictureId,
+        TL0PICIDX = TL0PICIDX
+    ).also { postClone(it) }
 
     companion object {
         private val logger = createLogger()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vpx/VpxRtpLayerDesc.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/rtp/codec/vpx/VpxRtpLayerDesc.kt
@@ -117,9 +117,8 @@ constructor(
     /**
      * {@inheritDoc}
      */
-    override fun toString(): String {
-        return "subjective_quality=$index,temporal_id=$tid,spatial_id=$sid,height=$height,frameRate=$frameRate"
-    }
+    override fun toString(): String =
+        "subjective_quality=$index,temporal_id=$tid,spatial_id=$sid,height=$height,frameRate=$frameRate"
 
     /**
      * Gets the cumulative bitrate (in bps) of this [RtpLayerDesc] and its dependencies.

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/srtp/SrtpTransformer.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/srtp/SrtpTransformer.kt
@@ -189,10 +189,8 @@ class SrtcpDecryptTransformer(
         packetInfo: PacketInfo,
         context: SrtcpCryptoContext,
         isNewContext: Boolean
-    ): SrtpErrorStatus {
-        return context.reverseTransformPacket(packetInfo.packet).apply {
-            packetInfo.resetPayloadVerification()
-        }
+    ): SrtpErrorStatus = context.reverseTransformPacket(packetInfo.packet).apply {
+        packetInfo.resetPayloadVerification()
     }
 }
 
@@ -209,17 +207,15 @@ class SrtcpEncryptTransformer(
         packetInfo: PacketInfo,
         context: SrtcpCryptoContext,
         isNewContext: Boolean
-    ): SrtpErrorStatus {
-        return context.transformPacket(packetInfo.packet).apply {
-            // We convert the encrypted RTCP packet to an UnparsedPacket because
-            // we don't want any of the RTCP fields trying to parse the data
-            // (since it's now encrypted)
-            // TODO: better way we can do this?  it's not typically a problem
-            // in the pipeline's usage, but it's a bit of a landmine since by
-            // accessing the packet it can try and parse the fields.
-            packetInfo.packet = packetInfo.packet.toOtherType(::UnparsedPacket)
-            packetInfo.resetPayloadVerification()
-        }
+    ): SrtpErrorStatus = context.transformPacket(packetInfo.packet).apply {
+        // We convert the encrypted RTCP packet to an UnparsedPacket because
+        // we don't want any of the RTCP fields trying to parse the data
+        // (since it's now encrypted)
+        // TODO: better way we can do this?  it's not typically a problem
+        // in the pipeline's usage, but it's a bit of a landmine since by
+        // accessing the packet it can try and parse the fields.
+        packetInfo.packet = packetInfo.packet.toOtherType(::UnparsedPacket)
+        packetInfo.resetPayloadVerification()
     }
 }
 
@@ -275,12 +271,11 @@ class SrtpEncryptTransformer(
     parentLogger: Logger
 ) : SrtpTransformer(contextFactory, parentLogger) {
 
-    override fun transform(packetInfo: PacketInfo, context: SrtpCryptoContext, isNewContext: Boolean): SrtpErrorStatus {
-        return context.transformPacket(packetInfo.packetAs()).apply {
+    override fun transform(packetInfo: PacketInfo, context: SrtpCryptoContext, isNewContext: Boolean): SrtpErrorStatus =
+        context.transformPacket(packetInfo.packetAs()).apply {
             packetInfo.packet = packetInfo.packet.toOtherType(::UnparsedPacket)
             packetInfo.resetPayloadVerification()
         }
-    }
 }
 
 /**

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/srtp/SrtpUtil.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/srtp/SrtpUtil.kt
@@ -32,32 +32,36 @@ class SrtpUtil {
             SrtpConfig.factoryClass?.let { Aes.setFactoryClassName(it) }
         }
 
-        fun getSrtpProtectionProfileFromName(profileName: String): Int {
-            return when (profileName) {
-                "SRTP_AES128_CM_HMAC_SHA1_80" -> {
-                    SRTPProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_80
-                }
-                "SRTP_AES128_CM_HMAC_SHA1_32" -> {
-                    SRTPProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_32
-                }
-                "SRTP_NULL_HMAC_SHA1_32" -> {
-                    SRTPProtectionProfile.SRTP_NULL_HMAC_SHA1_32
-                }
-                "SRTP_NULL_HMAC_SHA1_80" -> {
-                    SRTPProtectionProfile.SRTP_NULL_HMAC_SHA1_80
-                }
-                "SRTP_AEAD_AES_128_GCM" -> {
-                    SRTPProtectionProfile.SRTP_AEAD_AES_128_GCM
-                }
-                "SRTP_AEAD_AES_256_GCM" -> {
-                    SRTPProtectionProfile.SRTP_AEAD_AES_256_GCM
-                }
-                else -> throw IllegalArgumentException("Unsupported SRTP protection profile: $profileName")
+        fun getSrtpProtectionProfileFromName(profileName: String): Int = when (profileName) {
+            "SRTP_AES128_CM_HMAC_SHA1_80" -> {
+                SRTPProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_80
             }
+
+            "SRTP_AES128_CM_HMAC_SHA1_32" -> {
+                SRTPProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_32
+            }
+
+            "SRTP_NULL_HMAC_SHA1_32" -> {
+                SRTPProtectionProfile.SRTP_NULL_HMAC_SHA1_32
+            }
+
+            "SRTP_NULL_HMAC_SHA1_80" -> {
+                SRTPProtectionProfile.SRTP_NULL_HMAC_SHA1_80
+            }
+
+            "SRTP_AEAD_AES_128_GCM" -> {
+                SRTPProtectionProfile.SRTP_AEAD_AES_128_GCM
+            }
+
+            "SRTP_AEAD_AES_256_GCM" -> {
+                SRTPProtectionProfile.SRTP_AEAD_AES_256_GCM
+            }
+
+            else -> throw IllegalArgumentException("Unsupported SRTP protection profile: $profileName")
         }
 
-        fun getSrtpProfileInformationFromSrtpProtectionProfile(srtpProtectionProfile: Int): SrtpProfileInformation {
-            return when (srtpProtectionProfile) {
+        fun getSrtpProfileInformationFromSrtpProtectionProfile(srtpProtectionProfile: Int): SrtpProfileInformation =
+            when (srtpProtectionProfile) {
                 SRTPProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_32 -> {
                     SrtpProfileInformation(
                         cipherKeyLength = 128 / 8,
@@ -69,6 +73,7 @@ class SrtpUtil {
                         rtpAuthTagLength = 32 / 8
                     )
                 }
+
                 SRTPProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_80 -> {
                     SrtpProfileInformation(
                         cipherKeyLength = 128 / 8,
@@ -80,6 +85,7 @@ class SrtpUtil {
                         rtpAuthTagLength = 80 / 8
                     )
                 }
+
                 SRTPProtectionProfile.SRTP_NULL_HMAC_SHA1_32 -> {
                     SrtpProfileInformation(
                         cipherKeyLength = 0,
@@ -91,6 +97,7 @@ class SrtpUtil {
                         rtpAuthTagLength = 32 / 8
                     )
                 }
+
                 SRTPProtectionProfile.SRTP_NULL_HMAC_SHA1_80 -> {
                     SrtpProfileInformation(
                         cipherKeyLength = 0,
@@ -102,6 +109,7 @@ class SrtpUtil {
                         rtpAuthTagLength = 80 / 8
                     )
                 }
+
                 SRTPProtectionProfile.SRTP_AEAD_AES_128_GCM -> {
                     SrtpProfileInformation(
                         cipherKeyLength = 128 / 8,
@@ -113,6 +121,7 @@ class SrtpUtil {
                         rtpAuthTagLength = 128 / 8
                     )
                 }
+
                 SRTPProtectionProfile.SRTP_AEAD_AES_256_GCM -> {
                     SrtpProfileInformation(
                         cipherKeyLength = 256 / 8,
@@ -124,9 +133,9 @@ class SrtpUtil {
                         rtpAuthTagLength = 128 / 8
                     )
                 }
+
                 else -> throw IllegalArgumentException("Unsupported SRTP protection profile: $srtpProtectionProfile")
             }
-        }
 
         fun initializeTransformer(
             srtpProfileInformation: SrtpProfileInformation,
@@ -208,6 +217,7 @@ class SrtpUtil {
                     forwardSrtpContextFactory = clientSrtpContextFactory
                     reverseSrtpContextFactory = serverSrtpContextFactory
                 }
+
                 TlsRole.SERVER -> {
                     forwardSrtpContextFactory = serverSrtpContextFactory
                     reverseSrtpContextFactory = clientSrtpContextFactory

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/DelayStats.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/DelayStats.kt
@@ -35,9 +35,7 @@ class PacketDelayStats(thresholds: List<Long> = defaultThresholds) : DelayStats(
 
     fun addUnknown() = numPacketsWithoutTimestamps.increment()
 
-    override fun toJson(format: Format): ObjectNode {
-        return super.toJson(format).apply {
-            put("packets_without_timestamps", numPacketsWithoutTimestamps.sum())
-        }
+    override fun toJson(format: Format): ObjectNode = super.toJson(format).apply {
+        put("packets_without_timestamps", numPacketsWithoutTimestamps.sum())
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/EndpointConnectionStats.kt
@@ -91,14 +91,12 @@ class EndpointConnectionStats(
         endpointConnectionStatsListeners.remove(listener)
     }
 
-    fun getSnapshot(): Snapshot {
-        return synchronized(lock) {
-            Snapshot(
-                rtt = rtt,
-                incomingLossStats = incomingLossTracker.getSnapshot(),
-                outgoingLossStats = outgoingLossTracker.getSnapshot()
-            )
-        }
+    fun getSnapshot(): Snapshot = synchronized(lock) {
+        Snapshot(
+            rtt = rtt,
+            incomingLossStats = incomingLossTracker.getSnapshot(),
+            outgoingLossStats = outgoingLossTracker.getSnapshot()
+        )
     }
 
     override fun rtcpPacketReceived(packet: RtcpPacket, receivedTime: Instant?) {
@@ -107,6 +105,7 @@ class EndpointConnectionStats(
                 logger.cdebug { "Received SR packet with ${packet.reportBlocks.size} report blocks" }
                 packet.reportBlocks.forEach { reportBlock -> processReportBlock(receivedTime, reportBlock) }
             }
+
             is RtcpRrPacket -> {
                 logger.cdebug { "Received RR packet with ${packet.reportBlocks.size} report blocks" }
                 packet.reportBlocks.forEach { reportBlock -> processReportBlock(receivedTime, reportBlock) }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/JitterStats.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/JitterStats.kt
@@ -68,7 +68,7 @@ open class JitterStats {
             val delta = Duration.between(previousPacketSentTimestamp, previousPacketReceivedTimestamp) -
                 Duration.between(currentPacketSentTimestamp, currentPacketReceivedTimestamp)
 
-            /**
+            /*
              * The interarrival jitter SHOULD be calculated continuously as each
              * data packet i is received from source SSRC_n, using this
              * difference D for that packet and the previous packet i-1 in order

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/NodeStatsBlock.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/stats/NodeStatsBlock.kt
@@ -109,14 +109,19 @@ class NodeStatsBlock(val name: String) {
             when {
                 existingValue == null && (value is Long || value is Double) ->
                     stats[name] = value
+
                 existingValue is Long && value is Long ->
                     stats[name] = existingValue + value
+
                 existingValue is Double && value is Double ->
                     stats[name] = existingValue + value
+
                 existingValue is Long && value is Double ->
                     stats[name] = existingValue + value
+
                 existingValue is Double && value is Long ->
                     stats[name] = existingValue + value
+
                 else -> stats[name] = value
             }
         }
@@ -136,26 +141,25 @@ class NodeStatsBlock(val name: String) {
         else -> null
     }
 
-    fun prettyPrint(indentLevel: Int = 0): String {
-        return with(StringBuffer()) {
-            appendLnIndent(indentLevel, name)
-            stats.forEach { (statName, statValue) ->
-                when (statValue) {
-                    is NodeStatsBlock -> {
-                        appendLine(statValue.prettyPrint(indentLevel + 2))
-                    }
-                    else -> {
-                        // statValue is Any, so we know it's non-null
-                        appendLnIndent(indentLevel + 2, "$statName: $statValue")
-                    }
+    fun prettyPrint(indentLevel: Int = 0): String = with(StringBuffer()) {
+        appendLnIndent(indentLevel, name)
+        stats.forEach { (statName, statValue) ->
+            when (statValue) {
+                is NodeStatsBlock -> {
+                    appendLine(statValue.prettyPrint(indentLevel + 2))
+                }
+
+                else -> {
+                    // statValue is Any, so we know it's non-null
+                    appendLnIndent(indentLevel + 2, "$statName: $statValue")
                 }
             }
-            compoundStats.forEach { (statName, function) ->
-                val statValue = function.invoke(this@NodeStatsBlock)
-                appendLnIndent(indentLevel + 2, "$statName: $statValue")
-            }
-            toString()
         }
+        compoundStats.forEach { (statName, function) ->
+            val statValue = function.invoke(this@NodeStatsBlock)
+            appendLnIndent(indentLevel + 2, "$statName: $statValue")
+        }
+        toString()
     }
 
     /**

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/PipelineDsl.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/PipelineDsl.kt
@@ -60,9 +60,7 @@ class PipelineBuilder {
      */
     fun simpleNode(name: String, packetHandler: (PacketInfo) -> PacketInfo?) {
         val node = object : TransformerNode(name) {
-            override fun transform(packetInfo: PacketInfo): PacketInfo? {
-                return packetHandler.invoke(packetInfo)
-            }
+            override fun transform(packetInfo: PacketInfo): PacketInfo? = packetHandler.invoke(packetInfo)
 
             override val aggregationKey = this.name
             override fun trace(f: () -> Unit) = f.invoke()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/AudioRedHandler.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/AudioRedHandler.kt
@@ -158,6 +158,7 @@ class AudioRedHandler(
                         stats.redundancyPacketAdded()
                     }
                 }
+
                 RedDistance.TWO -> {
                     getPacketToProtect(
                         applySequenceNumberDelta(seq, -1),
@@ -234,8 +235,10 @@ class AudioRedHandler(
             // Whether we need to strip the RED encapsulation
             val strip = when (redPayloadType) {
                 null -> true
+
                 else -> when (config.policy) {
                     RedPolicy.STRIP -> true
+
                     // RedPolicy.PROTECT_DOMINANT -> !isDominant
                     RedPolicy.NOOP, RedPolicy.PROTECT_ALL -> false
                 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/Node.kt
@@ -396,11 +396,9 @@ abstract class TransformerNode(name: String) : StatsKeepingNode(name) {
         }
     }
 
-    final override fun packetDiscarded(packetInfo: PacketInfo) {
-        throw Exception(
-            "No subclass of TransformerNode should call packetDiscarded, return null from 'transform' instead"
-        )
-    }
+    final override fun packetDiscarded(packetInfo: PacketInfo): Unit = throw Exception(
+        "No subclass of TransformerNode should call packetDiscarded, return null from 'transform' instead"
+    )
 }
 
 /** A [TransformerNode] which gets its transformation function dynamically. */
@@ -434,12 +432,10 @@ abstract class ModifierNode(name: String) : NeverDiscardNode(name) {
 abstract class FilterNode(name: String) : TransformerNode(name) {
     protected abstract fun accept(packetInfo: PacketInfo): Boolean
 
-    override fun transform(packetInfo: PacketInfo): PacketInfo? {
-        return if (accept(packetInfo)) {
-            packetInfo
-        } else {
-            null
-        }
+    override fun transform(packetInfo: PacketInfo): PacketInfo? = if (accept(packetInfo)) {
+        packetInfo
+    } else {
+        null
     }
 }
 
@@ -448,9 +444,7 @@ abstract class PredicateFilterNode(
     name: String,
     val predicate: PacketInfoPredicate
 ) : FilterNode(name) {
-    override fun accept(packetInfo: PacketInfo): Boolean {
-        return predicate.test(packetInfo)
-    }
+    override fun accept(packetInfo: PacketInfo): Boolean = predicate.test(packetInfo)
 }
 
 /**

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/PacketCacher.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/PacketCacher.kt
@@ -35,10 +35,8 @@ class PacketCacher : ObserverNode("Packet cache") {
 
     fun getPacketCache(): PacketCache = packetCache
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            // Put the values directly in the node stats and not inside a block to make aggregation work correctly.
-            aggregate(packetCache.getNodeStats())
-        }
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        // Put the values directly in the node stats and not inside a block to make aggregation work correctly.
+        aggregate(packetCache.getNodeStats())
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/PacketLossNode.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/PacketLossNode.kt
@@ -55,19 +55,15 @@ class PacketLossNode(val config: PacketLossConfig) : FilterNode("PacketLossNode(
 
     override fun trace(f: () -> Unit) { }
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            addNumber("configured_uniform_rate", config.uniformRate)
-            addNumber("configured_burst_size", config.burstSize)
-            addNumber("configured_burst_interval", config.burstInterval)
-            addRatio("actual_drop_rate", "num_discarded_packets", "num_input_packets")
-        }
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        addNumber("configured_uniform_rate", config.uniformRate)
+        addNumber("configured_burst_size", config.burstSize)
+        addNumber("configured_burst_interval", config.burstInterval)
+        addRatio("actual_drop_rate", "num_discarded_packets", "num_input_packets")
     }
 
-    override fun getNodeStatsToAggregate(): NodeStatsBlock {
-        return super.getNodeStatsToAggregate().apply {
-            addRatio("actual_drop_rate", "num_discarded_packets", "num_input_packets")
-        }
+    override fun getNodeStatsToAggregate(): NodeStatsBlock = super.getNodeStatsToAggregate().apply {
+        addRatio("actual_drop_rate", "num_discarded_packets", "num_input_packets")
     }
 }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/PacketParser.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/PacketParser.kt
@@ -27,15 +27,13 @@ open class PacketParser(
 ) : TransformerNode(name) {
     private val logger = createChildLogger(parentLogger)
 
-    override fun transform(packetInfo: PacketInfo): PacketInfo? {
-        return try {
-            packetInfo.packet = action(packetInfo.packet)
-            packetInfo.resetPayloadVerification()
-            packetInfo
-        } catch (e: Exception) {
-            logger.warn("Error parsing packet: $e")
-            null
-        }
+    override fun transform(packetInfo: PacketInfo): PacketInfo? = try {
+        packetInfo.packet = action(packetInfo.packet)
+        packetInfo.resetPayloadVerification()
+        packetInfo
+    } catch (e: Exception) {
+        logger.warn("Error parsing packet: $e")
+        null
     }
 
     override fun trace(f: () -> Unit) = f.invoke()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/RtpParser.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/RtpParser.kt
@@ -53,12 +53,14 @@ class RtpParser(
                 logger.info("Dropping audio packet due to parse failure: ${e.message}")
                 return null
             }
+
             MediaType.VIDEO -> try {
                 packet.toOtherType(::VideoRtpPacket)
             } catch (e: Exception) {
                 logger.info("Dropping video packet due to parse failure: ${e.message}")
                 return null
             }
+
             else -> {
                 logger.info("Dropping packet with unrecognized media type: '${payloadType.mediaType}'")
                 return null

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/SrtpTransformerNode.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/SrtpTransformerNode.kt
@@ -121,23 +121,21 @@ abstract class SrtpTransformerNode(name: String) : MultipleOutputTransformerNode
         }
     }
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            addNumber("num_cached_packets", numCachedPackets)
-            if (firstPacketReceivedTimestamp != -1L && firstPacketForwardedTimestamp != -1L) {
-                val timeBetweenReceivedAndForwarded = firstPacketForwardedTimestamp - firstPacketReceivedTimestamp
-                addNumber("time_initial_hold_ms", timeBetweenReceivedAndForwarded)
-            } else {
-                addString("state", "hold_for_transformer")
-            }
-            addNumber("num_srtp_processed", numSrtpProcessed)
-            addNumber("num_srtp_fail", numSrtpFail)
-            addNumber("num_srtp_auth_fail", numSrtpAuthFail)
-            addNumber("num_srtp_replay_fail", numSrtpReplayFail)
-            addNumber("num_srtp_replay_old", numSrtpReplayOld)
-            addNumber("num_srtp_invalid_packet", numSrtpInvalidPacket)
-            addNumber("num_cached_contexts", transformer?.numCachedContexts ?: 0)
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        addNumber("num_cached_packets", numCachedPackets)
+        if (firstPacketReceivedTimestamp != -1L && firstPacketForwardedTimestamp != -1L) {
+            val timeBetweenReceivedAndForwarded = firstPacketForwardedTimestamp - firstPacketReceivedTimestamp
+            addNumber("time_initial_hold_ms", timeBetweenReceivedAndForwarded)
+        } else {
+            addString("state", "hold_for_transformer")
         }
+        addNumber("num_srtp_processed", numSrtpProcessed)
+        addNumber("num_srtp_fail", numSrtpFail)
+        addNumber("num_srtp_auth_fail", numSrtpAuthFail)
+        addNumber("num_srtp_replay_fail", numSrtpReplayFail)
+        addNumber("num_srtp_replay_old", numSrtpReplayOld)
+        addNumber("num_srtp_invalid_packet", numSrtpInvalidPacket)
+        addNumber("num_cached_contexts", transformer?.numCachedContexts ?: 0)
     }
 
     override fun statsJson() = super.statsJson().apply {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/BitrateCalculator.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/BitrateCalculator.kt
@@ -126,17 +126,13 @@ open class BitrateCalculator(
 
     override fun trace(f: () -> Unit) = f.invoke()
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            addNumber("bitrate_bps", bitrate.bps)
-            addNumber("packet_rate_pps", packetRatePps)
-            addBoolean("active", active)
-        }
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        addNumber("bitrate_bps", bitrate.bps)
+        addNumber("packet_rate_pps", packetRatePps)
+        addBoolean("active", active)
     }
 
-    override fun getNodeStatsToAggregate(): NodeStatsBlock {
-        return super.getNodeStats()
-    }
+    override fun getNodeStatsToAggregate(): NodeStatsBlock = super.getNodeStats()
 
     companion object {
         /**
@@ -149,11 +145,9 @@ open class BitrateCalculator(
         }
 
         /** The default bitrate calculator window size if not set in jvb.conf, based on the BWE algorithm in use.*/
-        private fun defaultWindowSize(): Duration {
-            return when (BandwidthEstimatorConfig.engine) {
-                BandwidthEstimatorEngine.GoogleCc -> GoogleCcEstimator.defaultRateTrackerWindowSize
-                BandwidthEstimatorEngine.GoogleCc2 -> GoogCcTransportCcEngine.defaultRateTrackerWindowSize
-            }
+        private fun defaultWindowSize(): Duration = when (BandwidthEstimatorConfig.engine) {
+            BandwidthEstimatorEngine.GoogleCc -> GoogleCcEstimator.defaultRateTrackerWindowSize
+            BandwidthEstimatorEngine.GoogleCc2 -> GoogCcTransportCcEngine.defaultRateTrackerWindowSize
         }
 
         /**
@@ -167,11 +161,9 @@ open class BitrateCalculator(
         }
 
         /** The default bitrate calculator bucket size if not set in jvb.conf, based on the BWE algorithm in use.*/
-        private fun defaultBucketSize(): Duration {
-            return when (BandwidthEstimatorConfig.engine) {
-                BandwidthEstimatorEngine.GoogleCc -> GoogleCcEstimator.defaultRateTrackerBucketSize
-                BandwidthEstimatorEngine.GoogleCc2 -> GoogCcTransportCcEngine.defaultRateTrackerBucketSize
-            }
+        private fun defaultBucketSize(): Duration = when (BandwidthEstimatorConfig.engine) {
+            BandwidthEstimatorEngine.GoogleCc -> GoogleCcEstimator.defaultRateTrackerBucketSize
+            BandwidthEstimatorEngine.GoogleCc2 -> GoogCcTransportCcEngine.defaultRateTrackerBucketSize
         }
 
         /**

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/IncomingStatisticsTracker.kt
@@ -67,12 +67,10 @@ class IncomingStatisticsTracker(
         }
     }
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            val stats = getSnapshot()
-            stats.ssrcStats.forEach { (ssrc, streamStats) ->
-                addJson(ssrc.toString(), streamStats.toJson())
-            }
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        val stats = getSnapshot()
+        stats.ssrcStats.forEach { (ssrc, streamStats) ->
+            addJson(ssrc.toString(), streamStats.toJson())
         }
     }
 
@@ -139,6 +137,7 @@ class IncomingSsrcStats(
     // acceptable for RRs?
     private var statsLock = Any()
     // Start variables protected by statsLock
+
     /**
      * This will be initialized to the first sequence number we process
      */
@@ -231,7 +230,7 @@ class IncomingSsrcStats(
 
     fun getSnapshot(): Snapshot = synchronized(statsLock) { createSnapshot() }
 
-    /**
+    /*
      * Resets this [IncomingSsrcStats]'s tracking variables such that:
      * 1) A new base sequence number (the given [newBaseSeqNum]) will be used to start new loss calculations.
      * 2) Any lost packet counters will be reset

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/PaddingTermination.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/PaddingTermination.kt
@@ -48,11 +48,9 @@ class PaddingTermination(parentLogger: Logger) : TransformerNode("Padding termin
         return packetInfo
     }
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            addNumber("num_padded_packets_seen", numPaddedPacketsSeen)
-            addNumber("num_padding_only_packets_seen", numPaddingOnlyPacketsSeen)
-        }
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        addNumber("num_padded_packets_seen", numPaddedPacketsSeen)
+        addNumber("num_padding_only_packets_seen", numPaddingOnlyPacketsSeen)
     }
 
     override fun statsJson() = super.statsJson().apply {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RemoteBandwidthEstimator.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RemoteBandwidthEstimator.kt
@@ -55,8 +55,7 @@ class RemoteBandwidthEstimator(
     /**
      * The remote bandwidth estimation is enabled when REMB support is signaled, but TCC is not signaled.
      */
-    private var enabled: Boolean by observableWhenChanged(false) {
-            _, _, newValue ->
+    private var enabled: Boolean by observableWhenChanged(false) { _, _, newValue ->
         logger.debug { "Setting enabled=$newValue." }
     }
     private var astExtId: Int? = null

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTermination.kt
@@ -72,22 +72,26 @@ class RtcpTermination(
                     }
                     forwardedRtcp = rtcpPacket
                 }
+
                 is RtcpSdesPacket, is RtcpRrPacket, is RtcpFbNackPacket,
                 is RtcpByePacket, is RtcpFbTccPacket, is RtcpFbRembPacket -> {
                     // Supported, but no special handling here (any special handling will be in
                     // notifyRtcpReceived below
                 }
+
                 is RtcpXrPacket -> {
                     // Unsupported, but we get them when chrome does screenshare and the
                     // message below clouds up the logs.  They are still tracked as part
                     // of the packetReceiveCount
                 }
+
                 is UnsupportedRtcpFbPacket -> {
                     logger.cinfo {
                         "TODO: not yet handling RTCP packet of type ${rtcpPacket.packetType} fmt " +
                             "${rtcpPacket.reportCount} ${rtcpPacket.javaClass}"
                     }
                 }
+
                 else -> {
                     logger.cinfo {
                         "TODO: not yet handling RTCP packet of type ${rtcpPacket.packetType} " +
@@ -125,13 +129,11 @@ class RtcpTermination(
         }
     }
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            packetReceiveCounts.forEach { (type, count) ->
-                addNumber("num_${type}_rx", count)
-            }
-            addNumber("num_failed_to_forward", numFailedToForward)
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        packetReceiveCounts.forEach { (type, count) ->
+            addNumber("num_${type}_rx", count)
         }
+        addNumber("num_failed_to_forward", numFailedToForward)
     }
 
     override fun statsJson() = super.statsJson().apply {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtxHandler.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/RtxHandler.kt
@@ -93,12 +93,10 @@ class RtxHandler(
         return packetInfo
     }
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            addNumber("num_rtx_packets_received", numRtxPacketsReceived)
-            addNumber("num_padding_packets_received", numPaddingPacketsReceived)
-            addString("rtx_payload_types", rtxPtToRtxPayloadType.values.toString())
-        }
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        addNumber("num_rtx_packets_received", numRtxPacketsReceived)
+        addNumber("num_padding_packets_received", numPaddingPacketsReceived)
+        addString("rtx_payload_types", rtxPtToRtxPayloadType.values.toString())
     }
 
     override fun statsJson() = super.statsJson().apply {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/TccGeneratorNode.kt
@@ -65,8 +65,7 @@ class TccGeneratorNode(
     private val tccFeedbackBitrate = BitrateTracker(1.secs, 10.ms)
     private var numTccSent: Int = 0
     private var numMultipleTccPackets = 0
-    private var enabled: Boolean by observableWhenChanged(false) {
-            _, _, newValue ->
+    private var enabled: Boolean by observableWhenChanged(false) { _, _, newValue ->
         logger.debug("Setting enabled=$newValue")
     }
     private val rtpSequenceIndexTracker = RtpSequenceIndexTracker()
@@ -240,14 +239,12 @@ class TccGeneratorNode(
 
     override fun trace(f: () -> Unit) = f.invoke()
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            addNumber("num_tcc_packets_sent", numTccSent)
-            addNumber("tcc_feedback_bitrate_bps", tccFeedbackBitrate.rate.bps)
-            addString("tcc_extension_id", tccExtensionId.toString())
-            addNumber("num_multiple_tcc_packets", numMultipleTccPackets)
-            addBoolean("enabled", enabled)
-        }
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        addNumber("num_tcc_packets_sent", numTccSent)
+        addNumber("tcc_feedback_bitrate_bps", tccFeedbackBitrate.rate.bps)
+        addString("tcc_extension_id", tccExtensionId.toString())
+        addNumber("num_multiple_tcc_packets", numMultipleTccPackets)
+        addBoolean("enabled", enabled)
     }
 
     override fun statsJson() = super.statsJson().apply {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoParser.kt
@@ -85,6 +85,7 @@ class VideoParser(
                     videoCodecParser = parser
                     vp8Packet
                 }
+
                 payloadType is Vp9PayloadType -> {
                     val (vp9Packet, parser) = parseNormalPayload<Vp9Parser>(packetInfo, ::Vp9Packet) { source ->
                         Vp9Parser(source, logger)
@@ -92,6 +93,7 @@ class VideoParser(
                     videoCodecParser = parser
                     vp9Packet
                 }
+
                 av1DDExtId != null && packet.getHeaderExtension(av1DDExtId) != null -> {
                     videoCodecParser = checkParserType<Av1DDParser>(packetInfo) { source ->
                         Av1DDParser(source, logger, diagnosticContext)
@@ -104,6 +106,7 @@ class VideoParser(
 
                     av1DDPacket
                 }
+
                 else -> {
                     val curParser = videoCodecParsers[packet.ssrc]
                     if (curParser != null) {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoQualityLayerLookup.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/incoming/VideoQualityLayerLookup.kt
@@ -64,9 +64,7 @@ class VideoQualityLayerLookup(
 
     override fun trace(f: () -> Unit) = f.invoke()
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            addNumber("num_packets_dropped_no_encoding", numPacketsDroppedNoEncoding.get())
-        }
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        addNumber("num_packets_dropped_no_encoding", numPacketsDroppedNoEncoding.get())
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/AbsSendTime.kt
@@ -47,10 +47,8 @@ class AbsSendTime(
         return packetInfo
     }
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            addString("abs_send_time_ext_id", extensionId.toString())
-        }
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        addString("abs_send_time_ext_id", extensionId.toString())
     }
 
     override fun trace(f: () -> Unit) = f.invoke()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/MidStamper.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/MidStamper.kt
@@ -64,11 +64,9 @@ class MidStamper(
         return packetInfo
     }
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            addString("mid_ext_id", extensionId.toString())
-            addNumber("num_stamped", numStamped)
-        }
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        addString("mid_ext_id", extensionId.toString())
+        addNumber("num_stamped", numStamped)
     }
 
     override fun trace(f: () -> Unit) = f.invoke()

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/OutgoingStatisticsTracker.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/OutgoingStatisticsTracker.kt
@@ -51,6 +51,7 @@ class OutgoingStatisticsTracker(
 
         when (rtpPacket) {
             is AudioRtpPacket -> numAudioPackets++
+
             is VideoRtpPacket -> {
                 numVideoPackets++
 
@@ -88,27 +89,23 @@ class OutgoingStatisticsTracker(
 
     override fun trace(f: () -> Unit) = f.invoke()
 
-    fun getSnapshot(): OutgoingStatisticsSnapshot {
-        return OutgoingStatisticsSnapshot(
-            ssrcStats.map { (ssrc, stats) ->
-                Pair(ssrc, stats.getSnapshot())
-            }.toMap()
-        ).also {
-            if (timeseriesLogger.isTraceEnabled) {
-                val point = diagnosticContext.makeTimeSeriesPoint("sent_video_stream_stats")
-                    .addField("bitrate_bps", videoBitrate.rate.bps)
-                videoBitratesByOrigin.forEach { (origin, tracker) ->
-                    point.addField("video_${origin}_bitrate", tracker.rate.bps)
-                }
-
-                timeseriesLogger.trace(point)
+    fun getSnapshot(): OutgoingStatisticsSnapshot = OutgoingStatisticsSnapshot(
+        ssrcStats.map { (ssrc, stats) ->
+            Pair(ssrc, stats.getSnapshot())
+        }.toMap()
+    ).also {
+        if (timeseriesLogger.isTraceEnabled) {
+            val point = diagnosticContext.makeTimeSeriesPoint("sent_video_stream_stats")
+                .addField("bitrate_bps", videoBitrate.rate.bps)
+            videoBitratesByOrigin.forEach { (origin, tracker) ->
+                point.addField("video_${origin}_bitrate", tracker.rate.bps)
             }
+
+            timeseriesLogger.trace(point)
         }
     }
 
-    fun getSsrcSnapshot(ssrc: Long): OutgoingSsrcStats.Snapshot? {
-        return ssrcStats[ssrc]?.getSnapshot()
-    }
+    fun getSsrcSnapshot(ssrc: Long): OutgoingSsrcStats.Snapshot? = ssrcStats[ssrc]?.getSnapshot()
 
     companion object {
         private val timeseriesLogger = TimeSeriesLogger.getTimeSeriesLogger(OutgoingStatisticsTracker::class.java)

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSender.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/RetransmissionSender.kt
@@ -108,16 +108,14 @@ class RetransmissionSender(
         return packetInfo
     }
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            addNumber("num_retransmissions_requested", numRetransmissionsRequested)
-            addNumber("num_retransmissions_rtx_sent", numRetransmittedRtxPackets)
-            addNumber("num_retransmissions_plain_sent", numRetransmittedPlainPackets)
-            addString(
-                "rtx_payload_types(orig -> rtx)",
-                this@RetransmissionSender.origPtToRtxPayloadType.toString()
-            )
-        }
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        addNumber("num_retransmissions_requested", numRetransmissionsRequested)
+        addNumber("num_retransmissions_rtx_sent", numRetransmittedRtxPackets)
+        addNumber("num_retransmissions_plain_sent", numRetransmittedPlainPackets)
+        addString(
+            "rtx_payload_types(orig -> rtx)",
+            this@RetransmissionSender.origPtToRtxPayloadType.toString()
+        )
     }
 
     override fun statsJson() = super.statsJson().apply {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SentRtcpStats.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/SentRtcpStats.kt
@@ -30,11 +30,9 @@ class SentRtcpStats : ObserverNode("Sent RTCP stats") {
         sentRtcpCounts.merge(rtcpPacket::class.simpleName!!, 1, Int::plus)
     }
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            sentRtcpCounts.forEach { (rtcpType, count) ->
-                addNumber("num_${rtcpType}_tx", count)
-            }
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        sentRtcpCounts.forEach { (rtcpType, count) ->
+            addNumber("num_${rtcpType}_tx", count)
         }
     }
 

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/transform/node/outgoing/TccSeqNumTagger.kt
@@ -58,6 +58,7 @@ class TccSeqNumTagger(
 
                     currTccSeqNum++
                 }
+
                 else -> Unit
             }
         }
@@ -65,10 +66,8 @@ class TccSeqNumTagger(
         return packetInfo
     }
 
-    override fun getNodeStats(): NodeStatsBlock {
-        return super.getNodeStats().apply {
-            addString("tcc_ext_id", tccExtensionId.toString())
-        }
+    override fun getNodeStats(): NodeStatsBlock = super.getNodeStats().apply {
+        addString("tcc_ext_id", tccExtensionId.toString())
     }
 
     override fun stop() {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/ArrayCache.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/ArrayCache.kt
@@ -88,12 +88,15 @@ open class ArrayCache<T>(
                 head = 0
                 head
             }
+
             diff <= -size -> {
                 // The item is too old
                 numOldInserts++
                 return false
             }
+
             diff < 0 -> position(diff)
+
             else -> {
                 head = position(diff)
                 head
@@ -124,6 +127,7 @@ open class ArrayCache<T>(
             synchronize -> synchronized(syncRoot) {
                 doGet(index, shouldCloneItem)
             }
+
             else -> doGet(index, shouldCloneItem)
         }
 
@@ -156,14 +160,12 @@ open class ArrayCache<T>(
     /**
      * Checks whether the cache contains an item with a given index.
      */
-    fun containsIndex(index: Long): Boolean {
-        return if (synchronize) {
-            synchronized(syncRoot) {
-                doContains(index)
-            }
-        } else {
+    fun containsIndex(index: Long): Boolean = if (synchronize) {
+        synchronized(syncRoot) {
             doContains(index)
         }
+    } else {
+        doContains(index)
     }
 
     private fun doContains(index: Long): Boolean {
@@ -269,8 +271,7 @@ open class ArrayCache<T>(
         var index: Long = -1,
         var timeAdded: Long = -1
     ) {
-        fun clone(shouldCloneItem: Boolean): Container {
-            return Container(item?.let { if (shouldCloneItem) cloneItem(it) else it }, index, timeAdded)
-        }
+        fun clone(shouldCloneItem: Boolean): Container =
+            Container(item?.let { if (shouldCloneItem) cloneItem(it) else it }, index, timeAdded)
     }
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/Bandwidth.kt
@@ -142,23 +142,18 @@ val Long.mbps: Bandwidth
 /**
  * Create a [Bandwidth] from a [DataSize] over a given time
  */
-fun DataSize.per(duration: Duration): Bandwidth {
-    return Bandwidth((this.bits * 1_000_000) / duration.toRoundedMicros())
-}
+fun DataSize.per(duration: Duration): Bandwidth = Bandwidth((this.bits * 1_000_000) / duration.toRoundedMicros())
 
 /**
  * Create a [Duration] from a [DataSize] per [Bandwidth]
  */
-operator fun DataSize.div(bandwidth: Bandwidth): Duration {
-    return Duration.ofNanos(round((this.bits.toDouble() / bandwidth.bps * 1e9)).toLong())
-}
+operator fun DataSize.div(bandwidth: Bandwidth): Duration =
+    Duration.ofNanos(round((this.bits.toDouble() / bandwidth.bps * 1e9)).toLong())
 
 /**
  * create a [DataSize] from a [Bandwidth] times [Duration]
  */
-operator fun Bandwidth.times(duration: Duration): DataSize {
-    return round(bps * duration.toDouble()).toLong().bits
-}
+operator fun Bandwidth.times(duration: Duration): DataSize = round(bps * duration.toDouble()).toLong().bits
 
 /**
  * Returns the sum of all elements in the collection.
@@ -168,22 +163,16 @@ fun Iterable<Bandwidth>.sum(): Bandwidth = reduce(Bandwidth::plus)
 /**
  * Returns the maximum of two [Bandwidth]s
  */
-fun max(a: Bandwidth, b: Bandwidth): Bandwidth {
-    return if (a >= b) a else b
-}
+fun max(a: Bandwidth, b: Bandwidth): Bandwidth = if (a >= b) a else b
 
 /**
  * Returns the minimum of two [Bandwidth]s
  */
-fun min(a: Bandwidth, b: Bandwidth): Bandwidth {
-    return if (a <= b) a else b
-}
+fun min(a: Bandwidth, b: Bandwidth): Bandwidth = if (a <= b) a else b
 
 /**
  * Ensures that this value is not greater than the specified [maximumValue].
  *
  * @return this value if it's less than or equal to the [maximumValue] or the [maximumValue] otherwise.
  */
-public fun Bandwidth.coerceAtMost(maximumValue: Bandwidth): Bandwidth {
-    return if (this > maximumValue) maximumValue else this
-}
+public fun Bandwidth.coerceAtMost(maximumValue: Bandwidth): Bandwidth = if (this > maximumValue) maximumValue else this

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/DataSize.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/DataSize.kt
@@ -78,9 +78,7 @@ class DataSize(
 
     override fun hashCode(): Int = bits.hashCode()
 
-    fun toWholeBytes(): DataSize {
-        return (bits / 8.0).roundToLong().bytes
-    }
+    fun toWholeBytes(): DataSize = (bits / 8.0).roundToLong().bytes
 
     companion object {
         val ZERO = DataSize(0)
@@ -113,13 +111,9 @@ val Long.megabytes: DataSize
 /**
  * Returns the maximum of two [DataSize]s
  */
-fun max(a: DataSize, b: DataSize): DataSize {
-    return if (a >= b) a else b
-}
+fun max(a: DataSize, b: DataSize): DataSize = if (a >= b) a else b
 
 /**
  * Returns the minimum of two [DataSize]s
  */
-fun min(a: DataSize, b: DataSize): DataSize {
-    return if (a <= b) a else b
-}
+fun min(a: DataSize, b: DataSize): DataSize = if (a <= b) a else b

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/IndexTracker.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/IndexTracker.kt
@@ -16,7 +16,7 @@
 
 package org.jitsi.nlj.util
 
-/**
+/*
  * Index tracker inspired by the RFC3711 RTP sequence number index tracker.
  */
 
@@ -118,6 +118,7 @@ sealed class IndexTracker<T> {
                 // Seq num was from the previous roc value
                 roc - 1
             }
+
             rollsOver(highestSeqNumReceived, seqNum) -> {
                 // We've rolled over, so update the roc in place if updateRoc
                 // is set, otherwise return the right value (our current roc
@@ -128,6 +129,7 @@ sealed class IndexTracker<T> {
                     roc + 1
                 }
             }
+
             else -> roc
         }
 
@@ -149,7 +151,5 @@ sealed class IndexTracker<T> {
         getIndex(seq, true)
     }
 
-    fun debugState(): String {
-        return "{roc=$roc, highestSeqNumReceived=$highestSeqNumReceived}"
-    }
+    fun debugState(): String = "{roc=$roc, highestSeqNumReceived=$highestSeqNumReceived}"
 }

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/PacketCache.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/PacketCache.kt
@@ -50,10 +50,10 @@ class PacketCache(
 
     private var stopped = false
 
-    private fun getCache(ssrc: Long): RtpPacketCache {
-        return packetCaches.computeIfAbsent(ssrc) { RtpPacketCache(size) }.also { it.setLastAccess() }
-            .also { expireCaches(it.lastAccessMillis) }
-    }
+    private fun getCache(ssrc: Long): RtpPacketCache = packetCaches.computeIfAbsent(ssrc) {
+        RtpPacketCache(size)
+    }.also { it.setLastAccess() }
+        .also { expireCaches(it.lastAccessMillis) }
 
     private fun expireCaches(now: Long) {
         synchronized(packetCaches) {
@@ -153,9 +153,7 @@ class RtpPacketCache(
     /**
      * Gets a packet with a given RTP sequence number from the cache (clones the packet).
      */
-    fun get(sequenceNumber: Int): Container? {
-        return doGet(sequenceNumber, true)
-    }
+    fun get(sequenceNumber: Int): Container? = doGet(sequenceNumber, true)
 
     fun doGet(sequenceNumber: Int, shouldCloneItem: Boolean): Container? {
         // Note that we use [interpret] because we don't want the ROC to get out of sync because of funny requests
@@ -169,9 +167,7 @@ class RtpPacketCache(
     /**
      * Gets a packet with a given RTP sequence number from the cache (does not clone the packet).
      */
-    fun peek(sequenceNumber: Int): Container? {
-        return doGet(sequenceNumber, false)
-    }
+    fun peek(sequenceNumber: Int): Container? = doGet(sequenceNumber, false)
 
     fun contains(sequenceNumber: Int): Boolean {
         // Note that we use [interpret] because we don't want the ROC to get out of sync because of funny requests

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/RateUtils.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/RateUtils.kt
@@ -37,6 +37,4 @@ infix fun DataSize.atRate(bw: Bandwidth): Duration {
 fun howMuchCanISendAtRate(bw: Bandwidth): Bandwidth = bw
 
 @Suppress("ktlint:standard:function-naming")
-infix fun Bandwidth.`in`(time: Duration): DataSize {
-    return DataSize((bps * (time.seconds + time.nano / 1e9)).toLong())
-}
+infix fun Bandwidth.`in`(time: Duration): DataSize = DataSize((bps * (time.seconds + time.nano / 1e9)).toLong())

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/SsrcAssociationStore.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/SsrcAssociationStore.kt
@@ -68,9 +68,7 @@ class SsrcAssociationStore {
      * processed during which we return true for an SSRC which will later be denoted
      * as a secondary ssrc.
      */
-    fun isPrimarySsrc(ssrc: Long): Boolean {
-        return !ssrcAssociationsBySecondarySsrc.containsKey(ssrc)
-    }
+    fun isPrimarySsrc(ssrc: Long): Boolean = !ssrcAssociationsBySecondarySsrc.containsKey(ssrc)
 
     fun onAssociation(handler: (SsrcAssociation) -> Unit) {
         synchronized(lock) {

--- a/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/Util.kt
+++ b/jitsi-media-transform/src/main/kotlin/org/jitsi/nlj/util/Util.kt
@@ -45,13 +45,9 @@ inline fun <reified Expected> Iterable<*>.forEachIf(action: (Expected) -> Unit) 
     }
 }
 
-infix fun Int.floorMod(other: Int): Int {
-    return Math.floorMod(this, other)
-}
+infix fun Int.floorMod(other: Int): Int = Math.floorMod(this, other)
 
-infix fun Long.floorMod(other: Long): Long {
-    return Math.floorMod(this, other)
-}
+infix fun Long.floorMod(other: Long): Long = Math.floorMod(this, other)
 
 /** Set the value at position [index] in a [MutableList] to [element].  If the list has fewer
  * than [index] entries, extend the intermediate entries between its current size and

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/MediaSourceDescTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/MediaSourceDescTest.kt
@@ -253,11 +253,7 @@ private fun createSource(
 private class FakeBitrateTracker(
     private val fakeRateBps: Long
 ) : BitrateTracker(1.secs) {
-    override fun getRate(nowMs: Long): Bandwidth {
-        return fakeRateBps.bps
-    }
+    override fun getRate(nowMs: Long): Bandwidth = fakeRateBps.bps
 
-    override fun getRateBps(nowMs: Long): Long {
-        return fakeRateBps
-    }
+    override fun getRateBps(nowMs: Long): Long = fakeRateBps
 }

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/module_tests/SrtpTransformerFactory.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/module_tests/SrtpTransformerFactory.kt
@@ -23,15 +23,13 @@ import org.jitsi.test_utils.SrtpData
 
 class SrtpTransformerFactory {
     companion object {
-        fun createSrtpTransformers(srtpData: SrtpData): SrtpTransformers {
-            return SrtpUtil.initializeTransformer(
-                srtpData.srtpProfileInformation,
-                srtpData.keyingMaterial,
-                srtpData.tlsRole,
-                // TODO: add tests for the cryptex=true case
-                cryptex = false,
-                StdoutLogger()
-            )
-        }
+        fun createSrtpTransformers(srtpData: SrtpData): SrtpTransformers = SrtpUtil.initializeTransformer(
+            srtpData.srtpProfileInformation,
+            srtpData.keyingMaterial,
+            srtpData.tlsRole,
+            // TODO: add tests for the cryptex=true case
+            cryptex = false,
+            StdoutLogger()
+        )
     }
 }

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/AudioRedHandlerTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/AudioRedHandlerTest.kt
@@ -182,7 +182,9 @@ class AudioRedHandlerTest : ShouldSpec() {
     private val redPackets = List(7) { i ->
         when (i) {
             0 -> RedAudioRtpPacket.builder.build(redPt, audioPackets[0].clone(), emptyList())
+
             1 -> RedAudioRtpPacket.builder.build(redPt, audioPackets[1].clone(), listOf(audioPackets[0]))
+
             else -> RedAudioRtpPacket.builder.build(
                 redPt,
                 audioPackets[i].clone(),
@@ -207,11 +209,13 @@ class AudioRedHandlerTest : ShouldSpec() {
             val parsedRedundancy = it.removeRedAndGetRedundancyPackets()
             when (it.sequenceNumber) {
                 0 -> parsedRedundancy.size shouldBe 0
+
                 1 -> {
                     parsedRedundancy.size shouldBe 1
                     parsedRedundancy[0].sequenceNumber shouldBe 0
                     parsedRedundancy[0].getPacketId() shouldBe 0
                 }
+
                 2, 3 -> {
                     parsedRedundancy.size shouldBe 2
                     parsedRedundancy[0].sequenceNumber shouldBe it.sequenceNumber - 2
@@ -219,6 +223,7 @@ class AudioRedHandlerTest : ShouldSpec() {
                     parsedRedundancy[1].sequenceNumber shouldBe it.sequenceNumber - 1
                     parsedRedundancy[1].getPacketId() shouldBe it.sequenceNumber - 1
                 }
+
                 5 -> {
                     if (packet4WasAvailable) {
                         parsedRedundancy.size shouldBe 2
@@ -231,6 +236,7 @@ class AudioRedHandlerTest : ShouldSpec() {
                         parsedRedundancy.size shouldBe 0
                     }
                 }
+
                 6 -> {
                     if (packet4WasAvailable) {
                         parsedRedundancy.size shouldBe 2

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimationTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation/BandwidthEstimationTest.kt
@@ -56,8 +56,7 @@ abstract class FixedRateSender(
 
     var running = false
 
-    var rate: Bandwidth by Delegates.observable(0.bps) {
-            _, _, _ ->
+    var rate: Bandwidth by Delegates.observable(0.bps) { _, _, _ ->
         nextPacket?.cancel(false)
         schedulePacket(false)
     }
@@ -70,6 +69,7 @@ abstract class FixedRateSender(
         } else {
             val packetDelayTime = when (lastSendTime) {
                 NEVER -> Duration.ZERO
+
                 else -> {
                     var delayTime = (nextPacketSize() atRate rate)
                     if (!justSent) {

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/AlrDetectorTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/AlrDetectorTest.kt
@@ -17,7 +17,7 @@
 @file:Suppress("ktlint:standard:property-naming")
 
 package org.jitsi.nlj.rtp.bandwidthestimation2
-/**
+/*
  * Unit tests for AlrDetector.
  *
  * Based on WebRTC modules/congestion_controller/goog_cc/alr_detector_unittest.cc in

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcNetworkControllerTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/GoogCcNetworkControllerTest.kt
@@ -49,12 +49,10 @@ private fun createRouteChange(
     startRate: Bandwidth? = null,
     minRate: Bandwidth? = null,
     maxRate: Bandwidth? = null
-): NetworkRouteChange {
-    return NetworkRouteChange(
-        atTime = time,
-        constraints = TargetRateConstraints(minDataRate = minRate, maxDataRate = maxRate, startingRate = startRate)
-    )
-}
+): NetworkRouteChange = NetworkRouteChange(
+    atTime = time,
+    constraints = TargetRateConstraints(minDataRate = minRate, maxDataRate = maxRate, startingRate = startRate)
+)
 
 private fun createPacketResult(
     arrivalTime: Instant,

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/IntervalBudgetTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/IntervalBudgetTest.kt
@@ -25,9 +25,7 @@ const val kWindowMs = 500L
 const val kBitrateKbps = 100
 const val kCanBuildUpUnderuse = true
 const val kCanNotBuildUpUnderuse = false
-fun timeToBytes(bitrateKbps: Int, timeMs: Long): Long {
-    return bitrateKbps.toLong() * timeMs / 8
-}
+fun timeToBytes(bitrateKbps: Int, timeMs: Long): Long = bitrateKbps.toLong() * timeMs / 8
 
 /** Unit tests for IntervalBudget,
  * based on WebRTC modules/pacing/interval_budget_unittest.cc in

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/LossBasedBweV2Test.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/LossBasedBweV2Test.kt
@@ -53,37 +53,34 @@ const val kPacketSize = 15_000
 
 private var transportSequenceNumber = 0L
 
-private fun config(enabled: Boolean, valid: Boolean): LossBasedBweV2.Config {
-    return LossBasedBweV2.Config(
-        enabled = enabled,
-        bandwidthRampupUpperBoundFactor = if (valid) 1.2 else 0.0,
-        candidateFactors = doubleArrayOf(1.1, 1.0, 0.95),
-        higherBandwidthBiasFactor = 0.01,
-        inherentLossLowerBound = 0.001,
-        inherentLossUpperBoundBandwidthBalance = 14.kbps,
-        inherentLossUpperBoundOffset = 0.9,
-        initialInherentLossEstimate = 0.01,
-        newtonIterations = 2,
-        newtonStepSize = 0.4,
-        observationWindowSize = 15,
-        sendingRateSmoothingFactor = 0.01,
-        instantUpperBoundTemporalWeightFactor = 0.97,
-        instantUpperBoundBandwidthBalance = 90.kbps,
-        instantUpperBoundLossOffset = 0.1,
-        temporalWeightFactor = 0.98,
-        minNumObservations = 1,
-        observationDurationLowerBound = kObservationDurationLowerBound,
-        maxIncreaseFactor = kMaxIncreaseFactor,
-        delayedIncreaseWindow = kDelayedIncreaseWindow
-    )
-}
+private fun config(enabled: Boolean, valid: Boolean): LossBasedBweV2.Config = LossBasedBweV2.Config(
+    enabled = enabled,
+    bandwidthRampupUpperBoundFactor = if (valid) 1.2 else 0.0,
+    candidateFactors = doubleArrayOf(1.1, 1.0, 0.95),
+    higherBandwidthBiasFactor = 0.01,
+    inherentLossLowerBound = 0.001,
+    inherentLossUpperBoundBandwidthBalance = 14.kbps,
+    inherentLossUpperBoundOffset = 0.9,
+    initialInherentLossEstimate = 0.01,
+    newtonIterations = 2,
+    newtonStepSize = 0.4,
+    observationWindowSize = 15,
+    sendingRateSmoothingFactor = 0.01,
+    instantUpperBoundTemporalWeightFactor = 0.97,
+    instantUpperBoundBandwidthBalance = 90.kbps,
+    instantUpperBoundLossOffset = 0.1,
+    temporalWeightFactor = 0.98,
+    minNumObservations = 1,
+    observationDurationLowerBound = kObservationDurationLowerBound,
+    maxIncreaseFactor = kMaxIncreaseFactor,
+    delayedIncreaseWindow = kDelayedIncreaseWindow
+)
 
-private fun shortObservationConfig(config: LossBasedBweV2.Config = LossBasedBweV2.Config()): LossBasedBweV2.Config {
-    return config.copy(
+private fun shortObservationConfig(config: LossBasedBweV2.Config = LossBasedBweV2.Config()): LossBasedBweV2.Config =
+    config.copy(
         minNumObservations = 1,
         observationWindowSize = 2
     )
-}
 
 private fun createPacketResultsWithReceivedPackets(firstPacketTimestamp: Instant): List<PacketResult> {
     val enoughFeedback = List(2) { PacketResult() }

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/TransportFeedbackAdapterTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/rtp/bandwidthestimation2/TransportFeedbackAdapterTest.kt
@@ -208,6 +208,7 @@ class OneTransportFeedbackAdapterTest(val feedbackType: FeedbackType) {
                 val rtcpFeedback = buildRtcpTransportFeedbackPacket(packets)
                 return adapter.processTransportFeedback(rtcpFeedback, timeNow())
             }
+
             FeedbackType.Ccfb -> {
                 val rtcpFeedback = buildRtcpCongestionControlFeedbackPacket(packets)
                 return adapter.processCongestionControlFeedback(rtcpFeedback, timeNow())

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/test_utils/matchers/ByteBuffer.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/test_utils/matchers/ByteBuffer.kt
@@ -23,11 +23,9 @@ import org.jitsi.rtp.extensions.toHex
 import java.nio.ByteBuffer
 
 fun haveSameContentAs(expected: ByteBuffer) = object : Matcher<ByteBuffer> {
-    override fun test(value: ByteBuffer): MatcherResult {
-        return MatcherResult(
-            value.compareToFromBeginning(expected) == 0,
-            { "Buffer\n${value.toHex()}\nwas supposed to be:\n${expected.toHex()}" },
-            { "Buffer\n${value.toHex()}\nshould not have equaled buffer\n${expected.toHex()}" }
-        )
-    }
+    override fun test(value: ByteBuffer): MatcherResult = MatcherResult(
+        value.compareToFromBeginning(expected) == 0,
+        { "Buffer\n${value.toHex()}\nwas supposed to be:\n${expected.toHex()}" },
+        { "Buffer\n${value.toHex()}\nshould not have equaled buffer\n${expected.toHex()}" }
+    )
 }

--- a/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTerminationTest.kt
+++ b/jitsi-media-transform/src/test/kotlin/org/jitsi/nlj/transform/node/incoming/RtcpTerminationTest.kt
@@ -136,11 +136,9 @@ class RtcpTerminationTest : ShouldSpec() {
     }
 
     // Create a compound RTCP packet with another arbitrary RTCP packet alongside the SR
-    private fun createCompoundRtcp(srPacket: RtcpSrPacket): CompoundRtcpPacket {
-        return CompoundRtcpPacket(
-            nackPacket.buffer + srPacket.buffer,
-            srPacket.offset,
-            srPacket.length + nackPacket.length
-        )
-    }
+    private fun createCompoundRtcp(srPacket: RtcpSrPacket): CompoundRtcpPacket = CompoundRtcpPacket(
+        nackPacket.buffer + srPacket.buffer,
+        srPacket.offset,
+        srPacket.length + nackPacket.length
+    )
 }

--- a/jvb/pom.xml
+++ b/jvb/pom.xml
@@ -18,6 +18,8 @@
     <assembly.skipAssembly>false</assembly.skipAssembly>
     <exec.mainClass>org.jitsi.videobridge.MainKt</exec.mainClass>
     <slf4j.version>2.0.16</slf4j.version>
+    <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
+    <ktlint.version>1.8.0</ktlint.version>
   </properties>
 
   <profiles>
@@ -350,10 +352,11 @@
           </execution>
         </executions>
       </plugin>
+      <!-- ktlint: check runs in the verify phase; auto-format with "mvn exec:exec@ktlint-format" -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>${exec-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>exec-exec</id>
@@ -379,7 +382,57 @@
               <mainClass>${exec.mainClass}</mainClass>
             </configuration>
           </execution>
+          <execution>
+            <id>ktlint-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>java</executable>
+              <includePluginDependencies>true</includePluginDependencies>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath>
+                  <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                </classpath>
+                <argument>com.pinterest.ktlint.Main</argument>
+                <argument>--relative</argument>
+                <argument>src/main/kotlin/**/*.kt</argument>
+                <argument>src/test/kotlin/**/*.kt</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>ktlint-format</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>java</executable>
+              <includePluginDependencies>true</includePluginDependencies>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath>
+                  <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                </classpath>
+                <argument>com.pinterest.ktlint.Main</argument>
+                <argument>--format</argument>
+                <argument>--relative</argument>
+                <argument>src/main/kotlin/**/*.kt</argument>
+                <argument>src/test/kotlin/**/*.kt</argument>
+              </arguments>
+            </configuration>
+          </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.pinterest.ktlint</groupId>
+            <artifactId>ktlint-cli</artifactId>
+            <version>${ktlint.version}</version>
+            <classifier>all</classifier>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.eclipse.jetty.ee10</groupId>
@@ -489,27 +542,6 @@
             <version>${spotbugs.version}</version>
           </dependency>
         </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>com.github.gantsign.maven</groupId>
-        <artifactId>ktlint-maven-plugin</artifactId>
-        <version>${ktlint-maven-plugin.version}</version>
-        <configuration>
-          <sourceRoots>
-            <sourceRoot>${project.basedir}/src/main/kotlin</sourceRoot>
-          </sourceRoots>
-          <testSourceRoots>
-            <testSourceRoot>${project.basedir}/src/test/kotlin</testSourceRoot>
-          </testSourceRoots>
-        </configuration>
-        <executions>
-          <execution>
-            <id>check</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <!-- Instructs the plugin to add the current package version in the jar manifest

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/AudioSubscriptionManager.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/AudioSubscriptionManager.kt
@@ -78,12 +78,13 @@ class AudioSubscriptionManager() {
             audioSubscription.updateSubscription(subscription, knownSources.toList())
         }
 
-    /**
+    /*
      * Checks if audio from a given SSRC is wanted by a specific endpoint.
      * @param endpointId the ID of the endpoint
      * @param ssrc the SSRC to check
      * @return true if the audio is wanted, false otherwise
      */
+
     /** Whether the given SSRC belongs to a (currently-known) synthetic source. */
     fun isSynthetic(ssrc: Long): Boolean = ssrcSynthetic[ssrc] == true
 
@@ -118,9 +119,7 @@ class AudioSubscriptionManager() {
      * @param sourceName the name of the audio source
      * @return true if the source is explicitly subscribed, false otherwise
      */
-    fun isExplicitlySubscribed(sourceName: String?): Boolean {
-        return subscribedLocalAudioSources.containsKey(sourceName)
-    }
+    fun isExplicitlySubscribed(sourceName: String?): Boolean = subscribedLocalAudioSources.containsKey(sourceName)
 
     /**
      * Updates the subscribed local audio sources for a specific endpoint based on their subscription.

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -343,7 +343,9 @@ class Endpoint @JvmOverloads constructor(
                     }
                 }
             }
+
             is AudioRtpPacket -> if (doSsrcRewriting) audioSsrcs.rewriteRtp(packet)
+
             is RtcpSrPacket -> {
                 // Allow the BC to update the timestamp (in place).
                 bitrateController.transformRtcp(packet)
@@ -360,9 +362,8 @@ class Endpoint @JvmOverloads constructor(
 
     private val bandwidthProbing = BandwidthProbing(
         object : BandwidthProbing.ProbingDataSender {
-            override fun sendProbing(mediaSsrcs: Collection<Long>, numBytes: Int): Int {
-                return transceiver.sendProbing(mediaSsrcs, numBytes)
-            }
+            override fun sendProbing(mediaSsrcs: Collection<Long>, numBytes: Int): Int =
+                transceiver.sendProbing(mediaSsrcs, numBytes)
         },
         { bitrateController.getStatusSnapshot() }
     ).apply {
@@ -571,6 +572,7 @@ class Endpoint @JvmOverloads constructor(
     fun setFeature(feature: EndpointDebugFeatures, enabled: Boolean) {
         when (feature) {
             EndpointDebugFeatures.PCAP_DUMP -> transceiver.setFeature(Features.TRANSCEIVER_PCAP_DUMP, enabled)
+
             EndpointDebugFeatures.SCTP_PCAP_DUMP ->
                 if (enabled) {
                     toggleablePcapWriter.enable()
@@ -580,11 +582,9 @@ class Endpoint @JvmOverloads constructor(
         }
     }
 
-    fun isFeatureEnabled(feature: EndpointDebugFeatures): Boolean {
-        return when (feature) {
-            EndpointDebugFeatures.PCAP_DUMP -> transceiver.isFeatureEnabled(Features.TRANSCEIVER_PCAP_DUMP)
-            EndpointDebugFeatures.SCTP_PCAP_DUMP -> toggleablePcapWriter.isEnabled()
-        }
+    fun isFeatureEnabled(feature: EndpointDebugFeatures): Boolean = when (feature) {
+        EndpointDebugFeatures.PCAP_DUMP -> transceiver.isFeatureEnabled(Features.TRANSCEIVER_PCAP_DUMP)
+        EndpointDebugFeatures.SCTP_PCAP_DUMP -> toggleablePcapWriter.isEnabled()
     }
     override val isSendingAudio: Boolean
         get() =
@@ -995,12 +995,15 @@ class Endpoint @JvmOverloads constructor(
 
         return when (val packet = packetInfo.packet) {
             is VideoRtpPacket -> acceptVideo && bitrateController.accept(packetInfo)
+
             is AudioRtpPacket -> acceptAudio && conference.isEndpointAudioWanted(id, packet.ssrc)
+
             is RtcpSrPacket -> {
                 // TODO: For SRs we're only interested in the ntp/rtp timestamp
                 //  association, so we could only accept srs from the main ssrc
                 bitrateController.accept(packet)
             }
+
             is RtcpFbPliPacket, is RtcpFbFirPacket -> {
                 // We assume that we are only given PLIs/FIRs destined for this
                 // endpoint. This is because Conference has to find the target
@@ -1008,6 +1011,7 @@ class Endpoint @JvmOverloads constructor(
                 // performing the same check twice.
                 true
             }
+
             else -> {
                 logger.warn("Ignoring an unknown packet type:" + packet.javaClass.simpleName)
                 false

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/SsrcCache.kt
@@ -551,16 +551,14 @@ abstract class SsrcCache(
     /**
      * {@inheritDoc}
      */
-    override fun toString(): String {
-        return "SSRCs: received=" +
-            receivedSsrcs.entries.joinToString(", ", "[", "]") {
-                "(${it.key}->${it.value})"
-            } +
-            " mappings=" +
-            sendSources.entries.joinToString(", ", "[", "]") {
-                "(${it.key}->${it.value})"
-            }
-    }
+    override fun toString(): String = "SSRCs: received=" +
+        receivedSsrcs.entries.joinToString(", ", "[", "]") {
+            "(${it.key}->${it.value})"
+        } +
+        " mappings=" +
+        sendSources.entries.joinToString(", ", "[", "]") {
+            "(${it.key}->${it.value})"
+        }
 }
 
 /**
@@ -778,13 +776,11 @@ private class Av1DDCodecDeltas(val frameNumDelta: Int, val templateIdDelta: Int)
     override fun toString() = "[AV1DD FrameNum]$frameNumDelta [Av1DD templateId]$templateIdDelta"
 }
 
-private fun RtpPacket.getCodecState(): CodecState? {
-    return when {
-        this is Vp8Packet && isRewritable() -> Vp8CodecState(this)
-        this is Vp9Packet -> Vp9CodecState(this)
-        this is Av1DDPacket -> Av1DDCodecState(this)
-        else -> null
-    }
+private fun RtpPacket.getCodecState(): CodecState? = when {
+    this is Vp8Packet && isRewritable() -> Vp8CodecState(this)
+    this is Vp9Packet -> Vp9CodecState(this)
+    this is Av1DDPacket -> Av1DDCodecState(this)
+    else -> null
 }
 
 private fun Vp8Packet.isRewritable(): Boolean = hasTL0PICIDX

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/ReceiverConstraintsMap.kt
@@ -35,9 +35,12 @@ class ReceiverConstraintsMap {
             return map.put(key, value).also { removed ->
                 maxHeight = when {
                     value.maxHeight == -1 -> value.maxHeight
+
                     maxHeight != -1 && value.maxHeight >= maxHeight -> value.maxHeight
+
                     (maxHeight == -1 || value.maxHeight < maxHeight) && removed?.maxHeight == maxHeight ->
                         findNextMax(maxHeight)
+
                     else -> maxHeight
                 }
             }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/SingleSourceAllocation.kt
@@ -266,14 +266,12 @@ internal class SingleSourceAllocation(
             layers.idealLayer?.layer
         )
 
-    override fun toString(): String {
-        return (
-            "[id=" + endpointId +
-                " constraints=" + constraints +
-                " ratedPreferredIdx=" + layers.preferredIndex +
-                " ratedTargetIdx=" + targetIdx
-            )
-    }
+    override fun toString(): String = (
+        "[id=" + endpointId +
+            " constraints=" + constraints +
+            " ratedPreferredIdx=" + layers.preferredIndex +
+            " ratedTargetIdx=" + targetIdx
+        )
 
     /**
      * Selects from a list of layers the ones which should be considered when allocating bandwidth, as well as the
@@ -383,12 +381,14 @@ internal class SingleSourceAllocation(
 
         return when {
             source.videoType == VideoType.CAMERA -> selectLayersForCamera(layers, constraints)
+
             source.videoType.isScreenshare() -> selectLayersForScreensharing(
                 layers,
                 constraints,
                 onStage,
                 highFps = source.videoType == VideoType.DESKTOP_HIGH_FPS
             )
+
             else -> Layers.noLayers
         }
     }
@@ -463,10 +463,9 @@ private fun <T> List<T>.lastIndexWhich(predicate: (T) -> Boolean): Int {
  * consider frame rates at least as high as the preferred. In practice this means we consider
  * 180p/7.5fps, 180p/15fps, 180p/30fps, 360p/30fps and 720p/30fps.
  */
-private fun getPreferred(constraints: VideoConstraints): VideoConstraints {
-    return if (constraints.maxHeight > 180 || !constraints.heightIsLimited()) {
+private fun getPreferred(constraints: VideoConstraints): VideoConstraints =
+    if (constraints.maxHeight > 180 || !constraints.heightIsLimited()) {
         VideoConstraints(config.onstagePreferredHeightPx, config.onstagePreferredFramerate)
     } else {
         VideoConstraints.UNLIMITED
     }
-}

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDFrame.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDFrame.kt
@@ -260,9 +260,7 @@ class Av1DDFrame internal constructor(
      * belongs to the same RTP stream as the frame that this instance refers to,
      * false otherwise.
      */
-    fun matchesSSRC(av1Frame: Av1DDFrame): Boolean {
-        return ssrc == av1Frame.ssrc
-    }
+    fun matchesSSRC(av1Frame: Av1DDFrame): Boolean = ssrc == av1Frame.ssrc
 
     /**
      * Checks whether the specified RTP packet is part of this frame.
@@ -271,10 +269,8 @@ class Av1DDFrame internal constructor(
      * @return true if the specified RTP packet is part of this frame, false
      * otherwise.
      */
-    fun matchesFrame(pkt: Av1DDPacket): Boolean {
-        return ssrc == pkt.ssrc && timestamp == pkt.timestamp &&
-            frameNumber == pkt.frameNumber
-    }
+    fun matchesFrame(pkt: Av1DDPacket): Boolean = ssrc == pkt.ssrc && timestamp == pkt.timestamp &&
+        frameNumber == pkt.frameNumber
 
     fun validateConsistency(pkt: Av1DDPacket) {
         if (frameInfo == null) {
@@ -295,10 +291,8 @@ class Av1DDFrame internal constructor(
             }
         )
     }
-    fun isImmediatelyAfter(otherFrame: Av1DDFrame): Boolean {
-        return frameNumber ==
-            applySequenceNumberDelta(otherFrame.frameNumber, 1)
-    }
+    fun isImmediatelyAfter(otherFrame: Av1DDFrame): Boolean = frameNumber ==
+        applySequenceNumberDelta(otherFrame.frameNumber, 1)
 
     override fun toString() = buildString {
         append("$ssrc, ")

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDFrameMap.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDFrameMap.kt
@@ -22,14 +22,10 @@ class Av1DDFrameMap(
 
     /** Find a frame in the frame map, based on a packet.  */
     @Synchronized
-    fun findFrame(packet: Av1DDPacket): Av1DDFrame? {
-        return frameHistory[packet.frameNumber]
-    }
+    fun findFrame(packet: Av1DDPacket): Av1DDFrame? = frameHistory[packet.frameNumber]
 
     /** Get the current size of the map.  */
-    fun size(): Int {
-        return frameHistory.numCached
-    }
+    fun size(): Int = frameHistory.numCached
 
     /** Check whether this is a large jump from previous state, so the map should be reset.  */
     private fun isLargeJump(packet: Av1DDPacket): Boolean {
@@ -114,32 +110,22 @@ class Av1DDFrameMap(
     fun getIndex(frameIndex: Long) = frameHistory.getIndex(frameIndex)
 
     @Synchronized
-    fun nextFrame(frame: Av1DDFrame): Av1DDFrame? {
-        return frameHistory.findAfter(frame) { true }
-    }
+    fun nextFrame(frame: Av1DDFrame): Av1DDFrame? = frameHistory.findAfter(frame) { true }
 
     @Synchronized
-    fun nextFrameWith(frame: Av1DDFrame, pred: (Av1DDFrame) -> Boolean): Av1DDFrame? {
-        return frameHistory.findAfter(frame, pred)
-    }
+    fun nextFrameWith(frame: Av1DDFrame, pred: (Av1DDFrame) -> Boolean): Av1DDFrame? =
+        frameHistory.findAfter(frame, pred)
 
     @Synchronized
-    fun prevFrame(frame: Av1DDFrame): Av1DDFrame? {
-        return frameHistory.findBefore(frame) { true }
-    }
+    fun prevFrame(frame: Av1DDFrame): Av1DDFrame? = frameHistory.findBefore(frame) { true }
 
     @Synchronized
-    fun prevFrameWith(frame: Av1DDFrame, pred: (Av1DDFrame) -> Boolean): Av1DDFrame? {
-        return frameHistory.findBefore(frame, pred)
-    }
+    fun prevFrameWith(frame: Av1DDFrame, pred: (Av1DDFrame) -> Boolean): Av1DDFrame? =
+        frameHistory.findBefore(frame, pred)
 
-    fun findPrevAcceptedFrame(frame: Av1DDFrame): Av1DDFrame? {
-        return prevFrameWith(frame) { it.isAccepted }
-    }
+    fun findPrevAcceptedFrame(frame: Av1DDFrame): Av1DDFrame? = prevFrameWith(frame) { it.isAccepted }
 
-    fun findNextAcceptedFrame(frame: Av1DDFrame): Av1DDFrame? {
-        return nextFrameWith(frame) { it.isAccepted }
-    }
+    fun findNextAcceptedFrame(frame: Av1DDFrame): Av1DDFrame? = nextFrameWith(frame) { it.isAccepted }
 
     companion object {
         const val FRAME_MAP_SIZE = 500 // Matches PacketCache default size.

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDQualityFilter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/av1/Av1DDQualityFilter.kt
@@ -286,9 +286,11 @@ internal class Av1DDQualityFilter(
             incomingEncoding > currentEncoding && currentEncoding < internalTargetEncoding ->
                 // It looks like upscaling is possible
                 true
+
             incomingEncoding < currentEncoding && currentEncoding > internalTargetEncoding ->
                 // It looks like downscaling is possible.
                 true
+
             else ->
                 false
         }
@@ -336,8 +338,10 @@ internal class Av1DDQualityFilter(
 
         val indexIfSwitched = when {
             incomingEncoding == externalTargetEncoding -> externalTargetIndex
+
             incomingEncoding == internalTargetEncoding && internalTargetDt != -1 ->
                 getIndex(currentEncoding, internalTargetDt)
+
             else -> frameInfo.dtisPresent.maxOrNull()!!
         }
         val dtIfSwitched = getDtFromIndex(indexIfSwitched)
@@ -387,6 +391,7 @@ internal class Av1DDQualityFilter(
                     }
                     acceptIfSwitched
                 }
+
                 incomingEncoding <= internalTargetEncoding &&
                     internalTargetEncoding < currentEncoding -> {
                     // downscale case
@@ -399,6 +404,7 @@ internal class Av1DDQualityFilter(
                     }
                     acceptIfSwitched
                 }
+
                 else -> {
                     false
                 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/config/BitrateControllerConfig.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/config/BitrateControllerConfig.kt
@@ -123,11 +123,9 @@ class BitrateControllerConfig private constructor() {
     )
 
     /** The default initial ignore BWE period if not set in jvb.conf, based on the BWE algorithm in use.*/
-    private fun defaultInitialIgnoreBwePeriod(): Duration {
-        return when (BandwidthEstimatorConfig.engine) {
-            BandwidthEstimatorEngine.GoogleCc -> GoogleCcEstimator.defaultInitialIgnoreBwePeriod
-            BandwidthEstimatorEngine.GoogleCc2 -> GoogCcTransportCcEngine.defaultInitialIgnoreBwePeriod
-        }
+    private fun defaultInitialIgnoreBwePeriod(): Duration = when (BandwidthEstimatorConfig.engine) {
+        BandwidthEstimatorEngine.GoogleCc -> GoogleCcEstimator.defaultInitialIgnoreBwePeriod
+        BandwidthEstimatorEngine.GoogleCc2 -> GoogCcTransportCcEngine.defaultInitialIgnoreBwePeriod
     }
 
     /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9Frame.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9Frame.kt
@@ -258,9 +258,7 @@ class Vp9Frame internal constructor(
      * belongs to the same RTP stream as the frame that this instance refers to,
      * false otherwise.
      */
-    fun matchesSSRC(vp9Frame: Vp9Frame): Boolean {
-        return ssrc == vp9Frame.ssrc
-    }
+    fun matchesSSRC(vp9Frame: Vp9Frame): Boolean = ssrc == vp9Frame.ssrc
 
     /**
      * Determines whether the [VideoRtpPacket] that is specified as an
@@ -274,9 +272,7 @@ class Vp9Frame internal constructor(
      * argument is part of the VP9 picture that is represented by this
      * [Vp9Frame] instance, false otherwise.
      */
-    private fun matchesSSRC(pkt: VideoRtpPacket): Boolean {
-        return ssrc == pkt.ssrc
-    }
+    private fun matchesSSRC(pkt: VideoRtpPacket): Boolean = ssrc == pkt.ssrc
 
     /**
      * Checks whether the specified RTP packet is part of this frame.
@@ -285,10 +281,8 @@ class Vp9Frame internal constructor(
      * @return true if the specified RTP packet is part of this frame, false
      * otherwise.
      */
-    fun matchesFrame(pkt: Vp9Packet): Boolean {
-        return matchesSSRC(pkt) && timestamp == pkt.timestamp &&
-            spatialLayer == pkt.spatialLayerIndex
-    }
+    fun matchesFrame(pkt: Vp9Packet): Boolean = matchesSSRC(pkt) && timestamp == pkt.timestamp &&
+        spatialLayer == pkt.spatialLayerIndex
 
     /**
      * Validates that the specified RTP packet consistently matches all the
@@ -394,8 +388,11 @@ class Vp9Frame internal constructor(
         return when {
             delta == 0 ->
                 spatialLayer == otherFrame.spatialLayer + 1
+
             delta == 1 ->
-                spatialLayer == 0 && otherFrame.spatialLayer == 2 // ???
+                spatialLayer == 0 && otherFrame.spatialLayer == 2
+
+            // ???
             else ->
                 false
         }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9FrameProjection.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9FrameProjection.kt
@@ -29,7 +29,7 @@ import java.time.Instant
  * are thread-safe.
  */
 class Vp9FrameProjection
-/**
+/*
  * Ctor.
  *
  * @param vp9Frame The [Vp9Frame] that's projected.
@@ -118,9 +118,7 @@ internal constructor(
         created = null
     )
 
-    fun rewriteSeqNo(seq: Int): Int {
-        return applySequenceNumberDelta(seq, sequenceNumberDelta)
-    }
+    fun rewriteSeqNo(seq: Int): Int = applySequenceNumberDelta(seq, sequenceNumberDelta)
 
     /**
      * Rewrites an RTP packet.

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9Picture.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9Picture.kt
@@ -126,9 +126,7 @@ class Vp9Picture(packet: Vp9Packet, index: Long) {
      * argument is part of the VP9 picture that is represented by this
      * [Vp9Picture] instance, false otherwise.
      */
-    private fun matchesSSRC(pkt: VideoRtpPacket): Boolean {
-        return ssrc == pkt.ssrc
-    }
+    private fun matchesSSRC(pkt: VideoRtpPacket): Boolean = ssrc == pkt.ssrc
 
     /**
      * Checks whether the specified RTP packet is part of this frame.
@@ -137,9 +135,7 @@ class Vp9Picture(packet: Vp9Packet, index: Long) {
      * @return true if the specified RTP packet is part of this frame, false
      * otherwise.
      */
-    fun matchesPicture(pkt: Vp9Packet): Boolean {
-        return matchesSSRC(pkt) && timestamp == pkt.timestamp
-    }
+    fun matchesPicture(pkt: Vp9Packet): Boolean = matchesSSRC(pkt) && timestamp == pkt.timestamp
 
     /**
      * Validates that the specified RTP packet consistently matches all the
@@ -197,10 +193,8 @@ class Vp9Picture(packet: Vp9Packet, index: Long) {
      * Check whether this picture is immediately after another one, according
      * to their extended picture IDs.
      */
-    fun isImmediatelyAfter(otherPicture: Vp9Picture): Boolean {
-        return pictureId ==
-            applyExtendedPictureIdDelta(otherPicture.pictureId, 1)
-    }
+    fun isImmediatelyAfter(otherPicture: Vp9Picture): Boolean = pictureId ==
+        applyExtendedPictureIdDelta(otherPicture.pictureId, 1)
 }
 
 /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9PictureMap.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9PictureMap.kt
@@ -37,14 +37,10 @@ class Vp9PictureMap(
 
     /** Find a picture in the picture map, based on a packet.  */
     @Synchronized
-    fun findPicture(packet: Vp9Packet): Vp9Picture? {
-        return pictureHistory[packet.pictureId]
-    }
+    fun findPicture(packet: Vp9Packet): Vp9Picture? = pictureHistory[packet.pictureId]
 
     /** Get the current size of the map.  */
-    fun size(): Int {
-        return pictureHistory.numCached
-    }
+    fun size(): Int = pictureHistory.numCached
 
     /** Check whether this is a large jump from previous state, so the map should be reset.  */
     private fun isLargeJump(packet: Vp9Packet): Boolean {
@@ -123,35 +119,23 @@ class Vp9PictureMap(
     }
 
     @Synchronized
-    fun nextFrame(frame: Vp9Frame): Vp9Frame? {
-        return pictureHistory.findAfter(frame) { true }
-    }
+    fun nextFrame(frame: Vp9Frame): Vp9Frame? = pictureHistory.findAfter(frame) { true }
 
     @Synchronized
-    fun nextFrameWith(frame: Vp9Frame, pred: (Vp9Frame) -> Boolean): Vp9Frame? {
-        return pictureHistory.findAfter(frame, pred)
-    }
+    fun nextFrameWith(frame: Vp9Frame, pred: (Vp9Frame) -> Boolean): Vp9Frame? = pictureHistory.findAfter(frame, pred)
 
     @Synchronized
-    fun prevFrame(frame: Vp9Frame): Vp9Frame? {
-        return pictureHistory.findBefore(frame) { true }
-    }
+    fun prevFrame(frame: Vp9Frame): Vp9Frame? = pictureHistory.findBefore(frame) { true }
 
     @Synchronized
-    fun prevFrameWith(frame: Vp9Frame, pred: (Vp9Frame) -> Boolean): Vp9Frame? {
-        return pictureHistory.findBefore(frame, pred)
-    }
+    fun prevFrameWith(frame: Vp9Frame, pred: (Vp9Frame) -> Boolean): Vp9Frame? = pictureHistory.findBefore(frame, pred)
 
-    fun findPrevAcceptedFrame(frame: Vp9Frame): Vp9Frame? {
-        return prevFrameWith(frame) { it.isAccepted }
-    }
+    fun findPrevAcceptedFrame(frame: Vp9Frame): Vp9Frame? = prevFrameWith(frame) { it.isAccepted }
 
-    fun findNextAcceptedFrame(frame: Vp9Frame): Vp9Frame? {
-        return nextFrameWith(frame) { it.isAccepted }
-    }
+    fun findNextAcceptedFrame(frame: Vp9Frame): Vp9Frame? = nextFrameWith(frame) { it.isAccepted }
 
-    fun findNextBaseTl0(frame: Vp9Frame): Vp9Frame? {
-        return nextFrameWith(frame) { it.spatialLayer <= 0 && it.temporalLayer <= 0 }
+    fun findNextBaseTl0(frame: Vp9Frame): Vp9Frame? = nextFrameWith(frame) {
+        it.spatialLayer <= 0 && it.temporalLayer <= 0
     }
 
     companion object {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilter.kt
@@ -317,9 +317,11 @@ internal class Vp9QualityFilter(parentLogger: Logger) {
             incomingEncoding > currentEncoding && currentEncoding < internalTargetEncoding ->
                 // It looks like upscaling is possible
                 true
+
             incomingEncoding < currentEncoding && currentEncoding > internalTargetEncoding ->
                 // It looks like downscaling is possible.
                 true
+
             else ->
                 false
         }
@@ -402,6 +404,7 @@ internal class Vp9QualityFilter(parentLogger: Logger) {
                     }
                     true
                 }
+
                 incomingEncoding <= internalTargetEncoding &&
                     internalTargetEncoding < currentEncoding -> {
                     // downscale case
@@ -412,6 +415,7 @@ internal class Vp9QualityFilter(parentLogger: Logger) {
                     }
                     true
                 }
+
                 else -> {
                     false
                 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/dcsctp/DcSctpTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/dcsctp/DcSctpTransport.kt
@@ -144,17 +144,11 @@ abstract class DcSctpBaseCallbacks(
     val clock: Clock = Clock.systemUTC()
 ) : DcSctpSocketCallbacks {
     /* Methods we can usefully implement for every JVB socket */
-    override fun createTimeout(p0: DcSctpSocketCallbacks.DelayPrecision): Timeout {
-        return ATimeout(transport)
-    }
+    override fun createTimeout(p0: DcSctpSocketCallbacks.DelayPrecision): Timeout = ATimeout(transport)
 
-    override fun Now(): Instant {
-        return clock.instant()
-    }
+    override fun Now(): Instant = clock.instant()
 
-    override fun getRandomInt(low: Long, high: Long): Long {
-        return ThreadLocalRandom.current().nextLong(low, high)
-    }
+    override fun getRandomInt(low: Long, high: Long): Long = ThreadLocalRandom.current().nextLong(low, high)
 
     /* Methods we wouldn't normally expect to be called for a JVB SCTP socket. */
     override fun OnConnectionRestarted() {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/Exporter.kt
@@ -220,6 +220,7 @@ internal class Exporter(
                     instanceTranscriptsReceived.incrementAndGet()
                     eventHandler.handleTranscriptionResult(event)
                 }
+
                 is PongEvent -> {
                     val expectedId = lastPingSentId.get()
                     if (event.id == expectedId) {
@@ -232,11 +233,13 @@ internal class Exporter(
                         logger.warn("Received pong with id=${event.id}, expected id=$expectedId")
                     }
                 }
+
                 is MediaEvent -> {
                     mediaEventsReceivedCount.inc()
                     instanceMediaEventsReceived.incrementAndGet()
                     eventHandler.handleMediaEvent(event)
                 }
+
                 is StartEvent -> {
                     // A `start` with a talk timestamp brackets the beginning of a "talk" (translated audio); one
                     // without is a plain stream-start announcement (the bridge->peer direction), which the bridge
@@ -251,6 +254,7 @@ internal class Exporter(
                         instanceOtherMessagesReceived.incrementAndGet()
                     }
                 }
+
                 is StopEvent -> {
                     // A `stop` with a talk timestamp brackets the end of a "talk"; a plain stop without one is a
                     // stream-end the bridge does not act on when received.
@@ -264,11 +268,13 @@ internal class Exporter(
                         instanceOtherMessagesReceived.incrementAndGet()
                     }
                 }
+
                 is InfoEvent -> {
                     infoReceivedCount.inc()
                     instanceInfoReceived.incrementAndGet()
                     logger.info("Received InfoEvent: ${event.toJson()}")
                 }
+
                 else -> {
                     otherMessagesReceivedCount.inc()
                     instanceOtherMessagesReceived.incrementAndGet()

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/health/JvbHealthChecker.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/health/JvbHealthChecker.kt
@@ -57,9 +57,8 @@ class JvbHealthChecker : HealthCheckService {
         return Result(success = true)
     }
 
-    private fun InetAddress.isValid(): Boolean {
-        return !this.isSiteLocalAddress && !this.isLinkLocalAddress && !this.isLoopbackAddress
-    }
+    private fun InetAddress.isValid(): Boolean =
+        !this.isSiteLocalAddress && !this.isLinkLocalAddress && !this.isLoopbackAddress
 
     private fun hasValidAddress(): Boolean {
         if (Harvesters.INSTANCE.singlePortHarvesters.any { it.localAddress.address.isValid() }) {

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/JvbLoadManager.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/JvbLoadManager.kt
@@ -153,11 +153,13 @@ open class JvbLoadManager<T : JvbLoadMeasurement> @JvmOverloads constructor(
                     reducer,
                     videobridge
                 )
+
                 CPU_USAGE_MEASUREMENT -> CpuUsageLoadManager(
                     CpuMeasurement.loadThreshold,
                     CpuMeasurement.recoverThreshold,
                     reducer
                 )
+
                 else -> throw IllegalArgumentException(
                     "Invalid configuration for load measurement type: $loadMeasurement"
                 )

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/LastNReducer.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/load_management/LastNReducer.kt
@@ -65,16 +65,14 @@ class LastNReducer(
         logger.cinfo { this.toString() }
     }
 
-    private fun getMaxForwardedEps(): Int? {
-        return conferencesSupplier.get()
-            .flatMap { it.endpoints }
-            .asSequence()
-            .filterIsInstance<Endpoint>()
-            .map {
-                it.numForwardedSources()
-            }
-            .maxOrNull()
-    }
+    private fun getMaxForwardedEps(): Int? = conferencesSupplier.get()
+        .flatMap { it.endpoints }
+        .asSequence()
+        .filterIsInstance<Endpoint>()
+        .map {
+            it.numForwardedSources()
+        }
+        .maxOrNull()
 
     override fun reduceLoad() {
         // Find the highest amount of endpoints any endpoint on this bridge is forwarding video for

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/message/BridgeChannelMessage.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/message/BridgeChannelMessage.kt
@@ -97,9 +97,7 @@ sealed class BridgeChannelMessage {
 
         @JvmStatic
         @Throws(JsonProcessingException::class, JsonMappingException::class)
-        fun parse(string: String): BridgeChannelMessage {
-            return mapper.readValue(string)
-        }
+        fun parse(string: String): BridgeChannelMessage = mapper.readValue(string)
         const val TYPE_PROPERTY_NAME = "colibriClass"
     }
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/Relay.kt
@@ -578,6 +578,7 @@ class Relay @JvmOverloads constructor(
                 }
                 senders.values.forEach { s -> s.setFeature(Features.TRANSCEIVER_PCAP_DUMP, enabled) }
             }
+
             EndpointDebugFeatures.SCTP_PCAP_DUMP ->
                 if (enabled) {
                     toggleablePcapWriter.enable()
@@ -587,11 +588,9 @@ class Relay @JvmOverloads constructor(
         }
     }
 
-    fun isFeatureEnabled(feature: EndpointDebugFeatures): Boolean {
-        return when (feature) {
-            EndpointDebugFeatures.PCAP_DUMP -> transceiver.isFeatureEnabled(Features.TRANSCEIVER_PCAP_DUMP)
-            EndpointDebugFeatures.SCTP_PCAP_DUMP -> toggleablePcapWriter.isEnabled()
-        }
+    fun isFeatureEnabled(feature: EndpointDebugFeatures): Boolean = when (feature) {
+        EndpointDebugFeatures.PCAP_DUMP -> transceiver.isFeatureEnabled(Features.TRANSCEIVER_PCAP_DUMP)
+        EndpointDebugFeatures.SCTP_PCAP_DUMP -> toggleablePcapWriter.isEnabled()
     }
 
     /**
@@ -896,11 +895,18 @@ class Relay @JvmOverloads constructor(
         ssrcs.add(packet.senderSsrc)
         when (packet) {
             is CompoundRtcpPacket -> packet.packets.forEach { ssrcs.addAll(getRtcpSsrcs(it)) }
-            is RtcpFbFirPacket -> ssrcs.add(packet.mediaSenderSsrc) // TODO: support multiple FIRs in a packet
+
+            is RtcpFbFirPacket -> ssrcs.add(packet.mediaSenderSsrc)
+
+            // TODO: support multiple FIRs in a packet
             is RtcpFbPacket -> ssrcs.add(packet.mediaSourceSsrc)
+
             is RtcpSrPacket -> packet.reportBlocks.forEach { ssrcs.add(it.ssrc) }
+
             is RtcpRrPacket -> packet.reportBlocks.forEach { ssrcs.add(it.ssrc) }
+
             is RtcpSdesPacket -> packet.sdesChunks.forEach { ssrcs.add(it.ssrc) }
+
             is RtcpByePacket -> ssrcs.addAll(packet.ssrcs)
         }
         return ssrcs
@@ -962,6 +968,7 @@ class Relay @JvmOverloads constructor(
                 // performing the same check twice.
                 true
             }
+
             else -> {
                 logger.warn("Ignoring an unknown packet type:" + packet.packet.javaClass.simpleName)
                 false

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayEndpointSender.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayEndpointSender.kt
@@ -61,9 +61,8 @@ class RelayEndpointSender(
     val rtcpEventNotifier = RtcpEventNotifier().apply {
         addRtcpEventListener(
             object : RtcpListener {
-                override fun rtcpPacketReceived(packet: RtcpPacket, receivedTime: Instant?) {
+                override fun rtcpPacketReceived(packet: RtcpPacket, receivedTime: Instant?): Unit =
                     throw IllegalStateException("got rtcpPacketReceived callback from a sender")
-                }
                 override fun rtcpPacketSent(packet: RtcpPacket) {
                     relay.rtcpPacketSent(packet, id)
                 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayMessageTransport.kt
@@ -323,12 +323,10 @@ class RelayMessageTransport(
         }
     }
 
-    private fun createServerHello(): ServerHelloMessage {
-        return if (VersionConfig.config.announceVersion()) {
-            ServerHelloMessage(relay.conference.videobridge.version.toString())
-        } else {
-            ServerHelloMessage()
-        }
+    private fun createServerHello(): ServerHelloMessage = if (VersionConfig.config.announceVersion()) {
+        ServerHelloMessage(relay.conference.videobridge.version.toString())
+    } else {
+        ServerHelloMessage()
     }
 
     /**

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayedEndpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/relay/RelayedEndpoint.kt
@@ -81,9 +81,8 @@ class RelayedEndpoint(
                 override fun rtcpPacketReceived(packet: RtcpPacket, receivedTime: Instant?) {
                     relay.rtcpPacketReceived(packet, receivedTime, id)
                 }
-                override fun rtcpPacketSent(packet: RtcpPacket) {
+                override fun rtcpPacketSent(packet: RtcpPacket): Unit =
                     throw IllegalStateException("got rtcpPacketSent callback from a receiver")
-                }
             },
             external = true
         )
@@ -121,9 +120,7 @@ class RelayedEndpoint(
         handleEvent(SetLocalSsrcEvent(MediaType.VIDEO, conference.localVideoSsrc))
     }
 
-    override fun receivesSsrc(ssrc: Long): Boolean {
-        return streamInformationStore.receiveSsrcs.contains(ssrc)
-    }
+    override fun receivesSsrc(ssrc: Long): Boolean = streamInformationStore.receiveSsrcs.contains(ssrc)
 
     override val ssrcs
         get() = HashSet(streamInformationStore.receiveSsrcs)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/dtls/DtlsTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/dtls/DtlsTransport.kt
@@ -157,11 +157,13 @@ class DtlsTransport(parentLogger: Logger, id: String) {
                     logger.info("The remote side is acting as DTLS client, we'll act as server")
                 }
             }
+
             "passive" -> {
                 if (dtlsStack.actAsClient()) {
                     logger.info("The remote side is acting as DTLS server, we'll act as client")
                 }
             }
+
             else -> {
                 logger.error(
                     "The remote side sent an unrecognized DTLS setup value: " +

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/transport/ice/IceTransport.kt
@@ -377,6 +377,7 @@ class IceTransport @JvmOverloads constructor(
                     // candidates were ignored:
                     // iceAgentStateIsRunning && candidates.isEmpty().
                 }
+
                 else -> bundle.component.updateRemoteCandidates()
             }
         } else if (remoteCandidateCount != 0) {
@@ -939,6 +940,7 @@ class IceTransport @JvmOverloads constructor(
                     iceSucceeded.inc()
                 }
             }
+
             transition.failed() -> {
                 if (isPending) {
                     // Only the restart failed. The established Agent is untouched, so keep using it rather
@@ -1141,10 +1143,8 @@ private data class IceProcessingStateTransition(
     // free prior to being started, so we handle that case separately below.
     fun completed(): Boolean = newState == IceProcessingState.COMPLETED
 
-    fun failed(): Boolean {
-        return newState == IceProcessingState.FAILED ||
-            (oldState == IceProcessingState.RUNNING && newState == IceProcessingState.TERMINATED)
-    }
+    fun failed(): Boolean = newState == IceProcessingState.FAILED ||
+        (oldState == IceProcessingState.RUNNING && newState == IceProcessingState.TERMINATED)
 }
 
 private fun IceMediaStream.remoteUfragAndPasswordKnown(): Boolean = remoteUfrag != null && remotePassword != null

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/util/MultiStreamCompatibility.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/util/MultiStreamCompatibility.kt
@@ -1,5 +1,3 @@
 package org.jitsi.videobridge.util
 
-fun endpointIdToSourceName(endpointId: String): String {
-    return "$endpointId-v0"
-}
+fun endpointIdToSourceName(endpointId: String): String = "$endpointId-v0"

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/util/PayloadTypeUtil.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/util/PayloadTypeUtil.kt
@@ -95,17 +95,25 @@ class PayloadTypeUtil {
 
             return when (encoding) {
                 VP8 -> Vp8PayloadType(id, parameters, rtcpFeedbackSet)
+
                 VP9 -> Vp9PayloadType(id, parameters, rtcpFeedbackSet)
+
                 AV1 -> Av1PayloadType(id, parameters, rtcpFeedbackSet)
+
                 H264 -> H264PayloadType(id, parameters, rtcpFeedbackSet)
+
                 RTX -> RtxPayloadType(id, parameters)
+
                 OPUS -> OpusPayloadType(id, clockRate, channels, parameters)
+
                 TELEPHONE_EVENT -> TelephoneEventPayloadType(id, clockRate, channels, parameters)
+
                 RED -> when (mediaType) {
                     AUDIO -> AudioRedPayloadType(id, clockRate, channels, parameters)
                     VIDEO -> VideoRedPayloadType(id, clockRate, parameters, rtcpFeedbackSet)
                     else -> null
                 }
+
                 OTHER -> when (mediaType) {
                     AUDIO -> OtherAudioPayloadType(id, ext.name, clockRate, channels, parameters)
                     VIDEO -> OtherVideoPayloadType(id, ext.name, clockRate, parameters)

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/version/JvbVersionService.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/version/JvbVersionService.kt
@@ -55,10 +55,8 @@ class JvbVersionService : VersionService {
     }
 }
 
-private fun Matcher.groupOrNull(groupId: Int): String? {
-    return try {
-        group(groupId)
-    } catch (t: Throwable) {
-        null
-    }
+private fun Matcher.groupOrNull(groupId: Int): String? = try {
+    group(groupId)
+} catch (t: Throwable) {
+    null
 }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/xmpp/XmppConnection.kt
@@ -216,6 +216,7 @@ class XmppConnection : IQListener {
             IQ.Type.get, IQ.Type.set -> handleIqRequest(iq, mucClient)?.also {
                 logger.cdebug { "SENT: ${it.toXML()}" }
             }
+
             else -> null
         }
     }
@@ -230,6 +231,7 @@ class XmppConnection : IQListener {
             is Version -> measureDelay(versionDelayStats, { iq.toXML() }) {
                 handler.versionIqReceived(iq)
             }
+
             is ConferenceModifyIQ -> {
                 // Colibri IQs are handled async.
                 handler.colibriRequestReceived(
@@ -240,9 +242,11 @@ class XmppConnection : IQListener {
                 )
                 null
             }
+
             is HealthCheckIQ -> measureDelay(healthDelayStats, { iq.toXML() }) {
                 handler.healthCheckIqReceived(iq)
             }
+
             else -> createError(
                 iq,
                 StanzaError.Condition.service_unavailable,

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/SsrcCacheTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/SsrcCacheTest.kt
@@ -105,13 +105,10 @@ private class Ep : SsrcRewriter {
 
     private var nextSendSsrc = 1L
 
-    override fun findVideoSourceProps(ssrc: Long): MediaSourceDesc? {
-        return null
-    }
+    override fun findVideoSourceProps(ssrc: Long): MediaSourceDesc? = null
 
-    override fun findAudioSourceProps(ssrc: Long): AudioSourceDesc? {
-        return AudioSourceDesc(ssrc, "anon-$ssrc", "anon-$ssrc-a0")
-    }
+    override fun findAudioSourceProps(ssrc: Long): AudioSourceDesc? =
+        AudioSourceDesc(ssrc, "anon-$ssrc", "anon-$ssrc-a0")
 
     val sentMessages = mutableListOf<BridgeChannelMessage>()
 

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/BitrateControllerTest.kt
@@ -1586,33 +1586,29 @@ class TestEndpoint(
     override val mediaSources: Array<MediaSourceDesc> = emptyArray()
 ) : MediaSourceContainer
 
-fun createEndpoints(vararg ids: String): MutableList<TestEndpoint> {
-    return MutableList(ids.size) { i ->
-        TestEndpoint(
-            ids[i],
-            arrayOf(
-                createSourceDesc(
-                    3 * i + 1,
-                    3 * i + 2,
-                    3 * i + 3,
-                    ids[i] + "-v0",
-                    ids[i]
-                )
+fun createEndpoints(vararg ids: String): MutableList<TestEndpoint> = MutableList(ids.size) { i ->
+    TestEndpoint(
+        ids[i],
+        arrayOf(
+            createSourceDesc(
+                3 * i + 1,
+                3 * i + 2,
+                3 * i + 3,
+                ids[i] + "-v0",
+                ids[i]
             )
         )
-    }
+    )
 }
 
-fun createSources(vararg ids: String): MutableList<MediaSourceDesc> {
-    return MutableList(ids.size) { i ->
-        createSourceDesc(
-            3 * i + 1,
-            3 * i + 2,
-            3 * i + 3,
-            ids[i],
-            ids[i]
-        )
-    }
+fun createSources(vararg ids: String): MutableList<MediaSourceDesc> = MutableList(ids.size) { i ->
+    createSourceDesc(
+        3 * i + 1,
+        3 * i + 2,
+        3 * i + 3,
+        ids[i],
+        ids[i]
+    )
 }
 
 fun createSourceDesc(ssrc1: Int, ssrc2: Int, ssrc3: Int, sourceName: String, owner: String): MediaSourceDesc =

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/EffectiveConstraintsTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/allocation/EffectiveConstraintsTest.kt
@@ -22,14 +22,13 @@ import io.kotest.matchers.shouldBe
 import org.jitsi.nlj.MediaSourceDesc
 import org.jitsi.nlj.VideoType
 
-fun testSource(endpointId: String, sourceName: String, videoType: VideoType = VideoType.CAMERA): MediaSourceDesc {
-    return MediaSourceDesc(
+fun testSource(endpointId: String, sourceName: String, videoType: VideoType = VideoType.CAMERA): MediaSourceDesc =
+    MediaSourceDesc(
         emptyArray(),
         endpointId,
         sourceName,
         videoType
     )
-}
 
 @Suppress("NAME_SHADOWING")
 class EffectiveConstraintsTest : ShouldSpec() {

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/av1/Av1DDAdaptiveSourceProjectionTest.kt
@@ -412,8 +412,7 @@ class Av1DDAdaptiveSourceProjectionTest {
                  */
                 val extFrameNum = frameNumsIndexTracker.update(packet.frameNumber)
                 frameNumsDropped.add(extFrameNum)
-            } else if (expectAccept(frameInfo)
-            ) {
+            } else if (expectAccept(frameInfo)) {
                 Assert.assertTrue(accepted)
 
                 context.rewriteRtp(packetInfo)

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9AdaptiveSourceProjectionTest.kt
@@ -135,7 +135,7 @@ class Vp9AdaptiveSourceProjectionTest {
             if (packet.temporalLayerIndex <= targetTid &&
                 (
                     packet.encodingId == targetEid ||
-                        packet.isKeyframe && packet.encodingId < targetEid
+                        (packet.isKeyframe && packet.encodingId < targetEid)
                     ) &&
                 (
                     packet.spatialLayerIndex == targetSid ||
@@ -874,7 +874,7 @@ class Vp9AdaptiveSourceProjectionTest {
             val packet = packetInfo.packetAs<Vp9Packet>()
             val accepted = context.accept(packetInfo, simulcastTargetIndex)
             Assert.assertTrue(packet.spatialLayerIndex == 0)
-            if (packet.encodingId == 1 || packet.isKeyframe && packet.encodingId < 1) {
+            if (packet.encodingId == 1 || (packet.isKeyframe && packet.encodingId < 1)) {
                 Assert.assertTrue(accepted)
                 context.rewriteRtp(packetInfo)
             } else {
@@ -1436,8 +1436,11 @@ class Vp9AdaptiveSourceProjectionTest {
         override fun nextPacket(): PacketInfo {
             val tid = when (tidCycle % 4) {
                 0 -> 0
+
                 2 -> 1
+
                 1, 3 -> 2
+
                 else -> {
                     assert(false) // Math is broken
                     -1
@@ -1680,8 +1683,11 @@ class Vp9AdaptiveSourceProjectionTest {
         override fun nextPacket(): PacketInfo {
             val tid = when (tidCycle % 4) {
                 0 -> 0
+
                 2 -> 1
+
                 1, 3 -> 2
+
                 else -> {
                     assert(false) // Math is broken
                     -1

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilterTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/cc/vp9/Vp9QualityFilterTest.kt
@@ -31,8 +31,7 @@ internal class Vp9QualityFilterTest : ShouldSpec() {
                 val generator = SingleLayerFrameGenerator()
                 val targetIndex = RtpLayerDesc.getIndex(0, 0, 0)
 
-                testGenerator(generator, filter, targetIndex) {
-                        _, result ->
+                testGenerator(generator, filter, targetIndex) { _, result ->
                     result.accept shouldBe true
                     result.mark shouldBe true
                     filter.needsKeyframe shouldBe false
@@ -46,8 +45,7 @@ internal class Vp9QualityFilterTest : ShouldSpec() {
                 val generator = TemporallyScaledFrameGenerator()
                 val targetIndex = RtpLayerDesc.getIndex(0, 0, 2)
 
-                testGenerator(generator, filter, targetIndex) {
-                        _, result ->
+                testGenerator(generator, filter, targetIndex) { _, result ->
                     result.accept shouldBe true
                     result.mark shouldBe true
                     filter.needsKeyframe shouldBe false
@@ -58,8 +56,7 @@ internal class Vp9QualityFilterTest : ShouldSpec() {
                 val generator = TemporallyScaledFrameGenerator()
                 val targetIndex = RtpLayerDesc.getIndex(0, 0, 0)
 
-                testGenerator(generator, filter, targetIndex) {
-                        f, result ->
+                testGenerator(generator, filter, targetIndex) { f, result ->
                     result.accept shouldBe (f.temporalLayer == 0)
                     if (result.accept) {
                         result.mark shouldBe true
@@ -72,8 +69,7 @@ internal class Vp9QualityFilterTest : ShouldSpec() {
                 val generator = TemporallyScaledFrameGenerator()
                 val targetIndex = RtpLayerDesc.getIndex(0, 0, 1)
 
-                testGenerator(generator, filter, targetIndex) {
-                        f, result ->
+                testGenerator(generator, filter, targetIndex) { f, result ->
                     result.accept shouldBe (f.temporalLayer <= 1)
                     if (result.accept) {
                         result.mark shouldBe true
@@ -226,7 +222,7 @@ internal class Vp9QualityFilterTest : ShouldSpec() {
                 val targetIndex = RtpLayerDesc.getIndex(0, 1, 2)
 
                 testGenerator(generator, filter, targetIndex) { f, result ->
-                    result.accept shouldBe (f.spatialLayer == 1 || f.spatialLayer < 1 && !f.isInterPicturePredicted)
+                    result.accept shouldBe (f.spatialLayer == 1 || (f.spatialLayer < 1 && !f.isInterPicturePredicted))
                     if (result.accept) {
                         result.mark shouldBe (f.spatialLayer == 1)
                         filter.needsKeyframe shouldBe false
@@ -336,7 +332,7 @@ internal class Vp9QualityFilterTest : ShouldSpec() {
                 val targetIndex = RtpLayerDesc.getIndex(1, 0, 2)
 
                 testGenerator(generator, filter, targetIndex) { f, result ->
-                    result.accept shouldBe (f.ssrc == 1L || f.isKeyframe && f.ssrc < 1L)
+                    result.accept shouldBe (f.ssrc == 1L || (f.isKeyframe && f.ssrc < 1L))
                     if (result.accept) {
                         result.mark shouldBe true
                         filter.needsKeyframe shouldBe false

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <jitsi.utils.version>1.0-153-gd5c0102</jitsi.utils.version>
         <jicoco.version>1.1-179-g52cf6ef</jicoco.version>
         <mockk.version>1.14.11</mockk.version>
-        <ktlint-maven-plugin.version>3.2.0</ktlint-maven-plugin.version>
+        <ktlint.version>1.8.0</ktlint.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>

--- a/rtp/README.md
+++ b/rtp/README.md
@@ -2,30 +2,20 @@
 Jitsi RTP contains classes for parsing and creating RTP and RTCP packets.
 
 # Code style
-We use ktlint for linting and autoformatting. The ktlint command-line utility
-can be installed by running:
+We use [ktlint](https://pinterest.github.io/ktlint/) for linting and autoformatting. It runs as part of
+`mvn verify` (the build fails on style violations), and the version used is pinned by `ktlint.version` in the
+root `pom.xml`, so no separate installation is needed.
+
+To run only the check, or to autoformat, run these in this module's directory:
 ```
-curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.34.2/ktlint && chmod a+x ktlint && sudo mv ktlint /usr/local/bin/
+mvn exec:exec@ktlint-check
+mvn exec:exec@ktlint-format
 ```
 
-Or, on macOS with Homebrew:
+If you also want the `ktlint` command-line tool (for editor integration or a git hook), install a version matching
+`ktlint.version`, e.g. on macOS with Homebrew:
 ```
 brew install ktlint
 ```
-
-To perform the checks simply run `ktlint`.
-
-You can install a pre-commit or pre-push git hook by running this in the git
-repository directory:
-```
-ktlint --install-git-pre-commit-hook
-```
-
-You can automatically update Intellij IDEA's formatting rules to to be
-compatible with ktlint. However, note that version 0.34.2 of ktlint will
-override any Java code style settings.
-```
-ktlint --apply-to-idea-project
-```
-
-Autoformatting can be run by calling `mvn antrun:run@ktlint-format`.
+It can then be run directly with `ktlint` (or `ktlint -F` to autoformat), install a pre-commit hook with
+`ktlint installGitPreCommitHook`, and configure IntelliJ IDEA with `ktlint applyToIDEAProject`.

--- a/rtp/pom.xml
+++ b/rtp/pom.xml
@@ -173,26 +173,63 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <!-- ktlint: check runs in the verify phase; auto-format with "mvn exec:exec@ktlint-format" -->
             <plugin>
-              <groupId>com.github.gantsign.maven</groupId>
-              <artifactId>ktlint-maven-plugin</artifactId>
-              <version>${ktlint-maven-plugin.version}</version>
-              <configuration>
-                <sourceRoots>
-                  <sourceRoot>${project.basedir}/src/main/kotlin</sourceRoot>
-                </sourceRoots>
-                <testSourceRoots>
-                  <testSourceRoot>${project.basedir}/src/test/kotlin</testSourceRoot>
-                </testSourceRoots>
-              </configuration>
-            <executions>
-              <execution>
-                <id>check</id>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.6.3</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.pinterest.ktlint</groupId>
+                        <artifactId>ktlint-cli</artifactId>
+                        <version>${ktlint.version}</version>
+                        <classifier>all</classifier>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>ktlint-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <includePluginDependencies>true</includePluginDependencies>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath>
+                                    <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                                </classpath>
+                                <argument>com.pinterest.ktlint.Main</argument>
+                                <argument>--relative</argument>
+                                <argument>src/main/kotlin/**/*.kt</argument>
+                                <argument>src/test/kotlin/**/*.kt</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>ktlint-format</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <includePluginDependencies>true</includePluginDependencies>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath>
+                                    <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                                </classpath>
+                                <argument>com.pinterest.ktlint.Main</argument>
+                                <argument>--format</argument>
+                                <argument>--relative</argument>
+                                <argument>src/main/kotlin/**/*.kt</argument>
+                                <argument>src/test/kotlin/**/*.kt</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>

--- a/rtp/src/main/kotlin/org/jitsi/rtp/extensions/Byte.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/extensions/Byte.kt
@@ -31,12 +31,10 @@ fun Byte.getBit(bitPos: Int): Int {
  * Unfortunately we can't do this as an in-place modifier because
  * we can't modify the Byte via 'this' in an extension function.
  */
-fun Byte.putBit(bitPos: Int, isSet: Boolean): Byte {
-    return if (isSet) {
-        (this.toInt() or (0b10000000 ushr bitPos)).toByte()
-    } else {
-        (this.toInt() and (0b10000000 ushr bitPos).inv()).toByte()
-    }
+fun Byte.putBit(bitPos: Int, isSet: Boolean): Byte = if (isSet) {
+    (this.toInt() or (0b10000000 ushr bitPos)).toByte()
+} else {
+    (this.toInt() and (0b10000000 ushr bitPos).inv()).toByte()
 }
 
 /**
@@ -45,12 +43,10 @@ fun Byte.putBit(bitPos: Int, isSet: Boolean): Byte {
  * Unfortunately we can't do this as an in-place modifier because
  * we can't modify the Byte via 'this' in an extension function.
  */
-fun Byte.putBitWithMask(mask: Byte, isSet: Boolean): Byte {
-    return if (isSet) {
-        (this.toInt() or mask.toInt()).toByte()
-    } else {
-        (this.toInt() and mask.toInt().inv()).toByte()
-    }
+fun Byte.putBitWithMask(mask: Byte, isSet: Boolean): Byte = if (isSet) {
+    (this.toInt() or mask.toInt()).toByte()
+} else {
+    (this.toInt() and mask.toInt().inv()).toByte()
 }
 
 /**

--- a/rtp/src/main/kotlin/org/jitsi/rtp/extensions/bytearray/ByteArrayExtensions.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/extensions/bytearray/ByteArrayExtensions.kt
@@ -53,9 +53,7 @@ fun ByteArray.put3Bytes(byteIndex: Int, value: Int) = writeUint24(this, byteInde
 fun ByteArray.getInt(byteIndex: Int): Int = readInt(this, byteIndex)
 fun ByteArray.putInt(byteIndex: Int, value: Int) = writeInt(this, byteIndex, value)
 
-fun byteArrayOf(vararg elements: Number): ByteArray {
-    return elements.map { it.toByte() }.toByteArray()
-}
+fun byteArrayOf(vararg elements: Number): ByteArray = elements.map { it.toByte() }.toByteArray()
 
 /**
  * Shifts the data from [startPos] to [endPos] [numBytes] to the right.

--- a/rtp/src/main/kotlin/org/jitsi/rtp/extensions/unsigned/Unsigned.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/extensions/unsigned/Unsigned.kt
@@ -34,25 +34,19 @@ fun Short.toPositiveInt(): Int = toInt() and 0xFFFF
 fun Int.toPositiveLong(): Long = toLong() and 0xFFFFFFFF
 
 // TODO: i think these should be able to make the above functions obsolete
-fun Number.toPositiveShort(): Short {
-    return when (this) {
-        is Byte -> this.toShort() and 0xFF
-        else -> this.toShort()
-    }
+fun Number.toPositiveShort(): Short = when (this) {
+    is Byte -> this.toShort() and 0xFF
+    else -> this.toShort()
 }
-fun Number.toPositiveInt(): Int {
-    return when (this) {
-        is Byte -> this.toInt() and 0xFF
-        is Short -> this.toInt() and 0xFFFF
-        else -> this.toInt()
-    }
+fun Number.toPositiveInt(): Int = when (this) {
+    is Byte -> this.toInt() and 0xFF
+    is Short -> this.toInt() and 0xFFFF
+    else -> this.toInt()
 }
 
-fun Number.toPositiveLong(): Long {
-    return when (this) {
-        is Byte -> this.toLong() and 0xFF
-        is Short -> this.toLong() and 0xFFFF
-        is Int -> this.toLong() and 0xFFFFFFFF
-        else -> this.toLong()
-    }
+fun Number.toPositiveLong(): Long = when (this) {
+    is Byte -> this.toLong() and 0xFF
+    is Short -> this.toLong() and 0xFFFF
+    is Int -> this.toLong() and 0xFFFFFFFF
+    else -> this.toLong()
 }

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/CompoundRtcpPacket.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/CompoundRtcpPacket.kt
@@ -64,9 +64,8 @@ class CompoundRtcpPacket(
          * no more than [mtu] bytes in size (unless an individual packet is bigger than that, in which
          * case it will be in a compound packet on its own).
          */
-        fun createWithMtu(packets: List<RtcpPacket>, mtu: Int = 1500): List<CompoundRtcpPacket> {
-            return packets.chunkMaxSize(mtu) { it.length }.map { CompoundRtcpPacket(it) }
-        }
+        fun createWithMtu(packets: List<RtcpPacket>, mtu: Int = 1500): List<CompoundRtcpPacket> =
+            packets.chunkMaxSize(mtu) { it.length }.map { CompoundRtcpPacket(it) }
     }
 
     override fun clone(): RtcpPacket = CompoundRtcpPacket(cloneBuffer(0), 0, length)

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/RtcpPacket.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/RtcpPacket.kt
@@ -82,11 +82,17 @@ abstract class RtcpPacket(
             }
             return when (packetType) {
                 RtcpByePacket.PT -> RtcpByePacket(buf, offset, packetLengthBytes)
+
                 RtcpRrPacket.PT -> RtcpRrPacket(buf, offset, packetLengthBytes)
+
                 RtcpSrPacket.PT -> RtcpSrPacket(buf, offset, packetLengthBytes)
+
                 RtcpSdesPacket.PT -> RtcpSdesPacket(buf, offset, packetLengthBytes)
+
                 in RtcpFbPacket.PACKET_TYPES -> RtcpFbPacket.parse(buf, offset, packetLengthBytes)
+
                 RtcpXrPacket.PT -> RtcpXrPacket(buf, offset, packetLengthBytes)
+
                 else -> {
                     return when (packetType) {
                         in RTCP_PACKET_TYPE_RANGE -> UnsupportedRtcpPacket(buf, offset, packetLengthBytes)

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/RtcpSdesPacket.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/RtcpSdesPacket.kt
@@ -163,6 +163,7 @@ abstract class SdesItem(
             val type = SdesItemType.fromInt(typeValue)
             return when (type) {
                 SdesItemType.EMPTY -> EmptySdesItem
+
                 else -> {
                     val length = getLength(buf, offset)
                     return when (type) {
@@ -184,9 +185,7 @@ class UnknownSdesItem(
     private val dataField = copyData(buf, offset, length)
     override val sizeBytes: Int = SDES_ITEM_HEADER_SIZE + dataField.size
 
-    override fun toString(): String {
-        return "Unknown SDES type($sdesTypeValue) data = ${dataField.toHex()}"
-    }
+    override fun toString(): String = "Unknown SDES type($sdesTypeValue) data = ${dataField.toHex()}"
 }
 
 object EmptySdesItem : SdesItem(SdesItemType.EMPTY) {

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/RtcpSrPacket.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/RtcpSrPacket.kt
@@ -151,21 +151,19 @@ class RtcpSrPacket(
 
     override fun clone(): RtcpSrPacket = RtcpSrPacket(cloneBuffer(0), 0, length)
 
-    fun cloneWithoutReportBlocks(): RtcpSrPacket {
-        return RtcpSrPacketBuilder(
-            rtcpHeader = RtcpHeaderBuilder(
-                reportCount = 0,
-                senderSsrc = this.senderSsrc
-            ),
-            senderInfo = SenderInfoBuilder(
-                ntpTimestampMsw = this.senderInfo.ntpTimestampMsw,
-                ntpTimestampLsw = this.senderInfo.ntpTimestampLsw,
-                rtpTimestamp = this.senderInfo.rtpTimestamp,
-                sendersPacketCount = this.senderInfo.sendersPacketCount,
-                sendersOctetCount = this.senderInfo.sendersOctetCount
-            )
-        ).build()
-    }
+    fun cloneWithoutReportBlocks(): RtcpSrPacket = RtcpSrPacketBuilder(
+        rtcpHeader = RtcpHeaderBuilder(
+            reportCount = 0,
+            senderSsrc = this.senderSsrc
+        ),
+        senderInfo = SenderInfoBuilder(
+            ntpTimestampMsw = this.senderInfo.ntpTimestampMsw,
+            ntpTimestampLsw = this.senderInfo.ntpTimestampLsw,
+            rtpTimestamp = this.senderInfo.rtpTimestamp,
+            sendersPacketCount = this.senderInfo.sendersPacketCount,
+            sendersOctetCount = this.senderInfo.sendersOctetCount
+        )
+    ).build()
 
     // SenderInfo is defined differently so that we can scope these variables under a the 'senderInfo'
     // member here.  Is there a better way?

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/RtcpFbPacket.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/RtcpFbPacket.kt
@@ -81,6 +81,7 @@ abstract class RtcpFbPacket(
                         else -> UnsupportedRtcpFbPacket(buf, offset, length)
                     }
                 }
+
                 PayloadSpecificRtcpFbPacket.PT -> {
                     when (fmt) {
                         RtcpFbFirPacket.FMT -> RtcpFbFirPacket(buf, offset, length)
@@ -89,6 +90,7 @@ abstract class RtcpFbPacket(
                         else -> UnsupportedRtcpFbPacket(buf, offset, length)
                     }
                 }
+
                 else -> throw Exception("Unrecognized RTCPFB payload type: ${packetType.toString(16)}")
             }
         }

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/payload_specific_fb/RtcpFbRembPacket.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/payload_specific_fb/RtcpFbRembPacket.kt
@@ -72,9 +72,7 @@ class RtcpFbRembPacket(
         }.toList()
     }
 
-    override fun clone(): RtcpFbRembPacket {
-        return RtcpFbRembPacket(cloneBuffer(0), 0, length)
-    }
+    override fun clone(): RtcpFbRembPacket = RtcpFbRembPacket(cloneBuffer(0), 0, length)
 
     companion object {
         const val FMT = 15

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/ccfb/RtcpFbCcfbPacket.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/ccfb/RtcpFbCcfbPacket.kt
@@ -67,15 +67,11 @@ sealed class PacketInfo(
     val ssrc: Long = 0,
     val sequenceNumber: Int = 0
 ) {
-    override fun toString(): String {
-        return "ssrc=$ssrc, sequenceNumber=$sequenceNumber"
-    }
+    override fun toString(): String = "ssrc=$ssrc, sequenceNumber=$sequenceNumber"
 }
 
 class UnreceivedPacketInfo(ssrc: Long = 0, sequenceNumber: Int = 0) : PacketInfo(ssrc, sequenceNumber) {
-    override fun toString(): String {
-        return "Unreceived: " + super.toString()
-    }
+    override fun toString(): String = "Unreceived: " + super.toString()
 }
 
 class ReceivedPacketInfo(
@@ -84,9 +80,8 @@ class ReceivedPacketInfo(
     val arrivalTimeOffset: Duration = MIN_DURATION,
     val ecn: EcnMarking = EcnMarking.kNotEct
 ) : PacketInfo(ssrc, sequenceNumber) {
-    override fun toString(): String {
-        return "Received: " + super.toString() + ", arrivalTimeOffset=$arrivalTimeOffset, ecn=$ecn"
-    }
+    override fun toString(): String =
+        "Received: " + super.toString() + ", arrivalTimeOffset=$arrivalTimeOffset, ecn=$ecn"
 }
 
 private const val kHeaderPerMediaSsrcLength = 8
@@ -209,13 +204,9 @@ private fun atoToTimeDelta(receiveInfo: Int): Duration {
     return ato.secs / 1024
 }
 
-private fun toEcnMarking(receiveInfo: Int): EcnMarking {
-    return EcnMarking.fromBits(((receiveInfo shr 13) and 0b11).toByte())
-}
+private fun toEcnMarking(receiveInfo: Int): EcnMarking = EcnMarking.fromBits(((receiveInfo shr 13) and 0b11).toByte())
 
-private fun to2BitEcn(ecnMarking: EcnMarking): Int {
-    return ecnMarking.bits.toInt() shl 13
-}
+private fun to2BitEcn(ecnMarking: EcnMarking): Int = ecnMarking.bits.toInt() shl 13
 
 /*
      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/LastChunk.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/LastChunk.kt
@@ -33,9 +33,7 @@ typealias Chunk = Int
  * future updates easier.
  */
 class LastChunk {
-    fun Empty(): Boolean {
-        return size_ == 0
-    }
+    fun Empty(): Boolean = size_ == 0
 
     fun Clear() {
         size_ = 0
@@ -98,12 +96,10 @@ class LastChunk {
     }
 
     // // Encode all stored delta_sizes into single chunk, pad with 0s if needed.
-    fun EncodeLast(): Chunk {
-        return when {
-            all_same_ -> EncodeRunLength()
-            size_ <= kMaxTwoBitCapacity -> EncodeTwoBit(size_)
-            else -> EncodeOneBit()
-        }
+    fun EncodeLast(): Chunk = when {
+        all_same_ -> EncodeRunLength()
+        size_ <= kMaxTwoBitCapacity -> EncodeTwoBit(size_)
+        else -> EncodeOneBit()
     }
 
     // Decode up to |max_size| delta sizes from |chunk|.

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacket.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacket.kt
@@ -154,9 +154,7 @@ class RtcpFbTccPacketBuilder(
         return true
     }
 
-    fun BaseTime(): Instant {
-        return Instant.EPOCH + base_time_ticks_ * kBaseScaleFactor
-    }
+    fun BaseTime(): Instant = Instant.EPOCH + base_time_ticks_ * kBaseScaleFactor
 
     private fun AddDeltaSize(deltaSize: DeltaSize): Boolean {
         if (num_seq_no_ == kMaxReportedPackets) {
@@ -223,6 +221,7 @@ class RtcpFbTccPacketBuilder(
             if (it is ReceivedPacketReport) {
                 when (it.deltaTicks) {
                     in 0..0xFF -> buf[currOffset++] = it.deltaTicks.toByte()
+
                     else -> {
                         buf.putShort(currOffset, it.deltaTicks)
                         currOffset += 2
@@ -353,18 +352,21 @@ class RtcpFbTccPacket(
                 }
                 when (delta_size) {
                     0 -> packets_.add(UnreceivedPacketReport(seq_no.value))
+
                     1 -> {
                         val delta = buffer[index]
                         packets_.add(ReceivedPacketReport(seq_no.value, delta.toPositiveShort()))
                         last_timestamp_ += delta.toInt() * kDeltaScaleFactor
                         index += delta_size
                     }
+
                     2 -> {
                         val delta = buffer.getShortAsInt(index)
                         packets_.add(ReceivedPacketReport(seq_no.value, delta.toShort()))
                         last_timestamp_ += delta * kDeltaScaleFactor
                         index += delta_size
                     }
+
                     3 -> {
                         throw Exception("Warning: invalid delta size for seq_no $seq_no")
                     }
@@ -429,13 +431,9 @@ class RtcpFbTccPacket(
 
     val feedbackSeqNum: Int = getFeedbackPacketCount(buffer, offset)
 
-    fun GetPacketStatusCount(): Int {
-        return num_seq_no_
-    }
+    fun GetPacketStatusCount(): Int = num_seq_no_
 
-    fun BaseTime(): Instant {
-        return Instant.EPOCH + base_time_ticks_ * kBaseScaleFactor
-    }
+    fun BaseTime(): Instant = Instant.EPOCH + base_time_ticks_ * kBaseScaleFactor
 
     fun GetBaseDelta(prev_timestamp: Instant): Duration {
         var delta = Duration.between(prev_timestamp, BaseTime())

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -402,13 +402,11 @@ open class RtpPacket(
         this.pendingHeaderExtensions = null
     }
 
-    override fun clone(): RtpPacket {
-        return RtpPacket(
-            cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),
-            BYTES_TO_LEAVE_AT_START_OF_PACKET,
-            length
-        ).also { postClone(it) }
-    }
+    override fun clone(): RtpPacket = RtpPacket(
+        cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),
+        BYTES_TO_LEAVE_AT_START_OF_PACKET,
+        length
+    ).also { postClone(it) }
 
     /** Extra operations that need to be done after [clone].  All subclasses overriding [clone]
      * must call this method on the newly-created clone. */

--- a/rtp/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/Av1DependencyDescriptorHeaderExtension.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/Av1DependencyDescriptorHeaderExtension.kt
@@ -34,15 +34,13 @@ open class Av1DependencyDescriptorStatelessSubset(
 
     val newTemplateDependencyStructure: Av1TemplateDependencyStructure?,
 ) {
-    open fun clone(): Av1DependencyDescriptorStatelessSubset {
-        return Av1DependencyDescriptorStatelessSubset(
-            startOfFrame = startOfFrame,
-            endOfFrame = endOfFrame,
-            frameDependencyTemplateId = frameDependencyTemplateId,
-            frameNumber = frameNumber,
-            newTemplateDependencyStructure = newTemplateDependencyStructure?.clone()
-        )
-    }
+    open fun clone(): Av1DependencyDescriptorStatelessSubset = Av1DependencyDescriptorStatelessSubset(
+        startOfFrame = startOfFrame,
+        endOfFrame = endOfFrame,
+        frameDependencyTemplateId = frameDependencyTemplateId,
+        frameNumber = frameNumber,
+        newTemplateDependencyStructure = newTemplateDependencyStructure?.clone()
+    )
 }
 
 /**
@@ -361,18 +359,16 @@ class Av1TemplateDependencyStructure(
             return length
         }
 
-    fun clone(): Av1TemplateDependencyStructure {
-        return Av1TemplateDependencyStructure(
-            templateIdOffset,
-            // These objects are not mutable so it's safe to copy them by reference
-            templateInfo,
-            decodeTargetProtectedBy,
-            decodeTargetLayers,
-            maxRenderResolutions,
-            maxSpatialId,
-            maxTemporalId
-        )
-    }
+    fun clone(): Av1TemplateDependencyStructure = Av1TemplateDependencyStructure(
+        templateIdOffset,
+        // These objects are not mutable so it's safe to copy them by reference
+        templateInfo,
+        decodeTargetProtectedBy,
+        decodeTargetLayers,
+        maxRenderResolutions,
+        maxSpatialId,
+        maxTemporalId
+    )
 
     fun write(writer: BitWriter) {
         writer.writeBits(6, templateIdOffset)
@@ -397,12 +393,15 @@ class Av1TemplateDependencyStructure(
                 templateInfo[templateNum].spatialId == templateInfo[templateNum - 1].spatialId &&
                     templateInfo[templateNum].temporalId == templateInfo[templateNum - 1].temporalId ->
                     0
+
                 templateInfo[templateNum].spatialId == templateInfo[templateNum - 1].spatialId &&
                     templateInfo[templateNum].temporalId == templateInfo[templateNum - 1].temporalId + 1 ->
                     1
+
                 templateInfo[templateNum].spatialId == templateInfo[templateNum - 1].spatialId + 1 &&
                     templateInfo[templateNum].temporalId == 0 ->
                     2
+
                 else ->
                     throw IllegalStateException(
                         "Template $templateNum with spatial and temporal IDs " +
@@ -752,10 +751,8 @@ class Av1DependencyDescriptorReader(
         }
     }
 
-    private fun readFrameDtis(): List<DTI> {
-        return List(templateDependencyStructure!!.decodeTargetCount) {
-            DTI.fromInt(reader.bits(2))
-        }
+    private fun readFrameDtis(): List<DTI> = List(templateDependencyStructure!!.decodeTargetCount) {
+        DTI.fromInt(reader.bits(2))
     }
 
     private fun readTemplateFdiffs() {
@@ -772,14 +769,12 @@ class Av1DependencyDescriptorReader(
         }
     }
 
-    private fun readFrameFdiffs(): List<Int> {
-        return buildList {
-            var nextFdiffSize = reader.bits(2)
-            while (nextFdiffSize != 0) {
-                val fdiffMinus1 = reader.bits(4 * nextFdiffSize)
-                add(fdiffMinus1 + 1)
-                nextFdiffSize = reader.bits(2)
-            }
+    private fun readFrameFdiffs(): List<Int> = buildList {
+        var nextFdiffSize = reader.bits(2)
+        while (nextFdiffSize != 0) {
+            val fdiffMinus1 = reader.bits(4 * nextFdiffSize)
+            add(fdiffMinus1 + 1)
+            nextFdiffSize = reader.bits(2)
         }
     }
 
@@ -798,10 +793,8 @@ class Av1DependencyDescriptorReader(
         }
     }
 
-    private fun readFrameChains(): List<Int> {
-        return List(templateDependencyStructure!!.chainCount) {
-            reader.bits(8)
-        }
+    private fun readFrameChains(): List<Int> = List(templateDependencyStructure!!.chainCount) {
+        reader.bits(8)
     }
 
     private fun readDecodeTargetLayers() {
@@ -862,9 +855,8 @@ open class FrameInfo(
         return result
     }
 
-    override fun toString(): String {
-        return "spatialId=$spatialId, temporalId=$temporalId, dti=$dti, fdiff=$fdiff, chains=$chains"
-    }
+    override fun toString(): String =
+        "spatialId=$spatialId, temporalId=$temporalId, dti=$dti, fdiff=$fdiff, chains=$chains"
 
     fun toJson(): String {
         val mapper = ObjectMapper()
@@ -901,24 +893,20 @@ class DecodeTargetLayer(
     val spatialId: Int,
     val temporalId: Int
 ) {
-    override fun toString(): String {
-        return JsonNodeFactory.instance.objectNode().apply {
-            put("spatialId", spatialId)
-            put("temporalId", temporalId)
-        }.toString()
-    }
+    override fun toString(): String = JsonNodeFactory.instance.objectNode().apply {
+        put("spatialId", spatialId)
+        put("temporalId", temporalId)
+    }.toString()
 }
 
 data class Resolution(
     val width: Int,
     val height: Int
 ) {
-    override fun toString(): String {
-        return JsonNodeFactory.instance.objectNode().apply {
-            put("width", width)
-            put("height", height)
-        }.toString()
-    }
+    override fun toString(): String = JsonNodeFactory.instance.objectNode().apply {
+        put("width", width)
+        put("height", height)
+    }.toString()
 }
 
 /** Decode target indication */
@@ -933,19 +921,15 @@ enum class DTI(val dti: Int) {
         fun fromInt(type: Int) = map[type] ?: throw java.lang.IllegalArgumentException("Bad DTI $type")
     }
 
-    fun toShortString(): String {
-        return when (this) {
-            NOT_PRESENT -> "N"
-            DISCARDABLE -> "D"
-            SWITCH -> "S"
-            REQUIRED -> "R"
-        }
+    fun toShortString(): String = when (this) {
+        NOT_PRESENT -> "N"
+        DISCARDABLE -> "D"
+        SWITCH -> "S"
+        REQUIRED -> "R"
     }
 }
 
-fun List<DTI>.toShortString(): String {
-    return joinToString(separator = "") { it.toShortString() }
-}
+fun List<DTI>.toShortString(): String = joinToString(separator = "") { it.toShortString() }
 
 class Av1DependencyException(msg: String) : RuntimeException(msg)
 

--- a/rtp/src/main/kotlin/org/jitsi/rtp/util/RtpUtils.kt
+++ b/rtp/src/main/kotlin/org/jitsi/rtp/util/RtpUtils.kt
@@ -136,14 +136,12 @@ class RtpUtils {
         fun millisToNtpTimestamp(timestampMs: Long): Long = TimeUtils.toNtpTime(timestampMs)
 
         @JvmStatic
-        fun convertRtpTimestampToMs(rtpTimestamp: Int, ticksPerSecond: Int): Long {
-            return ((rtpTimestamp / (ticksPerSecond.toDouble())) * 1000).toLong()
-        }
+        fun convertRtpTimestampToMs(rtpTimestamp: Int, ticksPerSecond: Int): Long =
+            ((rtpTimestamp / (ticksPerSecond.toDouble())) * 1000).toLong()
 
         @JvmStatic
-        fun convertRtpTimestampToInstant(rtpTimestamp: Int, ticksPerSecond: Int): Instant {
-            return Instant.EPOCH.plus(Duration.ofSeconds(rtpTimestamp.toLong()).dividedBy(ticksPerSecond.toLong()))
-        }
+        fun convertRtpTimestampToInstant(rtpTimestamp: Int, ticksPerSecond: Int): Instant =
+            Instant.EPOCH.plus(Duration.ofSeconds(rtpTimestamp.toLong()).dividedBy(ticksPerSecond.toLong()))
     }
 }
 

--- a/rtp/src/test/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/ccfb/RtcpFbCcfbPacketTest.kt
+++ b/rtp/src/test/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/ccfb/RtcpFbCcfbPacketTest.kt
@@ -123,46 +123,44 @@ class RtcpFbCcfbPacketTest : ShouldSpec() {
 }
 
 class PacketInfoMatcher(private val expected: PacketInfo) : Matcher<PacketInfo> {
-    override fun test(value: PacketInfo): MatcherResult {
-        return when (expected) {
-            is ReceivedPacketInfo -> if (value !is ReceivedPacketInfo) {
-                MatcherResult(
-                    false,
-                    { "Value should be $expected but was $value" },
-                    { "Value should not be $expected" }
-                )
-            } else {
-                // PacketInfo is equal after serializing-deserializing if members are equal
-                // except for arrival time offset that may differ because of conversion back and
-                // forth to CompactNtp.
+    override fun test(value: PacketInfo): MatcherResult = when (expected) {
+        is ReceivedPacketInfo -> if (value !is ReceivedPacketInfo) {
+            MatcherResult(
+                false,
+                { "Value should be $expected but was $value" },
+                { "Value should not be $expected" }
+            )
+        } else {
+            // PacketInfo is equal after serializing-deserializing if members are equal
+            // except for arrival time offset that may differ because of conversion back and
+            // forth to CompactNtp.
 
-                val arrivalTimeOffsetEqual =
+            val arrivalTimeOffsetEqual =
+                (
+                    value.arrivalTimeOffset.isInfinite() && expected.arrivalTimeOffset.isInfinite() &&
+                        value == expected
+                    ) ||
                     (
-                        value.arrivalTimeOffset.isInfinite() && expected.arrivalTimeOffset.isInfinite() &&
-                            value == expected
-                        ) ||
-                        (
-                            value.arrivalTimeOffset.isFinite() && expected.arrivalTimeOffset.isFinite() &&
-                                abs(value.arrivalTimeOffset - expected.arrivalTimeOffset) < 1.secs / 1024
-                            )
-                MatcherResult(
-                    value.ssrc == expected.ssrc &&
-                        value.sequenceNumber == expected.sequenceNumber &&
-                        arrivalTimeOffsetEqual &&
-                        value.ecn == expected.ecn,
-                    { "Value should be $expected but was $value" },
-                    { "Value should not be $expected" }
-                )
-            }
-
-            is UnreceivedPacketInfo -> MatcherResult(
-                value is UnreceivedPacketInfo &&
-                    value.ssrc == expected.ssrc &&
-                    value.sequenceNumber == expected.sequenceNumber,
+                        value.arrivalTimeOffset.isFinite() && expected.arrivalTimeOffset.isFinite() &&
+                            abs(value.arrivalTimeOffset - expected.arrivalTimeOffset) < 1.secs / 1024
+                        )
+            MatcherResult(
+                value.ssrc == expected.ssrc &&
+                    value.sequenceNumber == expected.sequenceNumber &&
+                    arrivalTimeOffsetEqual &&
+                    value.ecn == expected.ecn,
                 { "Value should be $expected but was $value" },
                 { "Value should not be $expected" }
             )
         }
+
+        is UnreceivedPacketInfo -> MatcherResult(
+            value is UnreceivedPacketInfo &&
+                value.ssrc == expected.ssrc &&
+                value.sequenceNumber == expected.sequenceNumber,
+            { "Value should be $expected but was $value" },
+            { "Value should not be $expected" }
+        )
     }
 }
 

--- a/rtp/src/test/kotlin/org/jitsi/test_helpers/matchers/ByteArrayBuffer.kt
+++ b/rtp/src/test/kotlin/org/jitsi/test_helpers/matchers/ByteArrayBuffer.kt
@@ -35,11 +35,9 @@ fun ByteArrayBuffer.hasSameContentAs(other: ByteArrayBuffer): Boolean {
 }
 
 fun haveSameContentAs(expected: ByteArrayBuffer) = object : Matcher<ByteArrayBuffer> {
-    override fun test(value: ByteArrayBuffer): MatcherResult {
-        return MatcherResult(
-            value.hasSameContentAs(expected),
-            { "\n${value.toHex()}\nwas supposed to be:\n${expected.toHex()}" },
-            { "\n${value.toHex()}\nshould not have equaled \n${expected.toHex()}" }
-        )
-    }
+    override fun test(value: ByteArrayBuffer): MatcherResult = MatcherResult(
+        value.hasSameContentAs(expected),
+        { "\n${value.toHex()}\nwas supposed to be:\n${expected.toHex()}" },
+        { "\n${value.toHex()}\nshould not have equaled \n${expected.toHex()}" }
+    )
 }

--- a/rtp/src/test/kotlin/org/jitsi/test_helpers/matchers/ByteBuffer.kt
+++ b/rtp/src/test/kotlin/org/jitsi/test_helpers/matchers/ByteBuffer.kt
@@ -23,11 +23,9 @@ import org.jitsi.rtp.extensions.toHex
 import java.nio.ByteBuffer
 
 fun haveSameContentAs(expected: ByteBuffer) = object : Matcher<ByteBuffer> {
-    override fun test(value: ByteBuffer): MatcherResult {
-        return MatcherResult(
-            value.compareToFromBeginning(expected) == 0,
-            { "Buffer\n${value.toHex()}\nwas supposed to be:\n${expected.toHex()}" },
-            { "Buffer\n${value.toHex()}\nshould not have equaled buffer\n${expected.toHex()}" }
-        )
-    }
+    override fun test(value: ByteBuffer): MatcherResult = MatcherResult(
+        value.compareToFromBeginning(expected) == 0,
+        { "Buffer\n${value.toHex()}\nwas supposed to be:\n${expected.toHex()}" },
+        { "Buffer\n${value.toHex()}\nshould not have equaled buffer\n${expected.toHex()}" }
+    )
 }

--- a/rtp/src/test/kotlin/org/jitsi/test_helpers/matchers/RtpPacket.kt
+++ b/rtp/src/test/kotlin/org/jitsi/test_helpers/matchers/RtpPacket.kt
@@ -23,13 +23,9 @@ import org.jitsi.rtp.rtp.RtpHeader
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.utils.ByteArrayBuffer
 
-fun RtpPacket.getPayload(): ByteArrayBuffer {
-    return UnparsedPacket(buffer, payloadOffset, payloadLength)
-}
+fun RtpPacket.getPayload(): ByteArrayBuffer = UnparsedPacket(buffer, payloadOffset, payloadLength)
 
-fun RtpPacket.getFixedHeaderAsBAB(): ByteArrayBuffer {
-    return UnparsedPacket(buffer, offset, RtpHeader.FIXED_HEADER_SIZE_BYTES)
-}
+fun RtpPacket.getFixedHeaderAsBAB(): ByteArrayBuffer = UnparsedPacket(buffer, offset, RtpHeader.FIXED_HEADER_SIZE_BYTES)
 
 fun haveSamePayload(expected: RtpPacket) = object : Matcher<RtpPacket> {
     override fun test(value: RtpPacket): MatcherResult {


### PR DESCRIPTION
Replaces the third-party ktlint-maven-plugin, which tends to trail ktlint releases, with the integration ktlint documents itself: the ktlint CLI jar (1.8.0) as an exec-maven-plugin dependency, with the classpath restricted to that jar. The check still runs in the `verify` phase and fails the build on violations. Autoformat with `mvn exec:exec@ktlint-format` instead of `mvn ktlint:format`. Run it inside a module directory; sibling modules must be resolvable, so run `mvn install -DskipTests` from the root first on a fresh clone.

The `class-signature` rule added in ktlint 1.x is disabled in `.editorconfig`: it joins wrapped constructor parameter lists onto one line when they fit and re-indents every kotest spec, which we do not want. All other new rules are applied.

The second commit is the resulting reformat: 2202 lines in 138 Kotlin files, almost entirely single-`return` function bodies becoming expression bodies and blank lines between multi-line `when` branches; plus KDoc comments that sat on non-declarations (ktlint cannot auto-correct these) become plain block comments and conditions mixing `&&` and `||` get explicit parentheses. Behaviour-neutral.

This is one of a set of same-named `ktlint-1.8` branches across jitsi-utils, jitsi-metaconfig, jicoco, jitsi-xmpp-extensions, ice4j, jicofo, jitsi-videobridge and jibri. Each PR is independent; they only change how ktlint is run and apply its formatting.